### PR TITLE
Options to use VLC Player

### DIFF
--- a/app.py
+++ b/app.py
@@ -497,6 +497,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Download higher quality video. Note: requires ffmpeg and may cause CPU, download speed, and other performance issues",
         required=False,
+    )
+    parser.add_argument(
+        "--use-vlc",
+        action="store_true",
+        help="Use VLC Player instead of the default OMX Player",
+        required=False,
     ),
     args = parser.parse_args()
 
@@ -519,6 +525,7 @@ if __name__ == "__main__":
         alsa_fix=args.alsa_fix,
         dual_screen=args.dual_screen,
         high_quality=args.high_quality,
+        use_vlc=args.use_vlc,
     )
     t = threading.Thread(target=k.run)
     t.daemon = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pygame
 futures
 psutil 
 unidecode
+python-vlc

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ if [ $? -ne 0 ]; then echo "ERROR: 'apt-get update' failed with error code: $?";
 
 echo
 echo "*** INSTALLING REQUIRED BINARIES ***"
-sudo apt-get install libjpeg-dev omxplayer python-pip python-pygame python-lxml ffmpeg -y
+sudo apt-get install libjpeg-dev omxplayer vlc python-pip python-pygame python-lxml ffmpeg -y
 if [ $? -ne 0 ]; then echo "ERROR: Binary dependency installation failed with error code: $?"; exit 1; fi
 
 echo


### PR DESCRIPTION
To use VLC player add argument `sudo python app.py --use-vlc`
Tested in RPI 3 B+ and Raspbian Desktop (Virtual Box).
VLC player is useful without or cannot install OMXplayer.