### PR TITLE
Add option to use WAN IP instead of LAN

### DIFF
--- a/app.py
+++ b/app.py
@@ -612,6 +612,12 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "--use-external-ip",
+        action="store_true",
+        help="Use external (wan/internet) ip address instead of local (lan) ip",
+        required=False,
+    )
+    parser.add_argument(
         "--hide-ip",
         action="store_true",
         help="Hide IP address from the screen.",
@@ -751,7 +757,8 @@ if __name__ == "__main__":
         vlc_path=args.vlc_path,
         vlc_port=args.vlc_port,
         logo_path=args.logo_path,
-        show_overlay=args.show_overlay
+        show_overlay=args.show_overlay,
+        use_external_ip=args.use_external_ip
     )
 
     if (args.developer_mode):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ futures
 psutil 
 unidecode
 requests
+miniupnpc


### PR DESCRIPTION
For those who don't want to give out their wifi password, I've added an option to get and display your external (WAN) IP address instead of the local (LAN) one. Currently this will require users to manually make sure the port is open and directing to the machine running pikaraoke. Next I'll work on automatic port mapping using UPnP.

Pikaraoke first attempts to get the external IP address using UPnP. If that fails, it uses a web call to [ident.me](http://ident.me). If it still can't get a valid external IP, it defaults back to the LAN IP.

This adds an additional requirement -- module `miniupnpc` -- which I've also added to `requirements.txt`.

I'm only a mediocre coder, and this is my first open source pull request. I'm open to suggestions on better ways to do this! :)