### PR TITLE
Show HTTPS and port in RaspiWiFi URL if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,9 @@ Or an even easier approach, if you install this: https://github.com/jasbur/Raspi
 
 ### Where do I plug in a microphone?
 
-Ideally, you'd have a mixer and amplifier that you could run the line out of the pi to, as well as the microphones. I used this affordable wireless microphone set from amazon: https://www.amazon.com/gp/product/B01N6448Q4/ It has a line in so you can also run PiKaraoke into the mix, and output to an amplifier.
+Ideally, you'd have a mixer and amplifier that you could run the line out of the pi to, as well as the microphones. I used this affordable wireless microphone set from amazon: https://amzn.to/2OXKXdc (affiliate link) It has a line-in so you can also run PiKaraoke into the mix, and output to an amplifier.
 
-The pi doesn't have a hardware audio input. Technically, you should be able to run a microphone through it with a USB sound card attached to the pi, but I personally wouldn't bother due to latency and quality issues.
+The pi doesn't have a hardware audio input. Technically, you should be able to run a microphone through it with a USB sound card attached to the pi, but I personally wouldn't bother due to latency and audio quality issues.
 
 ### How do I change song pitch/key?
 

--- a/karaoke.py
+++ b/karaoke.py
@@ -193,12 +193,30 @@ class Karaoke:
             s.close()
         return IP
 
-    def get_raspi_wifi_ap(self):
+    def get_raspi_wifi_conf_vals(self):
+        """Extract values from the RaspiWiFi configuration file."""
         f = open(self.raspi_wifi_conf_file, "r")
+        
+        # Define default values.
+        #
+        # References: 
+        # - https://github.com/jasbur/RaspiWiFi/blob/master/initial_setup.py (see defaults in input prompts)
+        # - https://github.com/jasbur/RaspiWiFi/blob/master/libs/reset_device/static_files/raspiwifi.conf
+        #
+        server_port = "80"
+        ssid_prefix = "RaspiWiFi Setup"
+        ssl_enabled = "0"
+        
+        # Override the default values according to the configuration file.
         for line in f.readlines():
-            if "ssid_prefix=" in line:
-                return line.split("x=")[1].strip()
-        return False
+            if "server_port=" in line:
+                server_port = line.split("t=")[1].strip()
+            elif "ssid_prefix=" in line:
+                ssid_prefix = line.split("x=")[1].strip()
+            elif "ssl_enabled=" in line:
+                ssl_enabled = line.split("d=")[1].strip()
+
+        return (server_port, ssid_prefix, ssl_enabled)
 
     def get_youtubedl_version(self):
         self.youtubedl_version = (
@@ -345,18 +363,21 @@ class Karaoke:
                 self.raspi_wifi_config_installed
                 and self.raspi_wifi_config_ip in self.url
             ):
-                ap = self.get_raspi_wifi_ap()
+                (server_port, ssid_prefix, ssl_enabled) = self.get_raspi_wifi_conf_vals()
+
                 text1 = self.font.render(
                     "RaspiWifiConfig setup mode detected!", True, (255, 255, 255)
                 )
                 text2 = self.font.render(
-                    "Connect another device/smartphone to the Wifi AP: '%s'" % ap,
+                    "Connect another device/smartphone to the Wifi AP: '%s'" % ssid_prefix,
                     True,
                     (255, 255, 255),
                 )
                 text3 = self.font.render(
-                    "Then point its browser to: 'http://%s' and follow the instructions."
-                    % self.raspi_wifi_config_ip,
+                    "Then point its browser to: '%s://%s%s' and follow the instructions."
+                    % ("https" if ssl_enabled == "1" else "http", 
+                       self.raspi_wifi_config_ip, 
+                       ":%s" % server_port if server_port != "80" else ""),
                     True,
                     (255, 255, 255),
                 )


### PR DESCRIPTION
Fixes https://github.com/vicwomg/pikaraoke/issues/128.

Now, when RaspiWiFi is configured to use SSL, the RaspiWiFi URL shown on the pikaraoke splash screen begins with `https://` instead of `http://`. Also, when RaspiWiFi is configured to host its SSID selection page on a port number other than 80, the RaspiWiFi URL shown on the pikaraoke splash screen includes that port number (e.g. `:1234`). As a result, in these two situations, the URL is now accurate.