### PR TITLE
Add option to hide RaspiWiFi setup instructions

### DIFF
--- a/app.py
+++ b/app.py
@@ -665,6 +665,12 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "--hide-raspiwifi-instructions",
+        action="store_true",
+        help="Hide RaspiWiFi setup instructions from the splash screen.",
+        required=False,
+    )
+    parser.add_argument(
         "--hide-splash-screen",
         action="store_true",
         help="Hide splash screen before/between songs.",
@@ -789,6 +795,7 @@ if __name__ == "__main__":
         log_level=args.log_level,
         volume=args.volume,
         hide_ip=args.hide_ip,
+        hide_raspiwifi_instructions=args.hide_raspiwifi_instructions,
         hide_splash_screen=args.hide_splash_screen,
         omxplayer_adev=args.adev,
         dual_screen=args.dual_screen,

--- a/karaoke.py
+++ b/karaoke.py
@@ -47,6 +47,7 @@ class Karaoke:
         port=5000,
         download_path="/usr/lib/pikaraoke/songs",
         hide_ip=False,
+        hide_raspiwifi_instructions=False,
         hide_splash_screen=False,
         omxplayer_adev="both",
         dual_screen=False,
@@ -67,6 +68,7 @@ class Karaoke:
         # override with supplied constructor args if provided
         self.port = port
         self.hide_ip = hide_ip
+        self.hide_raspiwifi_instructions = hide_raspiwifi_instructions
         self.hide_splash_screen = hide_splash_screen
         self.omxplayer_adev = omxplayer_adev
         self.download_path = download_path
@@ -99,6 +101,7 @@ class Karaoke:
             """
     http port: %s
     hide IP: %s
+    hide RaspiWiFi instructions: %s,
     hide splash: %s
     splash_delay: %s
     omx audio device: %s
@@ -118,6 +121,7 @@ class Karaoke:
             % (
                 self.port,
                 self.hide_ip,
+                self.hide_raspiwifi_instructions,
                 self.hide_splash_screen,
                 self.splash_delay,
                 self.omxplayer_adev,
@@ -341,7 +345,7 @@ class Karaoke:
                     )
                     self.screen.blit(text, (p_image.get_width() + 35, blitY))
 
-            if (
+            if not self.hide_raspiwifi_instructions and (
                 self.raspi_wifi_config_installed
                 and self.raspi_wifi_config_ip in self.url
             ):


### PR DESCRIPTION
Added a new CLI option (i.e. `--hide-raspiwifi-instructions`), which can be used to hide the RaspiWiFi setup instructions from the pikaraoke splash screen.

Fixes https://github.com/vicwomg/pikaraoke/issues/130.