### PR TITLE
Clean up case-insensitive file validation

### DIFF
--- a/karaoke.py
+++ b/karaoke.py
@@ -10,6 +10,7 @@ import threading
 import time
 from io import BytesIO
 from subprocess import check_output
+from pathlib import Path
 
 import pygame
 import qrcode
@@ -470,18 +471,17 @@ class Karaoke:
         return rc
 
     def get_available_songs(self):
-        logging.debug("Fetching available songs in: " + self.download_path)
-        types = ['*.mp4', '*.mp3', '*.zip', '*.mkv', '*.avi', '*.webm', '*.mov'] 
-        if self.platform != "windows":
-            # Only non-windows. If we include extra casings, windows shows dups
-            types_caps = []
-            for ext in types:
-                types_caps.append(ext.upper())
-                types_caps.append(ext.title())
-            types = types + types_caps
+        logging.info("Fetching available songs in: " + self.download_path)
+        types = ['.mp4', '.mp3', '.zip', '.mkv', '.avi', '.webm', '.mov']
         files_grabbed = []
-        for files in types:
-            files_grabbed.extend(glob.glob(u"%s/**/%s" % (self.download_path, files), recursive=True))
+        P=Path(self.download_path)
+        for file in P.rglob('*.*'):
+            base, ext = os.path.splitext(file.as_posix())
+            if ext.lower() in types:
+                if os.path.isfile(file.as_posix()):
+                    logging.debug("adding song: " + file.name)
+                    files_grabbed.append(file.as_posix())
+
         self.available_songs = sorted(files_grabbed, key=lambda f: str.lower(os.path.basename(f)))
 
     def delete(self, song_path):

--- a/lib/vlcclient.py
+++ b/lib/vlcclient.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import random
 import shutil
 import string
@@ -108,9 +109,9 @@ class VLCClient:
         files = os.listdir(extracted_dir)
         for file in files:
             ext = os.path.splitext(file)[1]
-            if ext == ".mp3" or ext == ".Mp3" or ext == ".MP3":
+            if ext.casefold() == ".mp3":
                 mp3_file = file
-            elif ext == ".cdg" or ext == ".Cdg" or ext == ".CDG":
+            elif ext.casefold() == ".cdg":
                 cdg_file = file
         
         if (mp3_file is not None) and (cdg_file is not None):
@@ -122,17 +123,21 @@ class VLCClient:
             raise Exception("No .mp3 or .cdg was found in the zip file: " + file_path)
 
     def handle_mp3_cdg(self, file_path):
-        f = os.path.splitext(file_path)[0]
-        if (os.path.isfile(f + ".cdg") or os.path.isfile(f + ".Cdg") or os.path.isfile(f + ".CDG")):
-            return file_path
-        else:
+        pattern='*.cdg'
+        rule = re.compile(fnmatch.translate(pattern), re.IGNORECASE)
+        p=os.path.dirname(file_path)       # get the patch, not the filename
+        for n in os.listdir(p):
+            if rule.match(n):
+                return(n)
+        if (1):
+            # we didn't return, so always raise the exception: assert might work better?
             raise Exception("No matching .cdg file found for: " + file_path)
 
     def process_file(self, file_path):
         file_extension = os.path.splitext(file_path)[1]
-        if (file_extension == ".zip"):
+        if (file_extension.casefold() == ".zip"):
             return self.handle_zipped_cdg(file_path)
-        elif (file_extension == ".mp3"):
+        elif (file_extension.casefold() == ".mp3"):
             return self.handle_mp3_cdg(file_path)
         else:
             return file_path


### PR DESCRIPTION
These changes should result in more performant file searching and validation. 

Previously, only specific hardcoded variations of file extensions were checked.  This PR allows for any variation without the duplication of records.

It  *should*  work equivalently on Windows and Darwin, though I'm unable to test it.  Hopefully somebody can check my assumptions work portably under other OSes.