### PR TITLE
Fix Pathing for Songs in Windows

### DIFF
--- a/lib/vlcclient.py
+++ b/lib/vlcclient.py
@@ -152,7 +152,7 @@ class VLCClient:
                 # this pause prevents vlc http server from being borked after transpose
                 time.sleep(0.2)
             if self.platform == "windows":
-                file_path = r"{}".format(file_path)
+                file_path = r"{}".format(file_path.replace('/','\\'))
             if additional_parameters == None:
                 command = self.cmd_base + [file_path]
             else:


### PR DESCRIPTION
VLC would open a blank window due to the pathing of the filename using / instead of \
this adds a replace in the play_file function in the vlcclient lib if the platform is windows.