### PR TITLE
#162 - Slow downloads and lack of support of youtube-dl, switch to yt-dlp for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,13 @@ Install requirements from the pikaraoke directory:
 
 ```
 pip3 install -r requirements.txt
-pip3 install --upgrade youtube_dl
+pip3 install --upgrade yt-dlp
+```
+
+*OSX only:* pip installs to a python library directory specific to your version of Python 3. This sets a symlink for yt-dlp in /usr/local/bin so pikaraoke can find it (optional, otherwise you'll probably need to manually specify --youtubedl-path):
+
+```
+sudo ln -s `which yt-dlp` /usr/local/bin/yt-dlp
 ```
 
 #### Windows
@@ -121,10 +127,10 @@ pip3 install --upgrade youtube_dl
 - Install VLC (to its default location): https://www.videolan.org/
 - Install ffmpeg (only if you want to use --high-quality flag) https://ffmpeg.org/download.html
 - Install MS Visual C++ (required to launch youtube-dl)  https://www.microsoft.com/en-US/download/details.aspx?id=5555
-- Install youtube-dl.exe. FYI, pip3 didn't seem to work for this on windows, so I used scoop as a package manager and I think it handles filed permissions best. Install scoop by following the instructions here: https://scoop.sh/
+- Install youtube-dl (yt-dlp). FYI, pip3 didn't seem to work for this on windows, so I used scoop as a package manager and I think it handles filed permissions best. Install scoop by following the instructions here: https://scoop.sh/
 
 ```
-scoop install youtube-dl
+scoop install yt-dlp
 ```
 
 Open a powershell, and go to the pikaraoke directory:
@@ -324,7 +330,7 @@ Make sure youtube-dl is up to date, old versions have higher failure rates due t
 You can update youtube-dl directly from the web UI. Go to `Info > Update Youtube-dl` (depending on how you installed, you may need to be running pikaraoke as sudo for this to work)
 
 Or, from the CLI (path may vary):
-`youtube-dl -U`
+`yt-dlp -U`
 
 ### Downloads are slow!
 

--- a/app.py
+++ b/app.py
@@ -560,15 +560,23 @@ signal.signal(signal.SIGTERM, lambda signum, stack_frame: k.stop())
 
 def get_default_youtube_dl_path(platform):
     if platform == "windows":
-        choco_ytdl_path = r"C:\ProgramData\chocolatey\bin\youtube-dl.exe"
-        scoop_ytdl_path = os.path.expanduser(r"~\scoop\shims\youtube-dl.exe")
+        choco_ytdl_path = r"C:\ProgramData\chocolatey\bin\yt-dlp.exe"
+        scoop_ytdl_path = os.path.expanduser(r"~\scoop\shims\yt-dlp.exe")
         if os.path.isfile(choco_ytdl_path):
             return choco_ytdl_path
         if os.path.isfile(scoop_ytdl_path):
             return scoop_ytdl_path
-        return r"C:\Program Files\youtube-dl\youtube-dl.exe"
+        return r"C:\Program Files\yt-dlp\yd-dlp.exe"
+    default_ytdl_unix_path = "/usr/local/bin/yt-dlp"
+    if platform == "osx":
+        if os.path.isfile(default_ytdl_unix_path):
+            return default_ytdl_unix_path
+        else: 
+            # just a guess based on the default python 3 install in OSX monterey
+            return "/Library/Frameworks/Python.framework/Versions/3.10/bin/yt-dlp"
     else:
-        return "/usr/local/bin/youtube-dl"
+        return default_ytdl_unix_path
+        
 
 def get_default_dl_dir(platform):
     if platform == "raspberry_pi":

--- a/karaoke.py
+++ b/karaoke.py
@@ -9,8 +9,8 @@ import sys
 import threading
 import time
 from io import BytesIO
-from subprocess import check_output
 from pathlib import Path
+from subprocess import check_output
 
 import pygame
 import qrcode
@@ -56,7 +56,7 @@ class Karaoke:
         volume=0,
         log_level=logging.DEBUG,
         splash_delay=2,
-        youtubedl_path="/usr/local/bin/youtube-dl",
+        youtubedl_path="/usr/local/bin/yt-dlp",
         omxplayer_path=None,
         use_omxplayer=False,
         use_vlc=True,
@@ -427,13 +427,12 @@ class Karaoke:
             output = subprocess.check_output(cmd).decode("utf-8")
             logging.debug("Search results: " + output)
             rc = []
-            video_url_base = "https://www.youtube.com/watch?v="
             for each in output.split("\n"):
                 if len(each) > 2:
                     j = json.loads(each)
                     if (not "title" in j) or (not "url" in j):
                         continue
-                    rc.append([j["title"], video_url_base + j["url"], j["id"]])
+                    rc.append([j["title"], j["url"], j["id"]])
             return rc
         except Exception as e:
             logging.debug("Error while executing search: " + str(e))

--- a/karaoke.py
+++ b/karaoke.py
@@ -239,12 +239,12 @@ class Karaoke:
             try:
                 logging.info("Attempting youtube-dl upgrade via pip3...")
                 output = check_output(
-                    ["pip3", "install", "--upgrade", "youtube-dl"]
+                    ["pip3", "install", "--upgrade", "yt-dlp"]
                 ).decode("utf8")
             except FileNotFoundError:
                 logging.info("Attempting youtube-dl upgrade via pip...")
                 output = check_output(
-                    ["pip", "install", "--upgrade", "youtube-dl"]
+                    ["pip", "install", "--upgrade", "yt-dlp"]
                 ).decode("utf8")
             logging.info(output)
         self.get_youtubedl_version()

--- a/setup-pi.sh
+++ b/setup-pi.sh
@@ -23,7 +23,7 @@ if [ $? -ne 0 ]; then echo "ERROR: VLC patching failed with error code: $?"; exi
 
 echo
 echo "*** INSTALLING LATEST YOUTUBE_DL ***"
-sudo pip3 install --upgrade youtube_dl
+sudo pip3 install --upgrade yt-dlp
 if [ $? -ne 0 ]; then echo "ERROR: YouTube_dl installation failed with error code: $?"; exit 1; fi
 
 echo

--- a/templates/info.html
+++ b/templates/info.html
@@ -62,7 +62,7 @@
   <li>CPU: {{ cpu }}</li>
   <li>Disk Usage: {{ disk }}</li>
   <li>Memory: {{ memory }}</li>
-  <li>Youtube-dl version: {{ youtubedl_version }}</li>
+  <li>Youtube-dl (yt-dlp) version: {{ youtubedl_version }}</li>
   <li>Pikaraoke version: {{ pikaraoke_version }}</li>
 </ul>
 


### PR DESCRIPTION
- Change default binary to use yt-dlp for faster speeds, better ongoing maintenance
- Update install scripts to use yt-dlp
- Address pathing discrepancies for OSX
- Update documentation