### PR TITLE
Fix platform detection on 64-bit Raspberry Pi

### DIFF
--- a/lib/get_platform.py
+++ b/lib/get_platform.py
@@ -4,7 +4,10 @@ import sys
 
 def is_raspberry_pi():
     try: 
-        return os.uname()[4][:3] == "arm" and sys.platform != "darwin"
+        return (
+            os.uname()[4][:3] == "arm" or
+            os.uname()[4] == "aarch64"
+        ) and sys.platform != "darwin"
     except AttributeError:
         return False
 


### PR DESCRIPTION
This has been tested on a 64-bit Raspberry Pi B.