### PR TITLE
Increase the bottom margin of local splash screen

### DIFF
--- a/karaoke.py
+++ b/karaoke.py
@@ -344,7 +344,7 @@ class Karaoke:
             logo_rect = logo.get_rect(center=self.screen.get_rect().center)
             self.screen.blit(logo, logo_rect)
 
-            blitY = self.screen.get_rect().bottomleft[1] - 40
+            blitY = self.screen.get_rect().bottomleft[1] - 80
 
             if not self.hide_ip:
                 p_image = pygame.image.load(self.qr_code_path)


### PR DESCRIPTION
The splash screen displayed locally by the app on the Raspberry it runs on has a footer that contains a QR code and access instructions for the HTTP web interface.

It is laid out  very close to the bottom edge of the screen, with a margin of barely 40 pixels.

This works fine when the splash screen is displayed on a good screen that displays the entirety of the image area, and when proper full screen rendering is in effect.

However, there are some crappy HDMI displays that have their display area slightly cut off.

Another possible situation is when pikaraoke app is being launched from a X desktop environment (e.g. LXDE/Openbox on standard Raspberry Pi Desktop installation) - in that case `pygame`'s rendering doesn't handle full screen correctly and the entire image gets shifted downwards by the desktop environment's top bar, which remains on screen. This causes a small bottom margin to be cut off.

To guard against such situations, let's increase the bottom margin for the locally rendered splash screen. Having more generous margins is a good idea in general, especially for screens that don't need to accommodate a lot of content.