### PR TITLE
workaround for 'required interaction' with browser

### DIFF
--- a/app.py
+++ b/app.py
@@ -867,6 +867,7 @@ if __name__ == "__main__":
                 service = None
             options = Options()
             options.add_argument("--kiosk")
+            options.add_argument("--start-maximized")
             options.add_experimental_option("excludeSwitches", ['enable-automation'])
             driver = webdriver.Chrome(service=service, options=options)
             driver.get(f"{k.url}/splash" )


### PR DESCRIPTION
this allows PiKaraoke to autoplay without needing to click 'Confirm'. This only applies to the browser on the host machine. visiting /splash from your phone would still require tapping 'Confirm'.

This works with raspberry pi4 (8GB ram) with bookworm