### PR TITLE
Bug fix: #290 run apt only on required packages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,9 @@ if [ $REPLY = "y" ]
 if [[ $(cat /etc/os-release | grep -i debian) != "" ]]; then
   echo "Client is a Debian-based system. Installing binaries"; 
   echo
+  echo "*** RUNNING APT-GET UPDATE ***"
+  sudo apt update --allow-releaseinfo-change || true
+  if [ $? -ne 0 ]; then echo "ERROR: 'apt-get update' failed with error code: $?"; fi
   echo "*** INSTALLING REQUIRED BINARIES ***"
   sudo apt install --only-upgrade ffmpeg chromium-browser chromium-chromedriver -y
   if [ $? -ne 0 ]; then echo "ERROR: Binary dependency installation failed with error code: $?"; exit 1; fi

--- a/setup.sh
+++ b/setup.sh
@@ -9,15 +9,8 @@ if [ $REPLY = "y" ]
 if [[ $(cat /etc/os-release | grep -i debian) != "" ]]; then
   echo "Client is a Debian-based system. Installing binaries"; 
   echo
-  echo "*** RUNNING APT-GET UPDATE ***"
-  sudo apt-get update --allow-releaseinfo-change
-  if [ $? -ne 0 ]; then echo "ERROR: 'apt-get update' failed with error code: $?"; exit 1; fi
-
-  echo
   echo "*** INSTALLING REQUIRED BINARIES ***"
-  sudo apt-get install ffmpeg -y
-  sudo apt-get install chromium-browser -y
-  sudo apt-get install chromium-chromedriver -y
+  sudo apt install --only-upgrade ffmpeg chromium-browser chromium-chromedriver -y
   if [ $? -ne 0 ]; then echo "ERROR: Binary dependency installation failed with error code: $?"; exit 1; fi
 else  
  echo "Client is not Debian-based. Skipping binary installation. Please install ffmpeg and chrome manually."; 


### PR DESCRIPTION
fixes a case #290  where the user has a package that triggers this error:
`E: The repository '...' does not have a Release file
`
when running `sudo apt-get upgrade`, by upgrading / installing only what pikaraoke needs