### PR TITLE
Adding an ffmpeg url parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -831,7 +831,6 @@ if __name__ == "__main__":
         screensaver_timeout=args.screensaver_timeout,
         url=args.url,
         ffmpeg_url=args.ffmpeg_url,
-        prefer_ip=args.prefer_ip
         prefer_hostname=args.prefer_hostname
     )
 

--- a/app.py
+++ b/app.py
@@ -775,6 +775,13 @@ if __name__ == "__main__":
         required=False,
     ),
     parser.add_argument(
+        "-m",
+        "--ffmpeg-url",
+        help="Override the ffmpeg address with a supplied URL.",
+        default=None,
+        required=False,
+    ),
+    parser.add_argument(
         "--hide-overlay",
         action="store_true",
         help="Hide overlay that shows on top of video with pikaraoke QR code and IP",
@@ -833,6 +840,7 @@ if __name__ == "__main__":
         hide_overlay=args.hide_overlay,
         screensaver_timeout=args.screensaver_timeout,
         url=args.url,
+        ffmpeg_url=args.ffmpeg_url,
         prefer_ip=args.prefer_ip
     )
 

--- a/karaoke.py
+++ b/karaoke.py
@@ -75,6 +75,7 @@ class Karaoke:
         hide_overlay=False,
         screensaver_timeout = 300,
         url=None,
+        ffmpeg_url=None,
         prefer_ip=False
     ):
 
@@ -151,6 +152,10 @@ class Karaoke:
             else:
                 self.url = f"http://{socket.getfqdn().lower()}:{self.port}"
         self.url_parsed = urlparse(self.url)
+        if ffmpeg_url is None:
+            self.ffmpeg_url = f"{self.url_parsed.scheme}://{self.url_parsed.hostname}:{self.ffmpeg_port}"
+        else:
+            self.ffmpeg_url = ffmpeg_url
 
         # get songs from download_path
         self.get_available_songs()
@@ -360,7 +365,7 @@ class Karaoke:
     def play_file(self, file_path, semitones=0):
         logging.info(f"Playing file: {file_path} transposed {semitones} semitones")
         stream_uid = int(time.time())
-        stream_url = f"{self.url_parsed.scheme}://{self.url_parsed.hostname}:{self.ffmpeg_port}/{stream_uid}"
+        stream_url = f"{self.ffmpeg_url}/{stream_uid}"
         # pass a 0.0.0.0 IP to ffmpeg which will work for both hostnames and direct IP access
         ffmpeg_url = f"http://0.0.0.0:{self.ffmpeg_port}/{stream_uid}"
 

--- a/karaoke.py
+++ b/karaoke.py
@@ -76,7 +76,6 @@ class Karaoke:
         screensaver_timeout = 300,
         url=None,
         ffmpeg_url=None,
-        prefer_ip=False
         prefer_hostname=True
     ):
 


### PR DESCRIPTION
This adds a way to override the ffmpeg_url. Specifically helpful in proxy situations where the website domain and the ffmpeg domain aren't going to be the same. It should fallback to the same URL it is using today if you don't pass in the parameter though.

Allows me to do this:

```bash
python3 app.py --url karaoke.example.com --ffmpeg-url karaoke-stream.example.com
```

The issue comes down to this. I don't want people who are coming to my house for the karaoke party to have to connect to my wifi network in order to use that QR code. I'd like to reduce as much friction as possible. So I have my existing network proxying the main URL going to the backend. However, we can't use that main URL as the ffmpeg_url because the PORT doesn't proxy through my router. (yes, I can setup a port forward.. but I had this dynamically assigning ports when using nomad so this option works a bit better.)