### PR TITLE
Add command line arguments to specify width and height of the splash page

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ May not be up to date, run `python3 app.py --help` for the latest:
 ```
 usage: app.py [-h] [-p PORT] [-f FFMPEG_PORT] [-d DOWNLOAD_PATH] [-y YOUTUBEDL_PATH] [-v VOLUME] [-s SPLASH_DELAY] [-t SCREENSAVER_TIMEOUT]
               [-l LOG_LEVEL] [--hide-url] [--prefer-ip] [--hide-raspiwifi-instructions] [--hide-splash-screen] [--dual-screen] [--high-quality]
-              [--logo-path LOGO_PATH] [-u URL] [--hide-overlay] [--admin-password ADMIN_PASSWORD]
+              [--logo-path LOGO_PATH] [-u URL] [--hide-overlay] [--admin-password ADMIN_PASSWORD] [--window-size WIDTH,HEIGHT]
 
 options:
   -h, --help            show this help message and exit
@@ -184,6 +184,8 @@ options:
   --admin-password ADMIN_PASSWORD
                         Administrator password, for locking down certain features of the web UI such as queue editing, player controls, song editing,
                         and system shutdown. If unspecified, everyone is an admin.
+  --window-size WIDTH,HEIGHT
+                        Explicitly set the width and height of the splash screen, where the WIDTH and HEIGHT values are specified in pixels.
 ```
 
 ## Troubleshooting

--- a/app.py
+++ b/app.py
@@ -660,14 +660,8 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
-        "--width",
-        help="Desired window width in pixels",
-        default=0,
-        required=False,
-    )
-    parser.add_argument(
-        "--height",
-        help="Desired window height in pixels",
+        "--window-size",
+        help="Desired window geometry in pixels, specified as width,height",
         default=0,
         required=False,
     )
@@ -854,8 +848,8 @@ if __name__ == "__main__":
             service = None
         options = Options()
 
-        if args.width and args.height:
-            options.add_argument("--window-size=%s,%s" % (args.width,args.height))
+        if args.window_size:
+            options.add_argument("--window-size=%s" % (args.window_size))
             options.add_argument("--window-position=0,0")
             
         options.add_argument("--kiosk")

--- a/app.py
+++ b/app.py
@@ -660,6 +660,18 @@ if __name__ == "__main__":
         required=False,
     )
     parser.add_argument(
+        "--width",
+        help="Desired window width in pixels",
+        default=0,
+        required=False,
+    )
+    parser.add_argument(
+        "--height",
+        help="Desired window height in pixels",
+        default=0,
+        required=False,
+    )
+    parser.add_argument(
         "-f",
         "--ffmpeg-port",
         help=f"Desired ffmpeg port. This is where video stream URLs will be pointed (default: {default_ffmpeg_port})" ,
@@ -841,6 +853,11 @@ if __name__ == "__main__":
         else: 
             service = None
         options = Options()
+
+        if args.width and args.height:
+            options.add_argument("--window-size=%s,%s" % (args.width,args.height))
+            options.add_argument("--window-position=0,0")
+            
         options.add_argument("--kiosk")
         options.add_argument("--start-maximized")
         options.add_experimental_option("excludeSwitches", ['enable-automation'])


### PR DESCRIPTION
Thanks for sharing your code!

I've added a new command line parameter to specify the width and height of the chrome window that is opened. This was useful for me as I only installed the basic Xwindows without a window manager, so the --start-maximized flag doesn't do anything and I had to explicitly specify the window size.