### PR TITLE
Add host AP info to new splash UI

### DIFF
--- a/static/screensaver.css
+++ b/static/screensaver.css
@@ -18,8 +18,8 @@ body {
   position: absolute;
   left: 0px;
   top: 0px;
-  height: 180px;
-  width: 300px;
+  height: 200px;
+  width: 420px;
   z-index: 11;
   border-radius: 10px;
   display: flex;

--- a/templates/splash.html
+++ b/templates/splash.html
@@ -301,6 +301,12 @@
   </div>
 </div>
 
+<div id="ap-container">
+  <div class="is-size-5 stroke">
+    <div id="hostap">{% for line in hostap_info %}{{ line }}<br />{% endfor %}</div>
+  </div>
+</div>
+
 <div id="bottom-container">
   {% if not hide_url %}
   <div id="qr-code">
@@ -387,7 +393,7 @@
       <div style="text-align: right">
         <img src="{{ url_for('qrcode') }}" width="30%" height="30%" />
       </div>
-      <div>{{ url }}</div>
+      <div>{{ hostap_info[0] }}<br />{{ url }}</div>
     </div>
     {% endif %}
   </div>
@@ -401,6 +407,7 @@
     background-color: black;
   }
   #top-container,
+  #ap-container,
   #bottom-container {
     position: absolute;
     z-index: 1;
@@ -410,6 +417,14 @@
     top: 0px;
     right: 0px;
     max-width: 75%;
+  }
+  #ap-container {
+    top: 0px;
+    left: 0px;
+    max-width: 50%;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
   }
   #bottom-container {
     bottom: 0px;


### PR DESCRIPTION
This pull request adds the information about the Wifi AP name and password to the splash screen when using RaspiWifi, similar to how it looked before the switch to the web-based interface. In this instance, it displays a message that looks like the following in the upper left of the screen and also on the screensaver tile.

> Wifi Network: wifiName Password: wifiPassword
> Configure Wifi: http://10.0.0.1

This was tested on bullseye lite. For bookworm the wifi configuration is handled by networkmanager which breaks RaspiWifi functionality, so moving forward we will have to revisit this.