### PR TITLE
feat: Added support to Android via Termux App

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -553,7 +553,7 @@ def info():
     try:
         cpu = str(psutil.cpu_percent()) + "%"
     except:
-        cpu = "Android CPU usage query unsupported."
+        cpu = "CPU usage query unsupported"
 
     # mem
     memory = psutil.virtual_memory()
@@ -929,7 +929,7 @@ def main():
     cherrypy.engine.start()
 
     # force headless mode when on Android
-    if "Android" in platform and not args.hide_splash_screen:
+    if (platform == "android") and not args.hide_splash_screen:
         args.hide_splash_screen = True
         logging.info("Forced to run headless mode in Android")
     # Start the splash screen using selenium

--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -550,7 +550,10 @@ def info():
     url = k.url
 
     # cpu
-    cpu = str(psutil.cpu_percent()) + "%"
+    try:
+        cpu = str(psutil.cpu_percent()) + "%"
+    except:
+        cpu = "Android CPU usage query unsupported."
 
     # mem
     memory = psutil.virtual_memory()
@@ -925,6 +928,10 @@ def main():
     )
     cherrypy.engine.start()
 
+    # force headless mode when on Android
+    if "Android" in platform and not args.hide_splash_screen:
+        args.hide_splash_screen = True
+        logging.info("Forced to run headless mode in Android")
     # Start the splash screen using selenium
     if not args.hide_splash_screen:
         if raspberry_pi:

--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -191,7 +191,7 @@ class Karaoke:
 
     def get_ip(self):
         # python socket.connect will not work on android, access denied. Workaround: use ifconfig which is installed to termux by default, iirc.
-        if "Android" in self.platform:
+        if self.platform == "android":
             # shell command is: ifconfig 2> /dev/null | awk '/wlan0/{flag=1} flag && /inet /{print $2; exit}'
             IP = (
                 subprocess.check_output(

--- a/pikaraoke/lib/get_platform.py
+++ b/pikaraoke/lib/get_platform.py
@@ -26,10 +26,14 @@ def is_raspberry_pi():
         return (
             (os.uname()[4][:3] == "arm" or os.uname()[4] == "aarch64")
             and sys.platform != "darwin"
-            and not (os.path.exists("/system/app/") and os.path.exists("/system/priv-app"))
+            and not is_android()
         )
     except AttributeError:
         return False
+
+
+def is_android():
+    return os.path.exists("/system/app/") and os.path.exists("/system/priv-app")
 
 
 def get_platform():
@@ -41,8 +45,8 @@ def get_platform():
     #            if "termux" in os.environ[key]:
     #                return "Termux on Android"
     #    return "linux"
-    elif os.path.exists("/system/app/") and os.path.exists("/system/priv-app"):
-        return "Android"
+    elif is_android():
+        return "android"
     elif is_raspberry_pi():
         try:
             with open("/proc/device-tree/model", "r") as file:

--- a/pikaraoke/lib/get_platform.py
+++ b/pikaraoke/lib/get_platform.py
@@ -24,8 +24,10 @@ def get_ffmpeg_version():
 def is_raspberry_pi():
     try:
         return (
-            os.uname()[4][:3] == "arm" or os.uname()[4] == "aarch64"
-        ) and sys.platform != "darwin"
+            (os.uname()[4][:3] == "arm" or os.uname()[4] == "aarch64")
+            and sys.platform != "darwin"
+            and not (os.path.exists("/system/app/") and os.path.exists("/system/priv-app"))
+        )
     except AttributeError:
         return False
 
@@ -33,6 +35,14 @@ def is_raspberry_pi():
 def get_platform():
     if sys.platform == "darwin":
         return "osx"
+    # elif sys.platform.startswith("linux"):
+    #    for key in os.environ:
+    #        if key == "PREFIX":
+    #            if "termux" in os.environ[key]:
+    #                return "Termux on Android"
+    #    return "linux"
+    elif os.path.exists("/system/app/") and os.path.exists("/system/priv-app"):
+        return "Android"
     elif is_raspberry_pi():
         try:
             with open("/proc/device-tree/model", "r") as file:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,6 +44,27 @@ setup-windows.bat
 
 Windows firewall may initially block connections to port 5555 and 5556. Be sure to allow these. It should prompt the first time you run pikaraoke and launch a song. Otherwise, configure it manually in the security settings.
 
+### Android (via Termux App)
+
+Install the Termux App via https://f-droid.org/en/packages/com.termux/ or from Google Play via https://play.google.com/store/apps/details?id=com.termux
+
+Open the Termux App (A terminal emulator similar to linux)
+
+Optional (but recommended):
+Updated the packages using the command:
+
+```
+pkg update && pkg upgrade
+```
+
+Install python and ffmpeg:
+
+```
+pkg install python ffmpeg
+```
+
+from this point onwards, you only need to follow the installation for Raspberry pi / Linux / OSX (see above).
+
 ## Launch
 
 cd to the pikaraoke directory and run:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,27 +44,6 @@ setup-windows.bat
 
 Windows firewall may initially block connections to port 5555 and 5556. Be sure to allow these. It should prompt the first time you run pikaraoke and launch a song. Otherwise, configure it manually in the security settings.
 
-### Android (via Termux App)
-
-Install the Termux App via https://f-droid.org/en/packages/com.termux/ or from Google Play via https://play.google.com/store/apps/details?id=com.termux
-
-Open the Termux App (A terminal emulator similar to linux)
-
-Optional (but recommended):
-Updated the packages using the command:
-
-```
-pkg update && pkg upgrade
-```
-
-Install python and ffmpeg:
-
-```
-pkg install python ffmpeg
-```
-
-from this point onwards, you only need to follow the installation for Raspberry pi / Linux / OSX (see above).
-
 ## Launch
 
 cd to the pikaraoke directory and run:


### PR DESCRIPTION
This PR adds support to Android via the Termux App.

- lib/app.py 
Handle error when querying cpu usage on Termux (restricted)
Force to run on headless mode when detected running on Android.
- karaoke.py
Added way to query ip address when running on Termux/Android since sockets will not work.

- get_platform.py
is_raspberry_pi(): Added validation to avoid incorrectly reporting Termux/Android as raspberry pi.
get_platform(): Properly returns Android as platform to avoid crashes in other program logic.
- scripts/README.md
Added Termux/Android installation.
