### PR TITLE
feat: on pi, possibility to change the audio output as well as use bl…

### DIFF
--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -24,6 +24,17 @@ from pikaraoke.lib.get_platform import (
     is_raspberry_pi,
     supports_hardware_h264_encoding,
 )
+from pikaraoke.lib.audio_devices import (
+    get_audio_sinks,
+    set_default_audio_sink,
+    set_device_vol_up,
+    set_device_vol_down,
+)
+from pikaraoke.lib.bluetooth import (
+    scan_and_get_bt_devices,
+    connect_to_bt_device,
+    remove_bt_device,
+)
 
 
 # Support function for reading  lines from ffmpeg stderr without blocking
@@ -717,6 +728,35 @@ class Karaoke:
         self.is_playing = False
         self.now_playing_transpose = 0
         self.ffmpeg_log = None
+
+    def get_audio_devices(self):
+        logging.debug("Getting audio sinks")
+        return get_audio_sinks()
+    
+    def change_audio_output(self, audio_device):
+        logging.debug(f"Changing audio output to: {audio_device}")
+        result = set_default_audio_sink(audio_device)
+        return
+    
+    def change_device_volume(self, volume):
+        logging.debug(f"Changing device volume: {volume}")
+        if volume == "up":
+            result = set_device_vol_up()
+        else:
+            result = set_device_vol_down()
+        return
+    
+    def get_bluetooth_devices(self): 
+        logging.debug("Getting bluetooth audio devices")
+        return scan_and_get_bt_devices()
+    
+    def pair_bluetooth_device(self, bt_device):
+        logging.debug("Pairing to bluetooth device: " + bt_device["name"])
+        return connect_to_bt_device(bt_device)
+
+    def remove_bluetooth_device(self, bt_device):
+        logging.debug("Removing bluetooth device: " + bt_device["name"])
+        return remove_bt_device(bt_device)
 
     def run(self):
         logging.info("Starting PiKaraoke!")

--- a/pikaraoke/lib/audio_devices.py
+++ b/pikaraoke/lib/audio_devices.py
@@ -1,0 +1,139 @@
+""" 
+This script is only for Raspberry Pi
+
+It uses Pipewire / Wireplumber to:
+- Get the list of audio sinks (hdmi, headphone, bluetooth...)
+- Set the audio output
+- Set up or down output volume
+
+To install the necessary components run:
+`Sudo apt install pipewire pipewire-pulse pipewire-jack pipewire-alsa pipewire-audio -y`
+
+Based on the Wireplumber docs
+https://wiki.archlinux.org/title/WirePlumber
+"""
+
+import subprocess
+import html
+import logging
+
+def get_audio_sinks():
+    try:
+        # Executes the wpctl status command and captures the output
+        logging.debug("Getting audio sinks")
+
+        command = ['wpctl', 'status']
+        result = run_commands(command)
+
+        # logging.debug("Audio sinks: " + result)
+
+        # Control variables
+        in_audio_section = False
+        in_sinks_section = False
+        sinks = []
+
+        # Processes each line of the output
+        for line in result.splitlines():
+            line = line.strip()
+            
+            # Detects the start and end of the audio section
+            if not in_audio_section and line == "Audio":
+                in_audio_section = True
+                continue
+            elif in_audio_section and line == "Video":
+                in_audio_section = False
+                continue
+
+            # Detects the start and end of the "Sinks" subsection
+            if in_audio_section and "Sinks:" in line:
+                in_sinks_section = True
+                continue
+            elif in_audio_section and "Sink endpoints:" in line:
+                in_sinks_section = False
+                continue
+
+            # Captures only valid sink lines
+            elif in_sinks_section:
+                line = str.split(line)
+
+                # Checks if it's an empty line
+                if len(line) < 3:
+                    continue
+
+                # newline = []
+                default=False
+
+                # Checks if it's the default sink line
+                if "*" in line:
+                    # newline.append("1")
+                    default=True
+                    line.remove("*")
+                else:
+                    default=False
+                    # newline.append("0")
+
+                number = line[1].strip('.') # Gets the number
+                name = ' '.join(line[2:-2]) # Gets the name
+
+                volume = get_volume(float(line[-1].strip('[]'))) # Gets the volume
+
+                newline = {"default": default, "number": number, "volume": volume, "name": name}
+                   
+                sinks.append(newline)
+
+        return sinks
+
+    except Exception as e:
+        logging.debug(f"Error getting audio sinks: {e}")
+        return []
+
+def set_default_audio_sink(sink_number):
+    logging.debug(f"Setting default audio sink to: {sink_number}")
+    command = ['wpctl', 'set-default', sink_number]
+    return run_commands(command)
+
+
+def get_volume(volume):
+    logging.debug(f"Getting volume: {volume}")
+    volume = volume * 100
+
+    if volume % 10 != 0:
+        volume = round_sink_volume(volume)
+    return int(volume)
+
+# As we increase and decrease the volume by 0.1, we need to round it
+def round_sink_volume(volume, sink_number = "default"):
+    logging.debug(f"Rounding volume: {volume}")
+    volume = round(volume/100, 1)
+    sink = "@DEFAULT_AUDIO_SINK@" if sink_number == "default" else sink_number
+    command = ['wpctl', 'set-volume', sink, str(volume)]
+    run_commands(command)
+    return volume * 100
+
+def set_device_vol_up(sink_number = "default"):
+    sink = "@DEFAULT_AUDIO_SINK@" if sink_number == "default" else sink_number
+    command = ['wpctl', 'set-volume', '-l', '1.5', sink, "0.1+"]
+    return run_commands(command)
+
+def set_device_vol_down(sink_number = "default"):
+    sink = "@DEFAULT_AUDIO_SINK@" if sink_number == "default" else sink_number
+    command = ['wpctl', 'set-volume', '-l', '1.5', sink, "0.1-"]
+    return run_commands(command)
+
+# Function that runs the commands using subprocess
+def run_commands(command):
+    logging.debug("Running commands")
+
+    try:
+        # Executes the command, captures, and returns the output
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        output = html.unescape(result.stdout)
+        return output
+    except subprocess.CalledProcessError as e:
+        # Captures specific subprocess errors
+        logging.debug(f"Error executing the command: {e}")
+        return None
+    except Exception as e:
+        # Captures any other errors
+        logging.debug(f"An error occurred running the command: {e}")
+        return None

--- a/pikaraoke/lib/audio_devices.py
+++ b/pikaraoke/lib/audio_devices.py
@@ -110,14 +110,16 @@ def round_sink_volume(volume, sink_number = "default"):
     run_commands(command)
     return volume * 100
 
+# increase volume by 0.1 - max volume is 1.5 (150%)
 def set_device_vol_up(sink_number = "default"):
     sink = "@DEFAULT_AUDIO_SINK@" if sink_number == "default" else sink_number
     command = ['wpctl', 'set-volume', '-l', '1.5', sink, "0.1+"]
     return run_commands(command)
 
+# decrease volume by 0.1
 def set_device_vol_down(sink_number = "default"):
     sink = "@DEFAULT_AUDIO_SINK@" if sink_number == "default" else sink_number
-    command = ['wpctl', 'set-volume', '-l', '1.5', sink, "0.1-"]
+    command = ['wpctl', 'set-volume', sink, "0.1-"]
     return run_commands(command)
 
 # Function that runs the commands using subprocess

--- a/pikaraoke/lib/bluetooth.py
+++ b/pikaraoke/lib/bluetooth.py
@@ -1,0 +1,188 @@
+""" 
+This script is only for Raspberry Pi
+
+It uses bluetoothctl to:
+- Sacan for bluetooth devices
+- Pair a bluetooth device
+- Remove a bluetooth device
+
+To do:
+1. When looking for known devices, it should compare the file btdevices.txt with the list of known devices in bluetoothctl ("bluetoothctl devices"), to prevent
+a device already paired from not being seen as it's not in te bluetooth file.
+2. In the btdevices file, create a line with the new files, with the date/time of the addition, because if the the user scans for devicesbefore the "DiscoveryTimeout"
+setted in the bluetooth configuration file ("/etc/bluetooth/main.conf") it will not be shown.
+"""
+
+import subprocess
+import time
+import configparser
+import os
+import ast
+from time import localtime, strftime
+import logging
+
+now = strftime("%Y-%m-%d %H:%M:%S", localtime())
+path = os.path.dirname(__file__)
+file = os.path.join(path, "btdevices.txt")
+section = "DEVICES"
+key = "known"
+config_obj = configparser.ConfigParser()
+
+# Pega os dispositivos conhecidos do arquivo definido
+def get_known_devices():
+    logging.debug("Getting known devices")
+    if os.path.exists(file):
+        config_obj.read(file)
+        if section in config_obj:
+            try:
+                known_devices = ast.literal_eval(config_obj[section][key])
+                return ['ok', known_devices]
+            except (ValueError, SyntaxError) as e:
+                return ['error', f'parsing_error: {str(e)}']
+        else:
+            return ['error', 'no_section']
+    else:
+        return ['error', 'no_file']
+
+# Adiciona o dispositivo conhecido no arquivo
+def add_known_device(device):
+    logging.debug(f'Adding known device: {device["name"]}')
+    devices = get_known_devices()
+    device = {'mac': device['mac'], 'name': device['name']}
+
+    if devices[0] != "ok":
+        devices[1]=[]
+        if section not in config_obj:
+            config_obj.add_section(section)
+    else:
+        for existing_device in devices[1]:
+            if existing_device['mac'] == device['mac']:
+                logging.info("Device already exists: %s", device)
+                return
+
+    devices[1].append(device)
+    config_obj[section][key] = str(devices[1])
+    with open(file, 'w') as configfile:
+        config_obj.write(configfile)
+    
+    logging.info("Device added successfully: %s", device["name"])
+    return
+
+# Remove o dispositivo conhecido do arquivo
+def remove_known_device(device):
+    logging.debug(f'Removing known device: {device["name"]}')
+    if os.path.exists(file):
+        devices = get_known_devices()
+        if devices[0] == "ok":
+            # devices[1] = [item for item in devices[1] if item[1] != device]
+            devices[1] = [item for item in devices[1] if item['mac'] != device["mac"]]
+            config_obj[section][key] = str(devices[1])
+            with open(file, 'w') as configfile:
+                config_obj.write(configfile)
+            return ["ok", "Device removed successfully"]
+    return ["error", "Something went wrong while removing the device"]
+
+# Roda os comandos 
+def run_bluetoothctl_command(process, command):
+    # Inicia o processo bluetoothctl
+    process.stdin.write(command)
+    process.stdin.flush()
+    return
+
+# Recebe os comandos e roda em sequência
+def run_commands(process, commands):
+    for command in commands:
+        run_bluetoothctl_command(process, command)
+        # time.sleep(2)
+    return
+
+# Escaneia os dispositivos bluetooth detectáveis
+def scan_and_get_bt_devices(scan_time=10):
+
+    process = subprocess.Popen(['bluetoothctl'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,text=True)
+    
+    run_commands(process, ['scan on\n'])
+
+    time.sleep(scan_time)
+
+    run_commands(process, ['scan off\n', 'devices\n'])
+
+    devices_output, _ = process.communicate()
+
+    # Filtra e captura apenas as linhas que contenham 'Device', ou seja, os dispositivos reais
+    devices_new = []
+    devices_known = []
+
+    lines = devices_output.splitlines()
+
+    for line in lines:
+        if 'Device' in line:
+            line = line.split()
+            if line[0] == '\x1b[K[\x01\x1b[0;92m\x02NEW\x01\x1b[0m\x02]':
+                if line[2] != line[3].replace('-', ':'):
+                    newline = {'status':'new', 'mac':line[2], 'name':' '.join(line[3:]), 'date':now}
+                    devices_new.append(newline)
+
+    devices_known = [] if get_known_devices()[0] == "error" else get_known_devices()[1]
+
+    return {
+        'new': devices_new,
+        'known': devices_known
+    }
+
+# Conecta ao dispositivo escolhido
+def connect_to_bt_device(device):
+    tries = 0
+    success = False
+    
+    while tries != 5:
+        tries += 1
+
+        process = subprocess.Popen(['bluetoothctl'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,text=True)
+        process.stdin.write('scan on\n')
+        process.stdin.flush()
+        time.sleep(10)
+        process.stdin.write(f'pair {device["mac"]}\n')
+        process.stdin.flush()
+        time.sleep(2 + tries)
+        process.stdin.write(f'connect {device["mac"]}\n')
+        process.stdin.flush()
+        time.sleep(3)
+        process.stdin.write(f'trust {device["mac"]}\n')
+        process.stdin.flush()
+        result, _ = process.communicate()
+        
+        lines = result.splitlines()
+
+        for line in lines:
+            print(line)
+            if 'Connection successful' in line:
+                success = True
+                tries = 5
+                break
+
+    if success:
+        logging.debug("Successfully connected to " + device["name"])
+        add_known_device(device)
+        return ["ok", "Successfully connected to " + device["name"]]
+    else:
+        process = subprocess.Popen(['bluetoothctl'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,text=True)
+        process.stdin.write(f'remove {device["mac"]}\n')
+        process.stdin.flush()
+        result, _ = process.communicate()
+        logging.debug(f'Fail to connect to {device["name"]}')
+        return ["error", f'Fail to connect to {device["name"]}']
+
+# Remove o dispositivo do controle de bluetooth e do arquivo de dispositivos conhecidos
+def remove_bt_device(device):
+    logging.debug(f'Removing {device["name"]} - MAC: {device["mac"]}')
+    try:
+        process = subprocess.Popen(['bluetoothctl'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,text=True)
+        process.stdin.write(f'remove {device["mac"]}\n')
+        process.stdin.flush()
+        result, _ = process.communicate()
+        return remove_known_device(device)
+    except Exception as e:
+        logging.debug(f'Error removing {device["name"]}: {e}')
+        return ["error", f'Error removing {device["name"]}: {e}']
+    

--- a/pikaraoke/lib/bluetooth.py
+++ b/pikaraoke/lib/bluetooth.py
@@ -28,7 +28,7 @@ section = "DEVICES"
 key = "known"
 config_obj = configparser.ConfigParser()
 
-# Pega os dispositivos conhecidos do arquivo definido
+# Grabs the list of known devices
 def get_known_devices():
     logging.debug("Getting known devices")
     if os.path.exists(file):
@@ -44,7 +44,7 @@ def get_known_devices():
     else:
         return ['error', 'no_file']
 
-# Adiciona o dispositivo conhecido no arquivo
+# Adds the device to the file
 def add_known_device(device):
     logging.debug(f'Adding known device: {device["name"]}')
     devices = get_known_devices()
@@ -68,7 +68,7 @@ def add_known_device(device):
     logging.info("Device added successfully: %s", device["name"])
     return
 
-# Remove o dispositivo conhecido do arquivo
+# Remove the device from the file
 def remove_known_device(device):
     logging.debug(f'Removing known device: {device["name"]}')
     if os.path.exists(file):
@@ -82,21 +82,21 @@ def remove_known_device(device):
             return ["ok", "Device removed successfully"]
     return ["error", "Something went wrong while removing the device"]
 
-# Roda os comandos 
+# Runs the bt commands
 def run_bluetoothctl_command(process, command):
     # Inicia o processo bluetoothctl
     process.stdin.write(command)
     process.stdin.flush()
     return
 
-# Recebe os comandos e roda em sequência
+# Receive a list of commands and run them one by one
 def run_commands(process, commands):
     for command in commands:
         run_bluetoothctl_command(process, command)
         # time.sleep(2)
     return
 
-# Escaneia os dispositivos bluetooth detectáveis
+# Scan for bluetooth devices
 def scan_and_get_bt_devices(scan_time=10):
 
     process = subprocess.Popen(['bluetoothctl'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,text=True)
@@ -130,7 +130,7 @@ def scan_and_get_bt_devices(scan_time=10):
         'known': devices_known
     }
 
-# Conecta ao dispositivo escolhido
+# Connect to a bluetooth device (Pair, connect and trust)
 def connect_to_bt_device(device):
     tries = 0
     success = False
@@ -173,7 +173,7 @@ def connect_to_bt_device(device):
         logging.debug(f'Fail to connect to {device["name"]}')
         return ["error", f'Fail to connect to {device["name"]}']
 
-# Remove o dispositivo do controle de bluetooth e do arquivo de dispositivos conhecidos
+# Remove the device from bluetooth controller and the file
 def remove_bt_device(device):
     logging.debug(f'Removing {device["name"]} - MAC: {device["mac"]}')
     try:

--- a/pikaraoke/lib/get_platform.py
+++ b/pikaraoke/lib/get_platform.py
@@ -3,7 +3,26 @@ import platform
 import re
 import subprocess
 import sys
+import logging
 
+def is_pipewire_installed():
+    try:
+        # Check if pipewire is present'
+        result = subprocess.run(
+            ["pipewire", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        )
+        first_line = result.stdout.split("\n")[0]
+        if "pipewire" in first_line:
+            # Check if wireplumber is present'
+            result = subprocess.run(
+                ["wireplumber", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            )
+            first_line = result.stdout.split("\n")[0]
+            if "wireplumber" in first_line:
+                return True
+        return False
+    except:
+        return False
 
 def get_ffmpeg_version():
     try:

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -222,7 +222,7 @@
 
     {% if get_flashed_messages() %}
     {% for category, message in get_flashed_messages(with_categories=true) %}
-    <div id="notification" class="notification {{category}}" style="display: none">
+    <div id="notification" class="notification {{category}}">
       <button id="notification-close" class="delete"></button>
       <div class="flash">{{ message }}</div>
     </div>

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -40,11 +40,64 @@
     $("#expand-link").click(function (e) {
       e.preventDefault();
       // {# MSG: Confirmation text when the user wants to expand the filesystem to take the entire SD card. #}
-      if (window.confirm("Are you sure you want to expand the filesystem? This will reboot your raspberry pi.")) {
+      if (window.confirm("{{ _('Are you sure you want to expand the filesystem? This will reboot your raspberry pi.')}}")) {
         location.href = this.href;
       }
     });
+
+    $("#audio-devices").change(function (e) {
+      e.preventDefault();
+      // {# MSG: Confirmation text when the user wants to change the audio device. #}
+      if (window.confirm("{{ _('Are you sure you want to change the audio device?')}}")) {
+        changeDevice($(this).val())
+      }
+    });
+
+    function changeDevice(deviceValue){
+      url = "{{ url_for('change_audio_output') }}" + "?device=" + deviceValue
+      window.location.href = url;
+    }
+
+    $(".device-volume-button").click(function (e) {
+      e.preventDefault();
+
+      if ($(this).prop("disabled")) return;
+
+      let volume = parseInt($("#volume-value").text(), 10)
+      let upOrDown = $(this).attr("volume")
+      let url = $(this).data("url");
+
+      volume = (upOrDown == "up") ? volume + 10 : volume - 10
+
+      console.log(volume)
+      console.log(typeof volume)
+
+      $.get( url, function( response ) {
+        if (response.msg && response.status) {
+          showNotification(response.msg, response.status);
+          if (response.status == "is-success"){
+            console.log(volume)
+            console.log(volume === 150)
+            $("#volume-value").text(volume + "%");
+            $("#device-volume-up").prop("disabled", volume === 150);
+            $("#device-volume-down").prop("disabled", volume === 0);
+          }
+        }
+      });
+    });
+
+    $("#bt-container").on("click", ".pair-device", function(){
+      // {# MSG: Notification text when the system is pairing a bluetooth device. #}
+      showNotification("{{ _('Pairing bluetooth device...')}}", "is-info", timeout=15000);
+    })
+
+    $("#bt-container").on("click", ".remove-device", function(){
+      // {# MSG: Notification text when the system is removing a bluetooth device. #}
+      showNotification("{{ _('Removing bluetooth device...')}}", "is-info", timeout=15000);
+    })
+
   });
+
 </script>
 {% endblock %}
 
@@ -171,6 +224,129 @@
     you may want to expand the filesystem to utilize the remaining space. You only need to do this once.
     This will reboot the system.
   {%- endtrans %}</p>
+
+  {% if have_pipewire %}
+    <hr/>
+    {# MSG: Title for section about output audio devices #}
+    <h1>{% trans %}Output Audio Device{% endtrans %}</h1>
+    {# MSG: Subtitle for section where the user can change the default audio output #}
+    <h3>{% trans %}Main Sound Output{% endtrans %}</h3>
+    {# MSG: Explainitory text which explains about the default audio output. #}
+    <p class="help">{% trans -%}
+      If you want to change the default audio output, you can do so here. It uses Pipewire with Wireplumber so it's necessary to have them installed in your system.
+    {%- endtrans %}</p>
+    <div id="sound-devices" class="select is-loading">
+        <select id="audio-devices" name="audio-devices">
+        </select>
+    </div>
+
+    {# MSG: Subtitle for section where the user can change the audio output volume #}
+    <h3>{% trans %}Output Audio Device volume{% endtrans %}</h3>
+    {# MSG: information when the system is loading #}
+    <p class="loading">{% trans %}Loading...{% endtrans %}</p>
+    <div id="volume-buttons"class="buttons is-hidden">
+      {# MSG: Button for decreasing device volume #}
+      <button data-url="{{ url_for('change_device_volume', volume='down') }}" id="device-volume-down" class="device-volume-button button" volume="down" style="margin: 0" title="{% trans %}Decrease volume 10%{% endtrans %}">
+        <span class="icon icon-volume-down"></span>
+      </button>
+      <span id="volume-value" class="tag is-medium" style="margin: 0 0.5rem;"></span>
+      {# MSG: Button for increasing device volume #}
+      <button data-url="{{ url_for('change_device_volume', volume='up') }}" id="device-volume-up" class="device-volume-button button" volume="up" style="margin: 0" title="{% trans %}Increase volume 10%{% endtrans %}">
+        <span class="icon icon-volume-up"></span>
+      </button>
+    </div>
+
+    {# MSG: Subtitle for section where the user can scan and pair bluetooth devices #}
+    <h1>{% trans %}Bluetooth Devices{% endtrans %}</h1>
+    {# MSG: information when the system is loading #}
+    <p class="loading">{% trans %}Loading...{% endtrans %}</p>
+    <div id="bt-container" class="is-hidden">
+      <div id="known-bt-devices-container">
+        {# MSG: Subtitle for the Bluetooth section where the user can find known bluetooth devices #}
+        <p>{% trans %}Known devices:{% endtrans %}</p>
+        <ul id="known-bt-devices" class="bt-devices">
+        </ul>
+      </div>
+      <div id="new-bt-devices-container">
+      {# MSG: Subtitle for the Bluetooth section where the user can find New bluetooth devices #}
+      <p>{% trans %}Found devices:{% endtrans %}</p>
+        <ul id="new-bt-devices" class="bt-devices">
+        </ul>
+      </div>
+    </div>
+
+    <script>
+      $(document).ready(function () {
+        $.getJSON("{{ url_for('get_audio_devices') }}", function (data) {
+          // Hide "loading..."
+          $(".loading").hide();
+          $("#sound-devices").removeClass("is-loading")
+
+          if ("audio_devices" in data){
+            for (audio_device of data["audio_devices"]){
+              if (audio_device["default"]){
+                $("#audio-devices").append($("<option selected>").attr("value", audio_device["number"]).text("*" + audio_device["name"]))
+                $("#volume-value").text(audio_device["volume"] + "%")
+                $("#volume-buttons").removeClass("is-hidden")
+              } else {
+                $("#audio-devices").append($("<option>").attr("value", audio_device["number"]).text(audio_device["name"]))
+              }
+            }
+          } else {
+            // {# MSG: Text information for when no audio devices are found #}
+            $("#audio-devices").append($("<option>").attr("value", "").text("No audio devices found"))
+          }
+
+          if ("bluetooth" in data){
+            if (data["bluetooth"]["known"].length != 0){
+              for (bt_device of data["bluetooth"]["known"]){
+
+                line = `<li class="known-bt-device">`
+
+                if ("audio_device" in bt_device){
+                  if (!bt_device["default"]){
+                    // {# MSG: Link to make a known bluetooth device the default output audio device #}
+                    line += `<a href="{{ url_for('change_audio_output') }}?device=${bt_device.number}" class="make-bt-default-device" >${bt_device.name}</a>
+                      <span> | </span>
+                      <a href="{{ url_for('change_audio_output') }}?device=${bt_device.number}" class="make-bt-default-device" >{% trans %}Make default output{% endtrans %}</a>`
+                  }else{
+                    line += `${bt_device.name}`
+                  }
+                } else {
+                  line += `<a href="{{ url_for('pair_bt_device') }}?mac=${bt_device.mac}&name=${bt_device.name}" class="pair-device" >${bt_device.name}</a>`
+                }
+
+                // {# MSG: Link to remove a known bluetooth device #}
+                line += `<span> | </span>
+                <a href="{{ url_for('remove_bt_device') }}?mac=${bt_device.mac}&name=${bt_device.name}" class="remove-bt-device" >{% trans %}Remove{% endtrans %}</a>
+                </li>`
+
+                $("#known-bt-devices").append(line)
+              }
+            } else {
+              $("#known-bt-devices-container").addClass("is-hidden")
+            }
+
+            if (data["bluetooth"]["new"].length != 0){
+              for (bt_device of data["bluetooth"]["new"]){
+                $("#new-bt-devices").append(
+                  `<li class="new-bt-device">
+                    <a href="{{ url_for('pair_bt_device') }}?mac=${bt_device.mac}&name=${bt_device.name}" class="pair-device" >${bt_device.name}</a>
+                  </li>`
+                )
+              }
+            } else {
+              // {# MSG: Message to the user when no bluetooth devices are found #}
+              $("#new-bt-devices-container p").text("No devices found!")
+            }
+            
+            
+            $("#bt-container").removeClass("is-hidden")
+          }
+        })
+      })
+    </script>
+  {% endif %}
 {% endif %}
 
 <hr/>


### PR DESCRIPTION
I've created the possibility for a pi user, without access to the user interface, to change the oudio output from hdmi, headphone and bluetooth, as well as the possibility to scan and pair to bluetooth devices.

For it to work, it need the PipeWire with Wireplumber

`sudo apt install pipewire pipewire-pulse pipewire-jack pipewire-alsa pipewire-audio -y`

I created two files in the lib folder `audio_devices.py` and `bluetooth.py`.

- `audio devices.py` is the file responsible for getting the possible output audio devices, to connect to them and to increase and decrease their volumes. It uses `wpctl` from wireplumber.

- `bluetooth.py` is the file that manages bluetooth devices. It can scan for bt devices, connect and remove. It uses `bluetoothctl` to do the job. When the script pair to a devices it stores the device in a file called `btdevices.txt` inside the lib folder. Those are the devices that the system will automatically connect to when it finds it.

The user interface to work with these scripts are in the `info.html`.

I also created a function inside the `get_platform.py` to check if the pipewire is installed, if not it doesn't run these scripts.

One more thing: mainly because of the bluetooth scan, that takes some time, I've made it assyncronous so that the info page loads rigth away while this part is still loading and is updated when finished.