### PR TITLE
feat: add support for adjusting a/v sync (#489)

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -174,6 +174,7 @@ def main():
         bg_video_path=args.bg_video_path,
         disable_score=args.disable_score,
         limit_user_songs_by=args.limit_user_songs_by,
+        avsync=args.avsync,
         config_file_path=args.config_file_path,
     )
 

--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -108,6 +108,7 @@ class Karaoke:
         disable_bg_video=False,
         disable_score=False,
         limit_user_songs_by=0,
+        avsync=0,
         config_file_path="config.ini",
     ):
         logging.basicConfig(
@@ -161,6 +162,7 @@ class Karaoke:
         self.limit_user_songs_by = (
             self.get_user_preference("limit_user_songs_by") or limit_user_songs_by
         )
+        self.avsync = self.get_user_preference("avsync") or avsync
         self.url_override = url
         self.url = self.get_url()
 
@@ -458,7 +460,10 @@ class Karaoke:
         logging.info(f"Playing file: {file_path} transposed {semitones} semitones")
 
         requires_transcoding = (
-            semitones != 0 or self.normalize_audio or is_transcoding_required(file_path)
+            semitones != 0
+            or self.normalize_audio
+            or is_transcoding_required(file_path)
+            or self.avsync != 0
         )
 
         logging.debug(f"Requires transcoding: {requires_transcoding}")
@@ -493,7 +498,11 @@ class Karaoke:
         else:
             self.kill_ffmpeg()
             ffmpeg_cmd = build_ffmpeg_cmd(
-                fr, semitones, self.normalize_audio, self.complete_transcode_before_play
+                fr,
+                semitones,
+                self.normalize_audio,
+                self.complete_transcode_before_play,
+                self.avsync,
             )
             self.ffmpeg_process = ffmpeg_cmd.run_async(pipe_stderr=True, pipe_stdin=True)
 

--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -238,6 +238,12 @@ def parse_pikaraoke_args():
         required=False,
     ),
     parser.add_argument(
+        "--avsync",
+        help="Use avsync (in seconds) if the audio and video streams are out of sync. (negative = advances audio | positive = delays audio)",
+        default="0",
+        required=False,
+    ),
+    parser.add_argument(
         "--config-file-path",
         help=f"Path to a config file to load settings from. Config file settings are set in the web interface or manually edited and will override command line arguments. Default {default_config_file_path}",
         default=default_config_file_path,

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -73,6 +73,7 @@ def info():
         disable_score=k.disable_score,
         hide_url=k.hide_url,
         limit_user_songs_by=k.limit_user_songs_by,
+        avsync=k.avsync,
         hide_notifications=k.hide_notifications,
         hide_overlay=k.hide_overlay,
         normalize_audio=k.normalize_audio,

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -242,6 +242,13 @@
 </div>
 
 <div class="user-preference-container">
+  <input id="pref-avsync" class="user-preference-input" type="number" step="0.1" min="-10" max="10" data-pref="avsync" data-start-value="{{ avsync }}" value="{{ avsync }}" />
+  <label class="label">
+      {# MSG: Numberbox label for audio video synchronization #} {% trans %}Fix the audio and video synchronization in seconds (negative = advances audio | positive = delays audio){% endtrans %}
+  </label>
+</div>
+
+<div class="user-preference-container">
   <input id="pref-limit-user-songs-by" class="user-preference-input" type="number" min="0" max="99" data-pref="limit_user_songs_by" data-start-value="{{ limit_user_songs_by }}" value="{{ limit_user_songs_by }}" />
   <label class="label">
       {# MSG: Numberbox label for limitting the number of songs for each player #} {% trans %}Limit of songs an individual user can add to the queue (0 = unlimited){% endtrans %}
@@ -255,7 +262,7 @@
   </label>
 </div>
 
-<p class="help">{# MSG: Help text explaining when videos will be transcoded  #} {% trans %}* Videos are only transcoded when: normalization is on, a song is transposed, playing a CDG/MOV/AVI/MKV file. Most unmodified MP4 files will not need to be transcoded.{% endtrans %} </p>
+<p class="help">{# MSG: Help text explaining when videos will be transcoded  #} {% trans %}* Videos are only transcoded when: normalization is on, audio/video synchronization not zero, a song is transposed, playing a CDG/MOV/AVI/MKV file. Most unmodified MP4 files will not need to be transcoded.{% endtrans %} </p>
 
 <div style="margin-top: 20px">
   {# MSG: Text for the link where the user can clear all user preferences #}


### PR DESCRIPTION
Added the possibility for the admin to fix the A/V synchronization.

- CLI Parameter: --avsync (Use avsync (in seconds) if the audio and video streams are out of sync. (negative = advances audio | positive = delays audio))
- User preference: avsync

I haven't test it with CDG/MP3 files

Now I'll create a "how -to" on how the user can adjust the a/v sync.