### PR TITLE
feat: prefer h264 codec for youtube download

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -61,7 +61,7 @@ def build_ytdl_download_command(
         if high_quality
         else "mp4"
     )
-    cmd = [youtubedl_path, "-f", file_quality, "-o", dl_path]
+    cmd = [youtubedl_path, "-f", file_quality, "-o", dl_path, "-S", "vcodec:h264"]
     if youtubedl_proxy:
         cmd += ["--proxy", youtubedl_proxy]
     cmd += [video_url]


### PR DESCRIPTION
I was trying around with downloading karaoke-videos from youtube. 
Often these are encoded in h265 or vp9 or av1. 
The pi really struggles with formats like that, because they need additional cpu resources.

After setting a parameter for yt-dlp the the codes h264 is preferred. This helped alot when playing videos on a high-resolution tv. 