### PR TITLE
fix: Handle skip command for paused songs

### DIFF
--- a/pikaraoke/templates/splash.html
+++ b/pikaraoke/templates/splash.html
@@ -467,15 +467,21 @@
 
     socket.on('skip', (reason) => {
       const video = getVideoPlayer();
+      const currVolume = video.volume;
+
       if (isMediaPlaying(video)) {
-        const currVolume = video.volume;
+        // Fade out if currently playing
         $(video).animate({ volume: 0 }, 1000, () => {
             video.pause();
             video.volume = currVolume;
             hideVideo();
           });
-        console.log(`Skip: ${reason}`);
+      } else {
+        // Immediately hide if paused or stopped
+        video.pause();
+        hideVideo();
       }
+      console.log(`Skip: ${reason}`);
     });
 
     socket.on('volume', (val) => {


### PR DESCRIPTION
Fixes #574 (properly this time!)

When a paused song is skipped, the video container was not being hidden because the skip event handler only executed hideVideo() when the video was actively playing. This caused the next song to fail to start since the handleNowPlaying function checks if the video container is hidden.

This fix ensures hideVideo() is always called during skip, whether the video is playing or paused. When paused, it immediately hides the video. When playing, it maintains the existing fade-out animation.

Fixes the "Tried to skip, but no file is playing!" error that occurred when skipping paused songs.