### PR TITLE
chore: change to manual deployment of release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,5 @@
 on:
-  push:
-    branches:
-    - master
+  workflow_dispatch:  # Manual trigger only - go to Actions tab to run
 
 name: release-please
 


### PR DESCRIPTION
Prefer to release manually from the actions tab in order to batch release features better. Previously: would deploy on every merge to master