### PR TITLE
Change stream from vod to event

### DIFF
--- a/pikaraoke/lib/ffmpeg.py
+++ b/pikaraoke/lib/ffmpeg.py
@@ -139,7 +139,7 @@ def build_ffmpeg_cmd(
                 f="hls",
                 hls_time=3,
                 hls_list_size=0,
-                hls_playlist_type="vod",  # Tell Safari this is VOD, not live
+                hls_playlist_type="event",  # Tell Safari this an event stream
                 hls_segment_type="fmp4",
                 hls_fmp4_init_filename=fr.init_filename,
                 hls_segment_filename=fr.segment_pattern,
@@ -186,7 +186,7 @@ def build_ffmpeg_cmd(
                 f="hls",
                 hls_time=3,
                 hls_list_size=0,
-                hls_playlist_type="vod",  # Tell Safari this is VOD, not live
+                hls_playlist_type="event",  # Tell Safari this is an event stream
                 hls_segment_type="fmp4",
                 hls_fmp4_init_filename=fr.init_filename,
                 hls_segment_filename=fr.segment_pattern,


### PR DESCRIPTION
VOD is specifically for fullfiles, while EVENT is for streaming video. On completion of the stream, EVENT is effectively converted to VOD.

This fixes an issue where on non-Safari browsers the buffering would fail.