### PR TITLE
feat: add "event" as the hls_playlist_type

### DIFF
--- a/pikaraoke/lib/ffmpeg.py
+++ b/pikaraoke/lib/ffmpeg.py
@@ -145,6 +145,7 @@ def build_ffmpeg_cmd(
             f="hls",
             hls_time=3,
             hls_list_size=0,
+            hls_playlist_type="event",
             hls_segment_type="fmp4",
             hls_fmp4_init_filename=fr.init_filename,
             hls_segment_filename=fr.segment_pattern,


### PR DESCRIPTION
With hls_playlist_type="event":

- Playlist available earlier (as soon as first segment completes)
- Browser can start downloading init.mp4 + first segments immediately
- Buffering logic still works (counts filesystem segments)
- No delay waiting for complete transcode
- Must ensure hls_list_size=0 (already set) to keep all segments in playlist

Potential improvement:

- Slightly faster initial load since playlist is available sooner
- More accurate browser buffer estimation (playlist exists during buffering)