### PR TITLE
fix: splash screen menu loads page twice

### DIFF
--- a/pikaraoke/templates/splash.html
+++ b/pikaraoke/templates/splash.html
@@ -761,7 +761,7 @@
 
   <div id="menu-background" class="overlay"></div>
    <div id="menu-container" class="">
-     <iframe src="/"></iframe>
+     <iframe></iframe>
    </div>
 
 


### PR DESCRIPTION
There's a page refresh flash when opening the menu from the splash screen. Fix that.