### PR TITLE
ci: relax commitlint rules. 150 char max on titles, 1000 char max on body, warn on failures

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,6 +1,9 @@
 # Commitlint configuration
 # See: https://commitlint.js.org/reference/rules.html
 
+extends:
+  - '@commitlint/config-conventional'
+
 rules:
   # Header (first line) max length - default is 100
   header-max-length: [1, always, 150]
@@ -10,4 +13,3 @@ rules:
 
   # Footer line max length - default is 100
   footer-max-line-length: [1, always, 200]
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Required to get all commits for linting
     - name: Run commitlint
-      uses: opensource-nepal/commitlint@v1
+      uses: wagoid/commitlint-github-action@v6
 
   smoketest:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Relax the downright draconian commitlint rules. 150 char max on titles (was 72).