### PR TITLE
fix: shutdown/restart buttons don't show in settings screen for raspberry pi

### DIFF
--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -79,6 +79,7 @@ def info():
         cpu=cpu,
         memory=memory,
         disk=disk,
+        is_pi=k.is_raspberry_pi,
         is_linux=is_linux,
         volume=int(k.volume * 100),
         bg_music_volume=int(k.bg_music_volume * 100),


### PR DESCRIPTION
FIx: The shutdown/restart buttons were hidden in raspberry pi due to broken conditional.