### PR TITLE
fix: Use absolute paths for .ass, bg video and bg audio

### DIFF
--- a/pikaraoke/routes/background_music.py
+++ b/pikaraoke/routes/background_music.py
@@ -56,7 +56,7 @@ def bg_music(file):
     """
     k = get_karaoke_instance()
     mp3_path = os.path.join(k.bg_music_path, file)
-    return send_file(mp3_path, mimetype="audio/mpeg")
+    return send_file(os.path.abspath(mp3_path), mimetype="audio/mpeg")
 
 
 @background_music_bp.route("/bg_playlist", methods=["GET"])

--- a/pikaraoke/routes/stream.py
+++ b/pikaraoke/routes/stream.py
@@ -210,7 +210,7 @@ def stream_bg_video():
     k = get_karaoke_instance()
     file_path = k.bg_video_path
     if k.bg_video_path is not None:
-        return send_file(file_path, mimetype="video/mp4")
+        return send_file(os.path.abspath(file_path), mimetype="video/mp4")
     else:
         return Response("Background video not found.", status=404)
 
@@ -226,7 +226,7 @@ def stream_subtitle(id):
             ass_file_path = fr.ass_file_path
             if ass_file_path and os.path.exists(ass_file_path):
                 return send_file(
-                    ass_file_path,
+                    os.path.abspath(ass_file_path),
                     mimetype="text/plain",
                     as_attachment=False,
                     download_name=os.path.basename(ass_file_path),


### PR DESCRIPTION
Fix #648 
Fixes a bug where relative paths cause playback failure.

Affected .ass files but also bg_video and bg_audio