### PR TITLE
fix: Splash Page ?confirm=false not working 

### DIFF
--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -16,7 +16,7 @@
 
     // State management
     let isNavigating = false;
-    let currentPath = window.location.pathname;
+    let currentPath = window.location.pathname + window.location.search;
     let loadedResources = new Set(); // Track loaded external resources
     let isInitialized = false; // Prevent multiple initializations
 


### PR DESCRIPTION
Adds GET request arguments to the URL.

This fixes #653 where the splash page could not have ?confirm=false added