### PR TITLE
fix: slow info.html page load due to CPU check

### DIFF
--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -2,7 +2,7 @@
 
 import flask_babel
 import psutil
-from flask import Blueprint, render_template
+from flask import Blueprint, jsonify, render_template
 
 from pikaraoke import VERSION
 from pikaraoke.constants import LANGUAGES
@@ -36,32 +36,7 @@ def info():
     admin_password = get_admin_password()
     is_linux = get_platform() == "linux"
 
-    # 獲取當前偏好語言
     preferred_language = k.get_user_preference("preferred_language", "en")
-
-    # cpu
-    try:
-        # sample at interval of 0 seconds. Anything more blocks the server
-        # for the specified interval leading to slow loads downstream
-        cpu = str(psutil.cpu_percent(interval=0)) + "%"
-    except:
-        cpu = _("CPU usage query unsupported")
-
-    # mem
-    memory = psutil.virtual_memory()
-    available = round(memory.available / 1024.0 / 1024.0, 1)
-    total = round(memory.total / 1024.0 / 1024.0, 1)
-    memory = (
-        str(available) + "MB free / " + str(total) + "MB total ( " + str(memory.percent) + "% )"
-    )
-
-    # disk
-    disk = psutil.disk_usage("/")
-    # Divide from Bytes -> KB -> MB -> GB
-    free = round(disk.free / 1024.0 / 1024.0 / 1024.0, 1)
-    total = round(disk.total / 1024.0 / 1024.0 / 1024.0, 1)
-    disk = str(free) + "GB free / " + str(total) + "GB total ( " + str(disk.percent) + "% )"
-
     # youtube-dl
     youtubedl_version = k.youtubedl_version
 
@@ -78,9 +53,9 @@ def info():
         is_transpose_enabled=k.is_transpose_enabled,
         youtubedl_version=youtubedl_version,
         pikaraoke_version=VERSION,
-        cpu=cpu,
-        memory=memory,
-        disk=disk,
+        cpu=None,
+        memory=None,
+        disk=None,
         is_pi=k.is_raspberry_pi,
         is_linux=is_linux,
         volume=int(k.volume * 100),
@@ -109,3 +84,37 @@ def info():
             "high": k.high_score_phrases,
         },
     )
+
+
+@info_bp.route("/info/stats")
+def get_system_stats():
+    """Get system statistics (CPU, Memory, Disk).
+
+    Returns:
+        JSON response with system stats.
+    """
+    if not is_admin():
+        return jsonify({"error": "Unauthorized"}), 403
+
+    # cpu
+    try:
+        # We can afford to block a bit here since it is async
+        cpu = str(psutil.cpu_percent(interval=1)) + "%"
+    except:
+        cpu = _("CPU usage query unsupported")
+
+    # mem
+    memory = psutil.virtual_memory()
+    available = round(memory.available / 1024.0 / 1024.0, 1)
+    total = round(memory.total / 1024.0 / 1024.0, 1)
+    memory_str = (
+        str(available) + "MB free / " + str(total) + "MB total ( " + str(memory.percent) + "% )"
+    )
+
+    # disk
+    disk = psutil.disk_usage("/")
+    free = round(disk.free / 1024.0 / 1024.0 / 1024.0, 1)
+    total = round(disk.total / 1024.0 / 1024.0 / 1024.0, 1)
+    disk_str = str(free) + "GB free / " + str(total) + "GB total ( " + str(disk.percent) + "% )"
+
+    return jsonify({"cpu": cpu, "memory": memory_str, "disk": disk_str})

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -131,6 +131,19 @@
 
 				updatePhrases(phrases)
 			})
+
+			// Fetch system stats asynchronously
+			$.getJSON("{{ url_for('info.get_system_stats') }}", function(data) {
+				if (data.error) {
+					console.error("Error fetching stats:", data.error);
+					return;
+				}
+				$("#system-cpu").text(data.cpu);
+				$("#system-disk").text(data.disk);
+				$("#system-memory").text(data.memory);
+			}).fail(function() {
+				console.error("Failed to fetch system stats");
+			});
 		});
 	</script>
 {% endblock %}
@@ -197,11 +210,11 @@
 				<div class="content">
 					<ul>
 					{# MSG: The CPU usage of the computer running Pikaraoke. #}
-					<li>{% trans %}CPU: {{ cpu }}{% endtrans %}</li>
+					<li>{% trans %}CPU:{% endtrans %} <span id="system-cpu">{% trans %}Loading...{% endtrans %}</span></li>
 					{# MSG: The disk usage of the computer running Pikaraoke. Used by downloaded songs. #}
-					<li>{% trans %}Disk Usage: {{ disk }}{% endtrans %}</li>
+					<li>{% trans %}Disk Usage:{% endtrans %} <span id="system-disk">{% trans %}Loading...{% endtrans %}</span></li>
 					{# MSG: The memory (RAM) usage of the computer running Pikaraoke. #}
-					<li>{% trans %}Memory: {{ memory }}{% endtrans %}</li>
+					<li>{% trans %}Memory:{% endtrans %} <span id="system-memory">{% trans %}Loading...{% endtrans %}</span></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
I noticed the info.html page hangs for a second or so on load, unlike other routes. Turned out to be the CPU check which is a blocking action. Adjust the CPU check to occur asynchronously