### PR TITLE
fix: delete file not working since upgrade to SPA architecture

### DIFF
--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -113,6 +113,7 @@
         // Remove any existing handlers first to avoid duplicates
         $(document).off('click', '.confirm-clear');
         $(document).off('click', '.confirm-delete');
+        $(document).off('click', '.confirm-delete-file');
         $(document).off('click', '.up-button');
         $(document).off('click', '.down-button');
         $(document).off('click', '.add-random');
@@ -134,6 +135,14 @@
             e.preventDefault();
             if (window.confirm(`Are you sure you want to delete "${this.title}" from the queue?`)) {
                 $.get(this.href);
+            }
+        });
+
+        // Delete song file from library confirmation (full page navigation)
+        $(document).on('click', '.confirm-delete-file', function(e) {
+            e.preventDefault();
+            if (window.confirm('Are you sure you want to delete this song from the library?')) {
+                window.location.href = this.href;
             }
         });
 
@@ -224,7 +233,8 @@
             $link.hasClass('edit-button') ||
             $link.hasClass('add-song-link') ||  // Browse page add to queue
             $link.hasClass('confirm-clear') ||   // Clear queue button (has its own handler)
-            $link.hasClass('confirm-delete') ||  // Delete song button (has its own handler)
+            $link.hasClass('confirm-delete') ||  // Delete song from queue (has its own handler)
+            $link.hasClass('confirm-delete-file') ||  // Delete song file from library (has its own handler)
             $link.hasClass('up-button') ||       // Move song up button (has its own handler)
             $link.hasClass('down-button') ||     // Move song down button (has its own handler)
             $link.hasClass('add-random')) {      // Add random songs button (has its own handler)

--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -84,9 +84,10 @@
             e.preventDefault();
             // Get the current name from the cookie dynamically
             let currentName = Cookies.get("user");
-            let name = window.prompt(
-                "Do you want to change the name of the person using this device? This will show up on queued songs. Current: " + currentName
-            );
+            var promptMsg = (window.i18n && window.i18n.promptChangeUsername)
+                ? window.i18n.promptChangeUsername.replace('%s', currentName)
+                : "Do you want to change the name of the person using this device? This will show up on queued songs. Current: " + currentName;
+            let name = window.prompt(promptMsg);
             // Only update if user clicked OK and entered a non-empty name
             // null = Cancel clicked, "" = OK with empty input
             if (name !== null && name.trim() !== "") {
@@ -121,9 +122,10 @@
         // Clear queue confirmation
         $(document).on('click', '.confirm-clear', function(e) {
             e.preventDefault();
-            let userInput = window.prompt(
-                "Are you sure you want to clear the ENTIRE queue? Type 'ok' to continue"
-            );
+            var promptMsg = (window.i18n && window.i18n.promptClearQueue)
+                ? window.i18n.promptClearQueue
+                : "Are you sure you want to clear the ENTIRE queue? Type 'ok' to continue";
+            let userInput = window.prompt(promptMsg);
             // Only clear if user typed 'ok' exactly (case insensitive)
             if (userInput !== null && userInput.toLowerCase() === "ok") {
                 $.get(this.href);
@@ -133,7 +135,10 @@
         // Delete song from queue confirmation
         $(document).on('click', '.confirm-delete', function(e) {
             e.preventDefault();
-            if (window.confirm(`Are you sure you want to delete "${this.title}" from the queue?`)) {
+            var msg = (window.i18n && window.i18n.confirmDeleteFromQueue)
+                ? window.i18n.confirmDeleteFromQueue.replace('%s', this.title)
+                : `Are you sure you want to delete "${this.title}" from the queue?`;
+            if (window.confirm(msg)) {
                 $.get(this.href);
             }
         });
@@ -141,7 +146,10 @@
         // Delete song file from library confirmation (full page navigation)
         $(document).on('click', '.confirm-delete-file', function(e) {
             e.preventDefault();
-            if (window.confirm('Are you sure you want to delete this song from the library?')) {
+            var msg = (window.i18n && window.i18n.confirmDeleteFromLibrary)
+                ? window.i18n.confirmDeleteFromLibrary
+                : 'Are you sure you want to delete this song from the library?';
+            if (window.confirm(msg)) {
                 window.location.href = this.href;
             }
         });

--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -85,7 +85,7 @@
             // Get the current name from the cookie dynamically
             let currentName = Cookies.get("user");
             var promptMsg = (window.i18n && window.i18n.promptChangeUsername)
-                ? window.i18n.promptChangeUsername.replace('%s', currentName)
+                ? window.i18n.promptChangeUsername.replace('CURRENT_NAME', currentName)
                 : "Do you want to change the name of the person using this device? This will show up on queued songs. Current: " + currentName;
             let name = window.prompt(promptMsg);
             // Only update if user clicked OK and entered a non-empty name
@@ -136,7 +136,7 @@
         $(document).on('click', '.confirm-delete', function(e) {
             e.preventDefault();
             var msg = (window.i18n && window.i18n.confirmDeleteFromQueue)
-                ? window.i18n.confirmDeleteFromQueue.replace('%s', this.title)
+                ? window.i18n.confirmDeleteFromQueue.replace('SONG_TITLE', this.title)
                 : `Are you sure you want to delete "${this.title}" from the queue?`;
             if (window.confirm(msg)) {
                 $.get(this.href);

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -23,13 +23,13 @@
     // Translations for spa-navigation.js (static JS cannot use Jinja2 directly)
     window.i18n = {
       // {# MSG: Prompt to change the username displayed next to queued songs. %s is the current name #}
-      promptChangeUsername: "{{ _('Do you want to change the name of the person using this device? This will show up on queued songs. Current: %s') }}",
+      promptChangeUsername: '{{ _("Do you want to change the name of the person using this device? This will show up on queued songs. Current: %s") }}',
       // {# MSG: Confirmation prompt to clear entire queue. User must type ok to confirm #}
-      promptClearQueue: "{{ _('Are you sure you want to clear the ENTIRE queue? Type \\'ok\\' to continue') }}",
+      promptClearQueue: "{{ _('Are you sure you want to clear the ENTIRE queue? Type ok to continue') }}",
       // {# MSG: Confirmation dialog when removing a song from the queue. %s is the song title #}
-      confirmDeleteFromQueue: "{{ _('Are you sure you want to delete \"%s\" from the queue?') }}",
+      confirmDeleteFromQueue: "{{ _('Are you sure you want to delete %s from the queue?') }}",
       // {# MSG: Confirmation dialog when permanently deleting a song file from the library #}
-      confirmDeleteFromLibrary: "{{ _('Are you sure you want to delete this song from the library?') }}"
+      confirmDeleteFromLibrary: '{{ _("Are you sure you want to delete this song from the library?") }}'
     };
 
     function generateRandomString(length) {

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -20,6 +20,17 @@
   <link rel="stylesheet" href="/static/fontello/css/fontello.css?cachebust=1">
 
   <script>
+    // Translations for spa-navigation.js (static JS cannot use Jinja2 directly)
+    window.i18n = {
+      // {# MSG: Prompt to change the username displayed next to queued songs. %s is the current name #}
+      promptChangeUsername: "{{ _('Do you want to change the name of the person using this device? This will show up on queued songs. Current: %s') }}",
+      // {# MSG: Confirmation prompt to clear entire queue. User must type ok to confirm #}
+      promptClearQueue: "{{ _('Are you sure you want to clear the ENTIRE queue? Type \\'ok\\' to continue') }}",
+      // {# MSG: Confirmation dialog when removing a song from the queue. %s is the song title #}
+      confirmDeleteFromQueue: "{{ _('Are you sure you want to delete \"%s\" from the queue?') }}",
+      // {# MSG: Confirmation dialog when permanently deleting a song file from the library #}
+      confirmDeleteFromLibrary: "{{ _('Are you sure you want to delete this song from the library?') }}"
+    };
 
     function generateRandomString(length) {
       const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -22,12 +22,12 @@
   <script>
     // Translations for spa-navigation.js (static JS cannot use Jinja2 directly)
     window.i18n = {
-      // {# MSG: Prompt to change the username displayed next to queued songs. %s is the current name #}
-      promptChangeUsername: '{{ _("Do you want to change the name of the person using this device? This will show up on queued songs. Current: %s") }}',
+      // {# MSG: Prompt to change the username displayed next to queued songs. CURRENT_NAME is replaced with the name #}
+      promptChangeUsername: "{{ _('Do you want to change the name of the person using this device? This will show up on queued songs. Current: CURRENT_NAME') }}",
       // {# MSG: Confirmation prompt to clear entire queue. User must type ok to confirm #}
       promptClearQueue: "{{ _('Are you sure you want to clear the ENTIRE queue? Type ok to continue') }}",
-      // {# MSG: Confirmation dialog when removing a song from the queue. %s is the song title #}
-      confirmDeleteFromQueue: "{{ _('Are you sure you want to delete %s from the queue?') }}",
+      // {# MSG: Confirmation dialog when removing a song from the queue. SONG_TITLE is replaced with the title #}
+      confirmDeleteFromQueue: "{{ _('Are you sure you want to delete SONG_TITLE from the queue?') }}",
       // {# MSG: Confirmation dialog when permanently deleting a song file from the library #}
       confirmDeleteFromLibrary: '{{ _("Are you sure you want to delete this song from the library?") }}'
     };

--- a/pikaraoke/templates/edit.html
+++ b/pikaraoke/templates/edit.html
@@ -23,13 +23,6 @@
       new_name = new_name.trim();
       $('#new_file_name').val(new_name);
     });
-    $('.confirm-delete').click(function (e) {
-      e.preventDefault();
-      // {# MSG: Confirmation prompt when the user deletes a song. #}
-      if (window.confirm("{{ _('Are you sure you want to delete this song from the library?') }}")) {
-        location.href = this.href;
-      }
-    });
 
     $("#suggest_results").on("click", ".suggested_item", function () {
       $('#new_file_name').val($(this).text());
@@ -141,7 +134,7 @@
 </div>
 
 <hr>
-<a class="edit-button confirm-delete has-text-danger is-pulled-right"
+<a class="confirm-delete-file has-text-danger is-pulled-right"
   href="{{url_for('files.delete_file')}}?song={{url_escape(song)}}"><i class="icon icon-trash-empty"></i>
   {# MSG: Label on button which deletes the current song. #}
   {%- trans -%}


### PR DESCRIPTION
The delete file pop-up was broken since the update to the single page architecture.

Now fixed #181 