### PR TITLE
fix: Docker entrypoint args not separated properly

### DIFF
--- a/build_scripts/docker/Dockerfile
+++ b/build_scripts/docker/Dockerfile
@@ -30,4 +30,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
 
 USER pikaraoke
 
-ENTRYPOINT ["pikaraoke", "-d", "/app/pikaraoke-songs/", "--headless", "--config-file-path /app/config/config.ini"]
+ENTRYPOINT ["pikaraoke", "-d", "/app/pikaraoke-songs/", "--headless", "--config-file-path", "/app/config/config.ini"]


### PR DESCRIPTION
Bug fix in Dockerfile in the way the arguments were separated.