### PR TITLE
fix: prevent autoplay race condition and improve autoplay detection

### DIFF
--- a/pikaraoke/templates/splash.html
+++ b/pikaraoke/templates/splash.html
@@ -51,6 +51,7 @@
   var octopusInstance = null;
   var showMenu = false;
   var menuButtonVisible = false;
+  var autoplayConfirmed = false;
   var volume = 0.85;
   var playbackStartTimeout = 10000;
   var isScoreShown = false;
@@ -93,6 +94,7 @@
 
   async function handleConfirmation() {
     $('#permissions-modal').removeClass('is-active');
+    autoplayConfirmed = true;
     if (hasBgVideo) playBGVideo(true);
     playBGMusic(true);
   }
@@ -141,6 +143,7 @@
   async function playBGMusic(play) {
 	  let bgMusicVolume = "{{ bg_music_volume }}" *1
 	  if ('{{ disable_bg_music }}' == 'False') {
+      if (!autoplayConfirmed) return;
       let audio = getBackgroundMusicPlayer();
       if (bg_playlist.length == 0) return;
       if (!audio.getAttribute('src')) audio.setAttribute('src', getNextBgMusicSong());
@@ -159,6 +162,7 @@
 
   async function playBGVideo(play) {
     if ('{{ disable_bg_video }}' == 'False') {
+      if (!autoplayConfirmed) return;
       let bgVideo = getBackgroundVideoPlayer();
       const bgVideoContainer = $('#bg-video-container');
       if (play == true) {
@@ -431,8 +435,7 @@
       try {
         const testVideo = document.createElement('video');
         testVideo.playsInline = true;
-        testVideo.muted = false;
-        testVideo.volume = 0.01;
+        testVideo.muted = true;  // Start muted (always allowed)
         testVideo.src = "{{ url_for('static', filename='test-autoplay.mp4') }}";
 
         // Wait for video to be ready
@@ -442,7 +445,14 @@
         });
 
         await testVideo.play();
-        // Check if browser auto-muted the video (Safari does this)
+        // Now try to unmute - this is the real test
+        testVideo.muted = false;
+        testVideo.volume = 0.01;
+
+        // Brief delay to let browser enforce policy
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // Check if browser re-muted the video
         if (testVideo.muted) {
           testVideo.pause();
           enablePermissionsModal();


### PR DESCRIPTION
### Problem
After #670, the permissions modal would intermittently appear due to a race condition: `handleNowPlaying()` calls `playBGMusic()` before `testAutoplay()` completes, exhausting the browser's autoplay budget and causing the subsequent autoplay test to fail.

### Solution
1. **Race condition fix**: Added `autoplayConfirmed` flag - `playBGMusic()` and `playBGVideo()` return early until `handleConfirmation()` runs
2. **Improved autoplay test**: Start muted (always allowed), play, then unmute to check if browser permits audio - avoids the `NotAllowedError` that was corrupting browser state
