### PR TITLE
fix: splash up next does not update on new queue reorder actions

### DIFF
--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -153,6 +153,7 @@ def reorder():
             item = k.queue.pop(old_index)
             k.queue.insert(new_index, item)
             broadcast_event("queue_update")
+            k.update_now_playing_socket()
             return json.dumps({"success": True})
     except (ValueError, IndexError):
         pass
@@ -264,6 +265,8 @@ def queue_edit():
 
     if success:
         broadcast_event("queue_update")
+        # Ensure splash screen "up next" is updated
+        k.update_now_playing_socket()
 
     if is_ajax:
         return json.dumps({"success": success, "message": message})

--- a/tests/unit/test_queue_reorder.py
+++ b/tests/unit/test_queue_reorder.py
@@ -1,0 +1,80 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import werkzeug
+from flask import Flask
+
+# Monkeypatch werkzeug.__version__ for Flask compatibility if missing
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3.0.0"
+
+from pikaraoke.routes.queue import queue_bp
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.secret_key = "test"
+    app.register_blueprint(queue_bp)
+    # Mock Babel to avoid KeyError: 'babel'
+    app.extensions["babel"] = MagicMock()
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestQueueReorderSocketUpdates:
+    @patch("pikaraoke.routes.queue.is_admin", return_value=True)
+    @patch("pikaraoke.routes.queue.get_karaoke_instance")
+    @patch("pikaraoke.routes.queue.broadcast_event")
+    @patch("pikaraoke.routes.queue._", side_effect=lambda x: x)
+    def test_reorder_updates_now_playing_socket(
+        self, mock_gettext, mock_broadcast, mock_get_instance, mock_is_admin, client
+    ):
+        mock_karaoke = MagicMock()
+        mock_karaoke.queue = [{"file": "song1"}, {"file": "song2"}]
+        mock_get_instance.return_value = mock_karaoke
+
+        response = client.post("/queue/reorder", data={"old_index": 0, "new_index": 1})
+
+        assert response.status_code == 200
+        assert json.loads(response.data)["success"] is True
+        mock_karaoke.update_now_playing_socket.assert_called_once()
+
+    @patch("pikaraoke.routes.queue.is_admin", return_value=True)
+    @patch("pikaraoke.routes.queue.get_karaoke_instance")
+    @patch("pikaraoke.routes.queue.broadcast_event")
+    @patch("pikaraoke.routes.queue._", side_effect=lambda x: x)
+    def test_queue_edit_top_updates_now_playing_socket(
+        self, mock_gettext, mock_broadcast, mock_get_instance, mock_is_admin, client
+    ):
+        mock_karaoke = MagicMock()
+        mock_karaoke.queue = [{"file": "song1"}, {"file": "song2"}]
+        mock_karaoke.filename_from_path.return_value = "song2"
+        mock_get_instance.return_value = mock_karaoke
+
+        response = client.get("/queue/edit?action=top&song=song2")
+
+        assert response.status_code == 302  # Redirect
+        mock_karaoke.update_now_playing_socket.assert_called_once()
+
+    @patch("pikaraoke.routes.queue.is_admin", return_value=True)
+    @patch("pikaraoke.routes.queue.get_karaoke_instance")
+    @patch("pikaraoke.routes.queue.broadcast_event")
+    @patch("pikaraoke.routes.queue._", side_effect=lambda x: x)
+    def test_queue_edit_bottom_updates_now_playing_socket(
+        self, mock_gettext, mock_broadcast, mock_get_instance, mock_is_admin, client
+    ):
+        mock_karaoke = MagicMock()
+        mock_karaoke.queue = [{"file": "song1"}, {"file": "song2"}]
+        mock_karaoke.filename_from_path.return_value = "song1"
+        mock_get_instance.return_value = mock_karaoke
+
+        response = client.get("/queue/edit?action=bottom&song=song1")
+
+        assert response.status_code == 302  # Redirect
+        mock_karaoke.update_now_playing_socket.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "pikaraoke"
-version = "1.17.0"
+version = "1.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
Fix: When using drag to reorder on the queue (or move to top), the "Up next" song does not update on the splash screen