### PR TITLE
feat: update docker files to reflect app data directory

### DIFF
--- a/build_scripts/docker/Dockerfile
+++ b/build_scripts/docker/Dockerfile
@@ -30,4 +30,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
 
 USER pikaraoke
 
-ENTRYPOINT ["pikaraoke", "-d", "/app/pikaraoke-songs/", "--headless", "--config-file-path", "/app/config/config.ini"]
+ENTRYPOINT ["pikaraoke", "-d", "/app/pikaraoke-songs/", "--headless"]

--- a/build_scripts/docker/docker-compose.yml.example
+++ b/build_scripts/docker/docker-compose.yml.example
@@ -20,14 +20,13 @@ services:
     # --config-file-path: Ensures settings are saved to the mounted volume
     command: >
       -u http://<YOUR_LAN_IP>:5555
-      --config-file-path /app/config/config.ini
 
     # --- VOLUMES ---
     # relative paths (./) are used here for simplicity.
     # You can change these to absolute paths (e.g., C:/Music or /home/pi/Music)
     volumes:
-      - ./songs:/app/pikaraoke-songs  # Place your song files in a 'songs' folder next to this file
-      - ./config:/app/config          # Config settings will be saved here
+      - ./songs:/app/pikaraoke-songs      # Place your song files in a 'songs' folder next to this file
+      - ./data:/home/pikaraoke/.pikaraoke # Data, including your config, will be saved here
 
     # --- PORTS ---
     # Map host port 5555 to container port 5555


### PR DESCRIPTION
Now that more information can be stored in the app data folder, E.g. `/home/pikaraoke/.pikaraoke`, this updates the Docker files to ensure that the entire directory can be mapped externally, rather than just the `config.ini` file.