### PR TITLE
feat: centralise background media handling

### DIFF
--- a/tests/unit/test_karaoke_delegation.py
+++ b/tests/unit/test_karaoke_delegation.py
@@ -1,0 +1,165 @@
+"""Backwards compatibility tests for Karaoke class queue interface.
+
+These tests verify that the Karaoke class maintains its public API contract
+for queue operations, serving as regression prevention for any internal refactoring.
+"""
+
+import pytest
+
+
+class TestKaraokeQueueInterface:
+    """Verify Karaoke class exposes queue methods with correct signatures."""
+
+    def test_queue_attribute_is_list(self, mock_karaoke):
+        """Karaoke.queue should be accessible as a list."""
+        assert isinstance(mock_karaoke.queue, list)
+
+    def test_enqueue_accepts_all_parameters(self, mock_karaoke):
+        """enqueue() should accept file, user, semitones, and add_to_front."""
+        result = mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+        assert result is not False
+
+        result = mock_karaoke.enqueue("/songs/test2---def.mp4", "User2", semitones=3)
+        assert result is not False
+
+        result = mock_karaoke.enqueue("/songs/test3---ghi.mp4", "User3", add_to_front=True)
+        assert result is not False
+
+    def test_queue_edit_accepts_song_and_action(self, mock_karaoke):
+        """queue_edit() should accept song filename and action."""
+        mock_karaoke.enqueue("/songs/song1---abc.mp4", "User1")
+
+        result = mock_karaoke.queue_edit("song1---abc.mp4", "delete")
+        assert isinstance(result, bool)
+
+    def test_queue_clear_empties_queue(self, mock_karaoke):
+        """queue_clear() should remove all songs."""
+        mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+
+        mock_karaoke.queue_clear()
+        assert len(mock_karaoke.queue) == 0
+
+    def test_queue_add_random_accepts_amount(self, mock_karaoke):
+        """queue_add_random() should accept amount and return bool."""
+        result = mock_karaoke.queue_add_random(1)
+        assert isinstance(result, bool)
+
+    def test_is_song_in_queue_returns_bool(self, mock_karaoke):
+        """is_song_in_queue() should return bool for given path."""
+        mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+
+        result = mock_karaoke.is_song_in_queue("/songs/test---abc.mp4")
+        assert result is True
+
+    def test_is_user_limited_returns_bool(self, mock_karaoke):
+        """is_user_limited() should return bool for given username."""
+        result = mock_karaoke.is_user_limited("TestUser")
+        assert isinstance(result, bool)
+
+    def test_update_queue_socket_is_callable(self, mock_karaoke):
+        """update_queue_socket() should be callable without error."""
+        mock_karaoke.update_queue_socket()
+
+
+class TestKaraokeQueueBehavior:
+    """Verify queue behavior remains consistent after refactoring."""
+
+    def test_queue_modifications_persist(self, mock_karaoke):
+        """Queue changes through Karaoke methods should persist."""
+        mock_karaoke.enqueue("/songs/song1---abc.mp4", "User1")
+        mock_karaoke.enqueue("/songs/song2---def.mp4", "User2")
+
+        assert len(mock_karaoke.queue) == 2
+        assert mock_karaoke.queue[0]["file"] == "/songs/song1---abc.mp4"
+
+        mock_karaoke.queue_edit("song1---abc.mp4", "delete")
+
+        assert len(mock_karaoke.queue) == 1
+        assert mock_karaoke.queue[0]["file"] == "/songs/song2---def.mp4"
+
+    def test_enqueue_returns_list_on_success(self, mock_karaoke):
+        """Successful enqueue returns [True, message]."""
+        result = mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] is True
+        assert isinstance(result[1], str)
+
+    def test_enqueue_returns_false_for_duplicate(self, mock_karaoke):
+        """Duplicate song enqueue returns False."""
+        mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+
+        result = mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+        assert result is False
+
+    def test_enqueue_returns_list_when_user_limited(self, mock_karaoke):
+        """User limit rejection returns [False, message]."""
+        mock_karaoke.limit_user_songs_by = 1
+        mock_karaoke.enqueue("/songs/test1---abc.mp4", "User1")
+
+        result = mock_karaoke.enqueue("/songs/test2---def.mp4", "User1")
+        assert isinstance(result, list)
+        assert result[0] is False
+        assert isinstance(result[1], str)
+
+
+class TestKaraokeQueueStateManagement:
+    """Verify queue state attributes are properly accessible."""
+
+    def test_enable_fair_queue_is_mutable(self, mock_karaoke):
+        """enable_fair_queue attribute should be readable and writable."""
+        original = mock_karaoke.enable_fair_queue
+        mock_karaoke.enable_fair_queue = not original
+        assert mock_karaoke.enable_fair_queue == (not original)
+
+    def test_limit_user_songs_by_is_mutable(self, mock_karaoke):
+        """limit_user_songs_by attribute should be readable and writable."""
+        mock_karaoke.limit_user_songs_by = 5
+        assert mock_karaoke.limit_user_songs_by == 5
+
+    def test_socketio_can_be_assigned(self, mock_karaoke):
+        """socketio attribute should accept assignment."""
+        from unittest.mock import MagicMock
+
+        mock_karaoke.socketio = MagicMock()
+        assert mock_karaoke.socketio is not None
+
+
+class TestKaraokeQueueIntegration:
+    """Integration tests for complex queue operations."""
+
+    def test_fair_queue_interleaves_users(self, mock_karaoke):
+        """Fair queue should interleave songs from different users."""
+        mock_karaoke.enable_fair_queue = True
+
+        mock_karaoke.enqueue("/songs/a1---aaa.mp4", "UserA")
+        mock_karaoke.enqueue("/songs/a2---bbb.mp4", "UserA")
+        mock_karaoke.enqueue("/songs/b1---ccc.mp4", "UserB")
+
+        users = [item["user"] for item in mock_karaoke.queue]
+        assert users == ["UserA", "UserB", "UserA"]
+
+    def test_user_limit_blocks_excess_songs(self, mock_karaoke):
+        """User limit should reject songs beyond the limit."""
+        mock_karaoke.limit_user_songs_by = 2
+
+        mock_karaoke.enqueue("/songs/song1---abc.mp4", "LimitedUser")
+        mock_karaoke.enqueue("/songs/song2---def.mp4", "LimitedUser")
+        result = mock_karaoke.enqueue("/songs/song3---ghi.mp4", "LimitedUser")
+
+        assert result[0] is False
+        assert len(mock_karaoke.queue) == 2
+
+    def test_queue_operations_trigger_socket_updates(self, mock_karaoke):
+        """Queue operations with SocketIO should trigger emit calls."""
+        from unittest.mock import MagicMock
+
+        mock_karaoke.socketio = MagicMock()
+
+        mock_karaoke.enqueue("/songs/test---abc.mp4", "User1")
+        assert mock_karaoke.socketio.emit.called
+
+        mock_karaoke.socketio.emit.reset_mock()
+        mock_karaoke.queue_clear()
+        assert mock_karaoke.socketio.emit.called

--- a/tests/unit/test_queue_socketio.py
+++ b/tests/unit/test_queue_socketio.py
@@ -1,0 +1,168 @@
+"""Tests for queue-related SocketIO event payloads.
+
+These tests verify the exact data emitted to SocketIO when queue operations occur,
+documenting the contract between backend and frontend for real-time updates.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def karaoke_with_socketio(mock_karaoke):
+    """Create a MockKaraoke instance with mocked SocketIO."""
+    mock_karaoke.socketio = MagicMock()
+    return mock_karaoke
+
+
+class TestQueueSocketEmissions:
+    """Verify queue operations emit correct SocketIO events."""
+
+    def test_update_queue_socket_emits_event(self, karaoke_with_socketio):
+        """update_queue_socket emits 'queue_update' with no payload."""
+        k = karaoke_with_socketio
+        k.enqueue("/songs/song1---abc.mp4", "User1")
+        k.socketio.emit.reset_mock()
+
+        k.update_queue_socket()
+
+        k.socketio.emit.assert_called_once_with("queue_update", namespace="/")
+
+    def test_update_queue_socket_works_with_empty_queue(self, karaoke_with_socketio):
+        """update_queue_socket emits regardless of queue state."""
+        k = karaoke_with_socketio
+
+        k.update_queue_socket()
+
+        k.socketio.emit.assert_called_once_with("queue_update", namespace="/")
+
+    def test_update_now_playing_socket_emits_state(self, karaoke_with_socketio):
+        """update_now_playing_socket emits current playback state."""
+        k = karaoke_with_socketio
+        k.now_playing = "/songs/current---xyz.mp4"
+        k.now_playing_user = "CurrentUser"
+        k.now_playing_transpose = 2
+        k.now_playing_duration = 180
+        k.now_playing_position = 45
+        k.is_paused = False
+
+        k.update_now_playing_socket()
+
+        k.socketio.emit.assert_called_once()
+        event_name, payload = k.socketio.emit.call_args[0]
+        namespace = k.socketio.emit.call_args[1]["namespace"]
+
+        assert event_name == "now_playing"
+        assert namespace == "/"
+        assert payload["now_playing"] == "/songs/current---xyz.mp4"
+        assert payload["now_playing_user"] == "CurrentUser"
+        assert payload["now_playing_transpose"] == 2
+        assert payload["now_playing_duration"] == 180
+        assert payload["now_playing_position"] == 45
+        assert payload["is_paused"] is False
+        assert payload["volume"] == 0.85
+
+    def test_update_now_playing_socket_includes_up_next(self, karaoke_with_socketio):
+        """update_now_playing_socket includes first queued song as up_next."""
+        k = karaoke_with_socketio
+        k.now_playing = "/songs/current---xyz.mp4"
+        k.enqueue("/songs/Next Song---aaa.mp4", "User1")
+        k.enqueue("/songs/Another Song---bbb.mp4", "User2")
+        k.socketio.emit.reset_mock()
+
+        k.update_now_playing_socket()
+
+        payload = k.socketio.emit.call_args[0][1]
+        assert payload["up_next"] == "Next Song"
+        assert payload["next_user"] == "User1"
+
+    def test_enqueue_triggers_queue_socket_update(self, karaoke_with_socketio):
+        """enqueue triggers queue_update event."""
+        k = karaoke_with_socketio
+
+        k.enqueue("/songs/song1---abc.mp4", "User1")
+
+        queue_update_calls = [
+            call for call in k.socketio.emit.call_args_list if call[0][0] == "queue_update"
+        ]
+        assert len(queue_update_calls) > 0
+
+    def test_queue_edit_delete_triggers_socket_updates(self, karaoke_with_socketio):
+        """queue_edit (delete) triggers both queue_update and now_playing events."""
+        k = karaoke_with_socketio
+        k.enqueue("/songs/song1---abc.mp4", "User1")
+        k.enqueue("/songs/song2---def.mp4", "User2")
+        k.socketio.emit.reset_mock()
+
+        k.queue_edit("song1---abc.mp4", "delete")
+
+        event_names = [call[0][0] for call in k.socketio.emit.call_args_list]
+        assert "queue_update" in event_names
+        assert "now_playing" in event_names
+
+    def test_queue_clear_triggers_socket_updates(self, karaoke_with_socketio):
+        """queue_clear triggers both queue_update and now_playing events."""
+        k = karaoke_with_socketio
+        k.enqueue("/songs/song1---abc.mp4", "User1")
+        k.socketio.emit.reset_mock()
+
+        k.queue_clear()
+
+        event_names = [call[0][0] for call in k.socketio.emit.call_args_list]
+        assert "queue_update" in event_names
+        assert "now_playing" in event_names
+        assert len(k.queue) == 0
+
+
+class TestSocketIOEventFormats:
+    """Verify SocketIO event payload structure matches frontend expectations."""
+
+    def test_queue_item_has_required_fields(self, karaoke_with_socketio):
+        """Queue items contain fields required by frontend."""
+        k = karaoke_with_socketio
+        k.enqueue("/songs/Artist - Song---abc123.mp4", "TestUser", semitones=2)
+
+        queue_item = k.queue[0]
+
+        assert queue_item["file"] == "/songs/Artist - Song---abc123.mp4"
+        assert queue_item["user"] == "TestUser"
+        assert queue_item["title"] == "Artist - Song"
+        assert queue_item["semitones"] == 2
+
+    def test_now_playing_payload_has_required_fields(self, karaoke_with_socketio):
+        """now_playing event payload contains all fields required by frontend."""
+        k = karaoke_with_socketio
+        k.now_playing = "/songs/Artist - Song---abc123.mp4"
+        k.now_playing_user = "TestUser"
+        k.now_playing_transpose = 0
+        k.now_playing_duration = 240
+        k.now_playing_position = 30
+        k.now_playing_url = "https://youtube.com/watch?v=abc123"
+        k.now_playing_subtitle_url = None
+        k.is_paused = False
+        k.enqueue("/songs/Next Song---def456.mp4", "NextUser")
+        k.socketio.emit.reset_mock()
+
+        k.update_now_playing_socket()
+
+        payload = k.socketio.emit.call_args[0][1]
+
+        required_fields = [
+            "now_playing",
+            "now_playing_user",
+            "now_playing_transpose",
+            "now_playing_duration",
+            "now_playing_position",
+            "now_playing_url",
+            "now_playing_subtitle_url",
+            "is_paused",
+            "volume",
+            "up_next",
+            "next_user",
+        ]
+        for field in required_fields:
+            assert field in payload, f"Missing required field: {field}"
+
+        assert payload["up_next"] == "Next Song"
+        assert payload["next_user"] == "NextUser"


### PR DESCRIPTION
I have found the fragmented handling of background music and video a bit difficult to work with.

I hope you find this useful.

**Change:** Consolidates background music/video playback logic into dedicated functions.

**Benefit:** Single source of truth for when background media should play, pause, or resume - making behavior more predictable and easier to maintain.