### PR TITLE
feat: splash screen url scaling

### DIFF
--- a/pikaraoke/static/js/splash.js
+++ b/pikaraoke/static/js/splash.js
@@ -18,6 +18,7 @@ var screensaverTimeoutSeconds = PikaraokeConfig.screensaverTimeout;
 var bg_playlist = []
 const scoreReviews = PikaraokeConfig.scorePhrases;
 var isMaster = false;
+var uiScale = null;
 
 // Browser detection
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
@@ -543,10 +544,37 @@ const handleSocketRecovery = () => {
   });
 }
 
+const setupUIScaling = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const rawScale = urlParams.get('scale');
+  if (!rawScale) return;
+  uiScale = Math.max(0.3, Math.min(1, parseFloat(rawScale) || 1));
+
+  const scaleTargets = [
+    { selector: '#logo-container img.logo', origin: null },
+    { selector: '#top-container', origin: 'top right' },
+    { selector: '#ap-container', origin: 'top left' },
+    { selector: '#qr-code', origin: 'bottom left' },
+    { selector: '#up-next', origin: 'bottom right' },
+    { selector: '#dvd', origin: null },
+    { selector: '#score', origin: null },
+    { selector: '#splash-notification', origin: 'top left' },
+  ];
+
+  scaleTargets.forEach(({ selector, origin }) => {
+    const el = document.querySelector(selector);
+    if (el) {
+      el.style.transform = `scale(${uiScale})`;
+      if (origin) el.style.transformOrigin = origin;
+    }
+  });
+}
+
 // Document ready procedures
 
 $(function () {
   // Setup various features and listeners
+  setupUIScaling();
   setupScreensaver();
   setupOverlayMenus();
   setupVideoPlayer();


### PR DESCRIPTION
## Summary
- Add `?scale=` URL parameter to `/splash` for scaling down UI elements
- Resolves #699 

## Usage

- Use `/splash` as normal (no parameter needed)
- Or, bookmark `/splash?scale=0.6` (adjust value between 0.3 and 1.0 as needed)

Scales overlay elements (logo, now playing, up next, QR code, etc.) while keeping video playback, background video, and menu at full size.

## Test plan
- [ ] Open `/splash` with no parameter - verify no visual change
- [ ] Open `/splash?scale=0.7` - verify UI elements are scaled down
- [ ] Open `/splash?scale=0.5` - verify smaller scaling
- [ ] Verify video playback is unaffected at any scale
- [ ] Verify screensaver DVD logo scales correctly
- [ ] Verify menu button and menu iframe remain full size
