### PR TITLE
fix: some browsers flash an ugly grey screen before video starts

### DIFF
--- a/pikaraoke/templates/splash.html
+++ b/pikaraoke/templates/splash.html
@@ -126,13 +126,13 @@
 </div>
 
 <div id="video-container" class="video-container">
-  <video id="video" disableRemotePlayback playsinline webkit-playsinline style="width: 100%; height: 100%; object-fit: contain;">
+  <video id="video" poster="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" disableRemotePlayback playsinline webkit-playsinline style="width: 100%; height: 100%; object-fit: contain;">
     <source id="video-source" src="" />
   </video>
 </div>
 
 <div id="bg-video-container" class="video-container">
-  <video id="bg-video" disableRemotePlayback playsinline webkit-playsinline muted loop style="object-fit: cover">
+  <video id="bg-video" poster="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=" disableRemotePlayback playsinline webkit-playsinline muted loop style="object-fit: cover">
     <source id="bg-video-source" type="video/mp4" src="" />
   </video>
 </div>


### PR DESCRIPTION
fixes an issue where some devices like chromecast show an ugly grey preview screen before the video launches.