### PR TITLE
fix: correctly allow or block editing of files

### DIFF
--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -126,8 +126,7 @@ def delete_file():
     k = get_karaoke_instance()
     if "song" in request.args:
         song_path = request.args["song"]
-        exists = any(item.get("file") == song_path for item in k.queue_manager.queue)
-        if exists:
+        if k.queue_manager.is_song_in_queue(song_path):
             flash(
                 # MSG: Message shown after trying to delete a song that is in the queue.
                 _("Error: Can't delete this song because it is in the current queue")
@@ -153,8 +152,7 @@ def edit_file():
     queue_error_msg = _("Error: Can't edit this song because it is in the current queue: ")
     if "song" in request.args:
         song_path = request.args["song"]
-        # print "SONG_PATH" + song_path
-        if song_path in k.queue_manager.queue:
+        if k.queue_manager.is_song_in_queue(song_path):
             flash(queue_error_msg + song_path, "is-danger")
             return redirect(url_for("files.browse"))
         else:

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "pikaraoke"
-version = "1.18.1"
+version = "1.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
Correctly resolves #736 

### Problem
Line 157 in `edit_file()` used `if song_path in k.queue_manager.queue:` which always returned `False` because the queue is a list of dicts, not strings. This allowed users to edit/rename songs that were actively queued, potentially causing playback issues.

### Solution
- Fixed line 156 to use `k.queue_manager.is_song_in_queue(song_path)`
- Updated line 129 in `delete_file()` to use the same method for consistency

### Manual Test Checklist

**Setup:** Start PiKaraoke and add 2-3 songs to the queue

- [x] Click edit icon on a queued song → Error: "Can't edit this song because it is in the current queue"
- [x] Click edit icon on a non-queued song → Edit page loads successfully
- [x] On edit page, rename a non-queued song → Success: "Renamed file: X to Y"
- [x] Add a song to queue, get its edit URL, add it to queue in another tab, then visit the edit URL → Error message shown, redirects to browse page
