### PR TITLE
fix: Menu icon doesn't auto-hide on some browsers

### DIFF
--- a/pikaraoke/static/js/splash.js
+++ b/pikaraoke/static/js/splash.js
@@ -379,6 +379,7 @@ const setupOverlayMenus = () => {
     $('#bottom-container').hide();
     $('#top-container').hide();
   }
+  $("#menu a").fadeOut(); // start hidden
   document.onmousemove = function () {
     if (mouseTimer) window.clearTimeout(mouseTimer);
     if (!cursorVisible) {


### PR DESCRIPTION
Fix for Menu icon doesn't auto-hide on some browsers #743 . Just auto hide the menu on first load after initially showing it.