### PR TITLE
feat: add play history database and History UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,11 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    name: Unit Tests
+    name: Unit Tests (Python ${{ matrix.python-version }})
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+      fail-fast: false
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -93,5 +97,10 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v4
 
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Run tests
-      run: uv run pytest tests/ -v --cov=pikaraoke --cov-report=term-missing --cov-report=xml:coverage.xml
+      run: uv run --python ${{ matrix.python-version }} pytest tests/ -v --cov=pikaraoke --cov-report=term-missing --cov-report=xml:coverage.xml

--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -28,10 +28,12 @@ from pikaraoke.lib.get_platform import (
     is_windows,
 )
 from pikaraoke.routes.admin import admin_bp
+from pikaraoke.routes.admin_history import admin_history_bp
 from pikaraoke.routes.background_music import background_music_bp
 from pikaraoke.routes.batch_song_renamer import batch_song_renamer_bp
 from pikaraoke.routes.controller import controller_bp
 from pikaraoke.routes.files import files_bp
+from pikaraoke.routes.history import history_bp
 from pikaraoke.routes.home import home_bp
 from pikaraoke.routes.images import images_bp
 from pikaraoke.routes.info import info_bp
@@ -88,6 +90,8 @@ app.register_blueprint(info_bp)
 app.register_blueprint(splash_bp)
 app.register_blueprint(controller_bp)
 app.register_blueprint(nowplaying_bp)
+app.register_blueprint(history_bp)
+app.register_blueprint(admin_history_bp)
 
 
 def get_locale() -> str | None:
@@ -186,6 +190,8 @@ def main() -> None:
         additional_ytdl_args=getattr(args, "ytdl_args", None),
         socketio=socketio,
         preferred_language=args.preferred_language,
+        force_recreate_db=getattr(args, "force_recreate_db", False),
+        db_path=getattr(args, "db_path", None),
     )
 
     # expose karaoke object to the flask app

--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -304,6 +304,18 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         required=False,
     )
     parser.add_argument(
+        "--force-recreate-db",
+        action="store_true",
+        help="If the play history database is corrupt, rename it and create a new one instead of exiting.",
+        required=False,
+    )
+    parser.add_argument(
+        "--db-path",
+        help="Path to the play history database file. (default: <data-directory>/pikaraoke_plays.db)",
+        default=None,
+        required=False,
+    )
+    parser.add_argument(
         "--dolphly",
         action="store_true",
         help="Enable top-secret DOLPHLY mode.",

--- a/pikaraoke/lib/database.py
+++ b/pikaraoke/lib/database.py
@@ -1,0 +1,1046 @@
+"""SQLite database for play history tracking."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import sys
+from datetime import datetime
+
+
+class PlayDatabase:
+    """Manages play history in a SQLite database.
+
+    Tracks songs played, users, sessions, and user aliases.
+    Each server run creates a new session identified by UUID.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        """Initialize the database connection.
+
+        Args:
+            db_path: Path to the SQLite database file.
+        """
+        self.db_path = db_path
+        self.init_db()
+
+    def init_db(self) -> None:
+        """Initialize the database schema."""
+        with sqlite3.connect(self.db_path) as conn:
+            self._create_tables_if_needed(conn)
+            conn.commit()
+
+    def _create_tables_if_needed(self, conn: sqlite3.Connection) -> None:
+        """Create database tables and indexes if they don't exist."""
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                canonical_name TEXT PRIMARY KEY
+            )
+            """
+        )
+
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_aliases (
+                alias TEXT PRIMARY KEY,
+                canonical_name TEXT NOT NULL,
+                FOREIGN KEY (canonical_name) REFERENCES users (canonical_name)
+            )
+            """
+        )
+
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                started_at TEXT
+            )
+            """
+        )
+
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS plays (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                canonical_name TEXT NOT NULL,
+                display_name TEXT,
+                song TEXT NOT NULL,
+                completed INTEGER DEFAULT 0,
+                FOREIGN KEY (canonical_name) REFERENCES users (canonical_name),
+                FOREIGN KEY (session_id) REFERENCES sessions (session_id)
+            )
+            """
+        )
+
+        # Create indexes for better query performance
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_plays_canonical_name ON plays(canonical_name)"
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_plays_timestamp ON plays(timestamp)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_plays_session_id ON plays(session_id)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_user_aliases_canonical_name "
+            "ON user_aliases(canonical_name)"
+        )
+
+    def check_integrity(self) -> tuple[bool, str]:
+        """Check database integrity using PRAGMA integrity_check.
+
+        Returns:
+            Tuple of (is_ok, message) where is_ok is True if database is healthy.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.execute("PRAGMA integrity_check")
+                result = cursor.fetchone()
+                if result and result[0] == "ok":
+                    return True, "Database integrity check passed"
+                return False, f"Database integrity check failed: {result}"
+        except sqlite3.Error as e:
+            return False, f"Database error: {e}"
+
+    @staticmethod
+    def check_and_recover_db(db_path: str, force_recreate: bool = False) -> bool:
+        """Check database integrity at startup and recover if needed.
+
+        Args:
+            db_path: Path to the database file.
+            force_recreate: If True, rename corrupt DB and create new one.
+                           If False, exit on corruption.
+
+        Returns:
+            True if database is ready to use.
+
+        Raises:
+            SystemExit: If database is corrupt and force_recreate is False.
+        """
+        if not os.path.exists(db_path):
+            logging.info(f"Database does not exist, will be created: {db_path}")
+            return True
+
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute("PRAGMA integrity_check")
+                result = cursor.fetchone()
+                if result and result[0] == "ok":
+                    logging.info("Database integrity check passed")
+                    return True
+        except sqlite3.Error as e:
+            logging.error(f"Database error during integrity check: {e}")
+
+        # Database is corrupt
+        if force_recreate:
+            timestamp = datetime.now().strftime("%Y-%m-%d-%s")
+            failed_path = f"{db_path}.failed-{timestamp}"
+            logging.warning(f"Database corrupt, renaming to {failed_path} and creating new one")
+            try:
+                os.rename(db_path, failed_path)
+                return True
+            except OSError as e:
+                logging.error(f"Failed to rename corrupt database: {e}")
+                sys.exit(1)
+        else:
+            logging.error(
+                "Database is corrupt. Use --force-recreate-db to rename and create a new database."
+            )
+            sys.exit(1)
+
+    def ensure_session(self, session_id: str, default_name: str | None = None) -> None:
+        """Ensure a session exists in the database.
+
+        Args:
+            session_id: UUID string for the session.
+            default_name: Default session name (uses YYYY-MM-DD if not provided).
+        """
+        if default_name is None:
+            default_name = datetime.now().strftime("%Y-%m-%d")
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT session_id FROM sessions WHERE session_id = ?", (session_id,)
+            )
+            if cursor.fetchone() is None:
+                started_at = datetime.now().isoformat()
+                conn.execute(
+                    "INSERT INTO sessions (session_id, name, started_at) VALUES (?, ?, ?)",
+                    (session_id, default_name, started_at),
+                )
+                conn.commit()
+                logging.info(f"Created session: {default_name} ({session_id})")
+
+    def _resolve_canonical_user(self, user: str) -> str:
+        """Resolve a user name to its canonical name, creating user if needed.
+
+        Args:
+            user: User name or alias.
+
+        Returns:
+            The canonical user name.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT canonical_name FROM user_aliases WHERE alias = ?", (user,)
+            )
+            result = cursor.fetchone()
+            if result:
+                return result[0]
+            # Not an alias, ensure user exists in users table
+            conn.execute("INSERT OR IGNORE INTO users (canonical_name) VALUES (?)", (user,))
+            return user
+
+    def add_play(self, song: str, user: str, session_id: str) -> int:
+        """Add a new play record at song start.
+
+        Args:
+            song: Song title or filename.
+            user: User/singer name (will be resolved to canonical).
+            session_id: Current session UUID.
+
+        Returns:
+            The play record ID for later update.
+        """
+        canonical_name = self._resolve_canonical_user(user)
+        display_name = user  # Store original name before resolution
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO plays (timestamp, session_id, canonical_name, display_name, song)
+                VALUES (datetime('now'), ?, ?, ?, ?)
+                """,
+                (session_id, canonical_name, display_name, song),
+            )
+            conn.commit()
+            play_id = cursor.lastrowid
+            logging.debug(f"Added play record {play_id}: {song} by {user}")
+            return play_id  # type: ignore[return-value]
+
+    def update_play(self, play_id: int, completed: bool) -> None:
+        """Update a play record when song ends.
+
+        Args:
+            play_id: ID of the play record to update.
+            completed: True if song finished, False if skipped.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE plays SET completed = ? WHERE id = ?",
+                (1 if completed else 0, play_id),
+            )
+            conn.commit()
+            logging.debug(f"Updated play record {play_id}: completed={completed}")
+
+    def get_play(self, play_id: int) -> dict | None:
+        """Get a single play record by ID.
+
+        Args:
+            play_id: ID of the play record.
+
+        Returns:
+            Dictionary with play data or None if not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                """
+                SELECT p.*, s.name as session_name
+                FROM plays p
+                LEFT JOIN sessions s ON p.session_id = s.session_id
+                WHERE p.id = ?
+                """,
+                (play_id,),
+            )
+            row = cursor.fetchone()
+            if row:
+                return dict(row)
+            return None
+
+    def _build_filter_clause(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        session_ids: list[str] | None = None,
+        user_filter: str | None = None,
+        alias_filter: str | None = None,
+        song_filter: str | None = None,
+        table_prefix: str = "p",
+    ) -> tuple[str, list]:
+        """Build WHERE clause and parameters for filtering.
+
+        Args:
+            date_from: Start date (inclusive) in YYYY-MM-DD format.
+            date_to: End date (inclusive) in YYYY-MM-DD format.
+            session_ids: List of session IDs to filter by.
+            user_filter: Filter by canonical user name.
+            alias_filter: Filter by specific display_name (requires user_filter).
+            song_filter: Filter by exact song name.
+            table_prefix: Table alias prefix for column names.
+
+        Returns:
+            Tuple of (where_clause, params).
+        """
+        conditions = []
+        params: list = []
+
+        if date_from:
+            conditions.append(f"date({table_prefix}.timestamp) >= ?")
+            params.append(date_from)
+
+        if date_to:
+            conditions.append(f"date({table_prefix}.timestamp) <= ?")
+            params.append(date_to)
+
+        if session_ids:
+            placeholders = ",".join("?" * len(session_ids))
+            conditions.append(f"{table_prefix}.session_id IN ({placeholders})")
+            params.extend(session_ids)
+
+        if user_filter:
+            canonical_user = self._resolve_canonical_user(user_filter)
+            conditions.append(f"{table_prefix}.canonical_name = ?")
+            params.append(canonical_user)
+            # If alias_filter is set, also filter by display_name
+            if alias_filter:
+                conditions.append(f"{table_prefix}.display_name = ?")
+                params.append(alias_filter)
+
+        if song_filter:
+            conditions.append(f"{table_prefix}.song = ?")
+            params.append(song_filter)
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+        return where_clause, params
+
+    def get_last_plays(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        session_ids: list[str] | None = None,
+        user_filter: str | None = None,
+        alias_filter: str | None = None,
+        song_filter: str | None = None,
+        sort_by: str = "timestamp",
+        sort_order: str = "DESC",
+    ) -> list[dict]:
+        """Get recent plays with filtering and pagination.
+
+        Args:
+            limit: Maximum number of records to return.
+            offset: Number of records to skip.
+            date_from: Start date filter (YYYY-MM-DD).
+            date_to: End date filter (YYYY-MM-DD).
+            session_ids: List of session IDs to filter by.
+            user_filter: Filter by canonical user.
+            alias_filter: Filter by specific display_name (requires user_filter).
+            song_filter: Filter by exact song name.
+            sort_by: Column to sort by (timestamp, song, canonical_name).
+            sort_order: Sort direction (ASC or DESC).
+
+        Returns:
+            List of play records as dictionaries.
+        """
+        # Validate sort parameters
+        allowed_sort_cols = {"timestamp", "song", "canonical_name", "session_id"}
+        if sort_by not in allowed_sort_cols:
+            sort_by = "timestamp"
+        if sort_order.upper() not in ("ASC", "DESC"):
+            sort_order = "DESC"
+
+        where_clause, params = self._build_filter_clause(
+            date_from, date_to, session_ids, user_filter, alias_filter, song_filter
+        )
+
+        query = f"""
+            SELECT p.id, p.timestamp, p.session_id, s.name as session_name,
+                   p.canonical_name, p.display_name, p.song, p.completed
+            FROM plays p
+            LEFT JOIN sessions s ON p.session_id = s.session_id
+            {where_clause}
+            ORDER BY p.{sort_by} {sort_order}
+            LIMIT ? OFFSET ?
+        """
+        params.extend([limit, offset])
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_plays_count(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        session_ids: list[str] | None = None,
+        user_filter: str | None = None,
+        alias_filter: str | None = None,
+        song_filter: str | None = None,
+    ) -> int:
+        """Get total count of plays matching filters.
+
+        Args:
+            date_from: Start date filter (YYYY-MM-DD).
+            date_to: End date filter (YYYY-MM-DD).
+            session_ids: List of session IDs to filter by.
+            user_filter: Filter by canonical user.
+            alias_filter: Filter by specific display_name (requires user_filter).
+            song_filter: Filter by exact song name.
+
+        Returns:
+            Total count of matching plays.
+        """
+        where_clause, params = self._build_filter_clause(
+            date_from, date_to, session_ids, user_filter, alias_filter, song_filter
+        )
+
+        query = f"SELECT COUNT(*) FROM plays p{where_clause}"
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(query, params)
+            return cursor.fetchone()[0]
+
+    def get_session_ids_last_n(self, n: int) -> list[str]:
+        """Get the last N session IDs ordered by most recent play.
+
+        Args:
+            n: Number of sessions to return.
+
+        Returns:
+            List of session IDs.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT session_id
+                FROM plays
+                GROUP BY session_id
+                ORDER BY MAX(timestamp) DESC
+                LIMIT ?
+                """,
+                (n,),
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def get_sessions_with_names(
+        self, date_from: str | None = None, date_to: str | None = None
+    ) -> list[dict]:
+        """Get sessions with their names for dropdown filters.
+
+        Args:
+            date_from: Optional start date to filter sessions.
+            date_to: Optional end date to filter sessions.
+
+        Returns:
+            List of session dictionaries with session_id, name, started_at.
+        """
+        conditions = []
+        params: list = []
+
+        if date_from or date_to:
+            # Only return sessions that have plays in the date range
+            subquery_conditions = []
+            if date_from:
+                subquery_conditions.append("date(p.timestamp) >= ?")
+                params.append(date_from)
+            if date_to:
+                subquery_conditions.append("date(p.timestamp) <= ?")
+                params.append(date_to)
+            subquery_where = " AND ".join(subquery_conditions)
+            conditions.append(
+                f"s.session_id IN (SELECT DISTINCT session_id FROM plays p WHERE {subquery_where})"
+            )
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+        query = f"""
+            SELECT s.session_id, s.name, s.started_at
+            FROM sessions s
+            {where_clause}
+            ORDER BY s.started_at DESC
+        """
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_distinct_users(self) -> list[str]:
+        """Get all distinct users (canonical names with plays).
+
+        Returns:
+            List of canonical user names.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT DISTINCT canonical_name
+                FROM plays
+                ORDER BY canonical_name
+                """
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def get_distinct_dates(self) -> list[str]:
+        """Get all distinct dates when plays occurred.
+
+        Returns:
+            List of date strings in YYYY-MM-DD format.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT DISTINCT date(timestamp) as date FROM plays ORDER BY date DESC"
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    # --- Session Management (Phase 2b, 2c) ---
+
+    def get_session(self, session_id: str) -> dict | None:
+        """Get a single session by ID.
+
+        Args:
+            session_id: The session UUID.
+
+        Returns:
+            Dictionary with session data or None if not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT session_id, name, started_at FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+            if row:
+                return dict(row)
+            return None
+
+    def update_session_name(self, session_id: str, name: str) -> bool:
+        """Update a session's display name.
+
+        Args:
+            session_id: The session UUID.
+            name: New display name for the session.
+
+        Returns:
+            True if update succeeded, False if session not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "UPDATE sessions SET name = ? WHERE session_id = ?",
+                (name, session_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def merge_sessions(self, source_session_ids: list[str], target_session_id: str) -> int:
+        """Merge multiple sessions into a target session.
+
+        Moves all plays from source sessions to target, then deletes source sessions.
+
+        Args:
+            source_session_ids: List of session IDs to merge from.
+            target_session_id: Session ID to merge into.
+
+        Returns:
+            Number of plays moved.
+        """
+        if not source_session_ids or target_session_id in source_session_ids:
+            return 0
+
+        with sqlite3.connect(self.db_path) as conn:
+            placeholders = ",".join("?" * len(source_session_ids))
+
+            # Move plays to target session
+            cursor = conn.execute(
+                f"UPDATE plays SET session_id = ? WHERE session_id IN ({placeholders})",
+                [target_session_id] + source_session_ids,
+            )
+            plays_moved = cursor.rowcount
+
+            # Delete source sessions
+            conn.execute(
+                f"DELETE FROM sessions WHERE session_id IN ({placeholders})",
+                source_session_ids,
+            )
+
+            conn.commit()
+            logging.info(
+                f"Merged {len(source_session_ids)} sessions into {target_session_id}, "
+                f"moved {plays_moved} plays"
+            )
+            return plays_moved
+
+    def delete_session(self, session_id: str) -> tuple[int, int]:
+        """Delete a session and all its plays.
+
+        Args:
+            session_id: The session UUID to delete.
+
+        Returns:
+            Tuple of (plays_deleted, sessions_deleted).
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            # Delete plays first
+            cursor = conn.execute(
+                "DELETE FROM plays WHERE session_id = ?",
+                (session_id,),
+            )
+            plays_deleted = cursor.rowcount
+
+            # Delete session
+            cursor = conn.execute(
+                "DELETE FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            sessions_deleted = cursor.rowcount
+
+            conn.commit()
+            logging.info(f"Deleted session {session_id}: {plays_deleted} plays removed")
+            return plays_deleted, sessions_deleted
+
+    # --- User Alias Management (Phase 4) ---
+
+    def get_aliases_for_user(self, canonical_name: str) -> list[str]:
+        """Get all aliases for a canonical user.
+
+        Args:
+            canonical_name: The canonical user name.
+
+        Returns:
+            List of alias names for the user.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT alias FROM user_aliases WHERE canonical_name = ? ORDER BY alias",
+                (canonical_name,),
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def get_all_aliases(self) -> list[dict]:
+        """Get all user aliases.
+
+        Returns:
+            List of dicts with alias and canonical_name fields.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT alias, canonical_name FROM user_aliases ORDER BY canonical_name, alias"
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def add_alias(self, alias: str, canonical_name: str) -> bool:
+        """Add an alias for a canonical user.
+
+        Args:
+            alias: The alias name.
+            canonical_name: The canonical user name to map to.
+
+        Returns:
+            True if alias was added, False if it already exists.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            # Ensure canonical user exists
+            conn.execute("INSERT OR IGNORE INTO users (canonical_name) VALUES (?)", (canonical_name,))
+
+            try:
+                conn.execute(
+                    "INSERT INTO user_aliases (alias, canonical_name) VALUES (?, ?)",
+                    (alias, canonical_name),
+                )
+                conn.commit()
+                logging.info(f"Added alias '{alias}' -> '{canonical_name}'")
+                return True
+            except sqlite3.IntegrityError:
+                # Alias already exists
+                return False
+
+    def remove_alias(self, alias: str) -> bool:
+        """Remove an alias.
+
+        Args:
+            alias: The alias to remove.
+
+        Returns:
+            True if alias was removed, False if not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute("DELETE FROM user_aliases WHERE alias = ?", (alias,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def update_alias_canonical_user(self, alias: str, new_canonical_name: str) -> bool:
+        """Change the canonical user an alias points to.
+
+        Args:
+            alias: The alias to update.
+            new_canonical_name: New canonical user name.
+
+        Returns:
+            True if alias was updated, False if not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            # Ensure new canonical user exists
+            conn.execute(
+                "INSERT OR IGNORE INTO users (canonical_name) VALUES (?)", (new_canonical_name,)
+            )
+
+            cursor = conn.execute(
+                "UPDATE user_aliases SET canonical_name = ? WHERE alias = ?",
+                (new_canonical_name, alias),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def get_canonical_name_for_alias(self, alias: str) -> str | None:
+        """Get the canonical name for an alias.
+
+        Args:
+            alias: The alias to look up.
+
+        Returns:
+            The canonical name or None if alias not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT canonical_name FROM user_aliases WHERE alias = ?", (alias,)
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+
+    # --- Play Record Management (Phase 5) ---
+
+    def can_user_delete_play(self, play_id: int, username: str) -> bool:
+        """Check if a user can delete a specific play record.
+
+        A user can delete a play if:
+        - Their name matches the canonical_name of the play
+        - Their name matches the display_name of the play
+        - Their name is an alias that maps to the canonical_name
+
+        Args:
+            play_id: The play record ID.
+            username: The requesting user's name.
+
+        Returns:
+            True if user can delete the play.
+        """
+        play = self.get_play(play_id)
+        if not play:
+            return False
+
+        # Direct match on display_name or canonical_name
+        if username == play["display_name"] or username == play["canonical_name"]:
+            return True
+
+        # Check if username is an alias for the canonical user
+        canonical = self.get_canonical_name_for_alias(username)
+        if canonical and canonical == play["canonical_name"]:
+            return True
+
+        # Check if the play's canonical user resolves from the username
+        resolved = self._resolve_canonical_user(username)
+        return resolved == play["canonical_name"]
+
+    def delete_play(self, play_id: int) -> bool:
+        """Delete a play record by ID.
+
+        Args:
+            play_id: The play record ID.
+
+        Returns:
+            True if play was deleted, False if not found.
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute("DELETE FROM plays WHERE id = ?", (play_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    # --- Rankings (Phase 6) ---
+
+    def get_top_users(
+        self,
+        limit: int = 10,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        session_ids: list[str] | None = None,
+    ) -> list[dict]:
+        """Get users ranked by total songs played.
+
+        Args:
+            limit: Maximum number of results.
+            date_from: Optional start date filter.
+            date_to: Optional end date filter.
+            session_ids: Optional session filter.
+
+        Returns:
+            List of dicts with canonical_name and play_count.
+        """
+        where_clause, params = self._build_filter_clause(
+            date_from, date_to, session_ids, None, None
+        )
+
+        query = f"""
+            SELECT canonical_name, COUNT(*) as play_count
+            FROM plays p
+            {where_clause}
+            GROUP BY canonical_name
+            ORDER BY play_count DESC
+            LIMIT ?
+        """
+        params.append(limit)
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_top_songs(
+        self,
+        limit: int = 10,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        session_ids: list[str] | None = None,
+    ) -> list[dict]:
+        """Get songs ranked by times played.
+
+        Args:
+            limit: Maximum number of results.
+            date_from: Optional start date filter.
+            date_to: Optional end date filter.
+            session_ids: Optional session filter.
+
+        Returns:
+            List of dicts with song and play_count.
+        """
+        where_clause, params = self._build_filter_clause(
+            date_from, date_to, session_ids, None, None
+        )
+
+        query = f"""
+            SELECT song, COUNT(*) as play_count
+            FROM plays p
+            {where_clause}
+            GROUP BY song
+            ORDER BY play_count DESC
+            LIMIT ?
+        """
+        params.append(limit)
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_busiest_sessions(
+        self,
+        limit: int = 10,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[dict]:
+        """Get sessions ranked by number of plays.
+
+        Args:
+            limit: Maximum number of results.
+            date_from: Optional start date filter.
+            date_to: Optional end date filter.
+
+        Returns:
+            List of dicts with session_id, session_name, and play_count.
+        """
+        conditions = []
+        params = []
+
+        if date_from:
+            conditions.append("date(p.timestamp) >= ?")
+            params.append(date_from)
+        if date_to:
+            conditions.append("date(p.timestamp) <= ?")
+            params.append(date_to)
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+        query = f"""
+            SELECT p.session_id, s.name as session_name, COUNT(*) as play_count
+            FROM plays p
+            LEFT JOIN sessions s ON p.session_id = s.session_id
+            {where_clause}
+            GROUP BY p.session_id
+            ORDER BY play_count DESC
+            LIMIT ?
+        """
+        params.append(limit)
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            return [dict(row) for row in cursor.fetchall()]
+
+    def get_busiest_days(
+        self,
+        limit: int = 10,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> list[dict]:
+        """Get days ranked by number of plays.
+
+        Args:
+            limit: Maximum number of results.
+            date_from: Optional start date filter.
+            date_to: Optional end date filter.
+
+        Returns:
+            List of dicts with date and play_count.
+        """
+        conditions = []
+        params = []
+
+        if date_from:
+            conditions.append("date(timestamp) >= ?")
+            params.append(date_from)
+        if date_to:
+            conditions.append("date(timestamp) <= ?")
+            params.append(date_to)
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+        query = f"""
+            SELECT date(timestamp) as date, COUNT(*) as play_count
+            FROM plays
+            {where_clause}
+            GROUP BY date(timestamp)
+            ORDER BY play_count DESC
+            LIMIT ?
+        """
+        params.append(limit)
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            return [dict(row) for row in cursor.fetchall()]
+
+    # --- Performers (Phase 7) ---
+
+    def get_performers(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        sort_by: str = "play_count",
+        sort_order: str = "DESC",
+    ) -> list[dict]:
+        """Get all performers with their play counts and aliases.
+
+        Args:
+            limit: Maximum number of results.
+            offset: Offset for pagination.
+            date_from: Optional start date filter.
+            date_to: Optional end date filter.
+            sort_by: Column to sort by (canonical_name, play_count).
+            sort_order: ASC or DESC.
+
+        Returns:
+            List of dicts with canonical_name, play_count, and aliases.
+        """
+        conditions = []
+        params = []
+
+        if date_from:
+            conditions.append("date(p.timestamp) >= ?")
+            params.append(date_from)
+        if date_to:
+            conditions.append("date(p.timestamp) <= ?")
+            params.append(date_to)
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+        # Validate sort_by
+        valid_sorts = {"canonical_name": "canonical_name", "play_count": "play_count"}
+        sort_col = valid_sorts.get(sort_by, "play_count")
+        order = "DESC" if sort_order.upper() == "DESC" else "ASC"
+
+        query = f"""
+            SELECT canonical_name, COUNT(*) as play_count
+            FROM plays p
+            {where_clause}
+            GROUP BY canonical_name
+            ORDER BY {sort_col} {order}
+            LIMIT ? OFFSET ?
+        """
+        params.extend([limit, offset])
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, params)
+            performers = [dict(row) for row in cursor.fetchall()]
+
+            # Add aliases for each performer
+            for performer in performers:
+                performer["aliases"] = self.get_aliases_for_user(performer["canonical_name"])
+
+            return performers
+
+    def get_performers_count(
+        self,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> int:
+        """Get count of distinct performers.
+
+        Args:
+            date_from: Optional start date filter.
+            date_to: Optional end date filter.
+
+        Returns:
+            Count of distinct performers.
+        """
+        conditions = []
+        params = []
+
+        if date_from:
+            conditions.append("date(timestamp) >= ?")
+            params.append(date_from)
+        if date_to:
+            conditions.append("date(timestamp) <= ?")
+            params.append(date_to)
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+        query = f"SELECT COUNT(DISTINCT canonical_name) FROM plays{where_clause}"
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(query, params)
+            return cursor.fetchone()[0]
+
+    # --- Admin Play Editing (Phase 8) ---
+
+    def update_play_user(
+        self, play_id: int, display_name: str, canonical_name: str | None = None
+    ) -> bool:
+        """Update a play's user information.
+
+        Args:
+            play_id: The play record ID.
+            display_name: New display name for the play.
+            canonical_name: New canonical name. If None, resolved from display_name.
+
+        Returns:
+            True if play was updated, False if not found.
+        """
+        if canonical_name is None:
+            canonical_name = self._resolve_canonical_user(display_name)
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "UPDATE plays SET display_name = ?, canonical_name = ? WHERE id = ?",
+                (display_name, canonical_name, play_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0

--- a/pikaraoke/routes/admin_history.py
+++ b/pikaraoke/routes/admin_history.py
@@ -1,0 +1,319 @@
+"""Admin routes for managing play history."""
+
+from __future__ import annotations
+
+import flask_babel
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
+
+from pikaraoke.lib.current_app import get_karaoke_instance, get_site_name, is_admin
+
+_ = flask_babel.gettext
+
+admin_history_bp = Blueprint("admin_history", __name__)
+
+
+@admin_history_bp.route("/admin/history")
+def admin_history():
+    """Admin page for managing play history.
+
+    Requires admin authentication.
+    """
+    if not is_admin():
+        flash(_("Admin access required"), "is-danger")
+        return redirect(url_for("history.history"))
+
+    k = get_karaoke_instance()
+    site_name = get_site_name()
+
+    if not k.db:
+        flash(_("Play history database is not available"), "is-danger")
+        return render_template(
+            "admin_history.html",
+            site_title=site_name,
+            title=_("Manage History"),
+            sessions=[],
+            aliases=[],
+            distinct_users=[],
+            admin=True,
+        )
+
+    db = k.db
+    sessions = db.get_sessions_with_names()
+    aliases = db.get_all_aliases()
+    distinct_users = db.get_distinct_users()
+
+    return render_template(
+        "admin_history.html",
+        site_title=site_name,
+        title=_("Manage History"),
+        sessions=sessions,
+        aliases=aliases,
+        distinct_users=distinct_users,
+        admin=True,
+    )
+
+
+@admin_history_bp.route("/admin/history/sessions/<session_id>", methods=["GET"])
+def get_session(session_id: str):
+    """Get session details.
+
+    Args:
+        session_id: The session UUID.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    session = k.db.get_session(session_id)
+    if not session:
+        return jsonify({"success": False, "message": _("Session not found")}), 404
+
+    return jsonify({"success": True, "session": session})
+
+
+@admin_history_bp.route("/admin/history/sessions/<session_id>/name", methods=["POST"])
+def update_session_name(session_id: str):
+    """Update a session's display name.
+
+    Args:
+        session_id: The session UUID.
+
+    Form data:
+        name: The new session name.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    name = request.form.get("name", "").strip()
+    if not name:
+        return jsonify({"success": False, "message": _("Session name cannot be empty")}), 400
+
+    success = k.db.update_session_name(session_id, name)
+    if success:
+        flash(_("Session name updated"), "is-success")
+        return jsonify({"success": True, "message": _("Session name updated")})
+    else:
+        return jsonify({"success": False, "message": _("Session not found")}), 404
+
+
+@admin_history_bp.route("/admin/history/sessions/merge", methods=["POST"])
+def merge_sessions():
+    """Merge multiple sessions into one.
+
+    Form data:
+        source_sessions: Comma-separated list of source session IDs.
+        target_session: The target session ID.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    source_sessions = request.form.get("source_sessions", "").strip()
+    target_session = request.form.get("target_session", "").strip()
+
+    if not source_sessions or not target_session:
+        return jsonify({"success": False, "message": _("Missing required parameters")}), 400
+
+    source_ids = [s.strip() for s in source_sessions.split(",") if s.strip()]
+    if not source_ids:
+        return jsonify({"success": False, "message": _("No source sessions specified")}), 400
+
+    plays_moved = k.db.merge_sessions(source_ids, target_session)
+    flash(_("Merged %d plays into target session") % plays_moved, "is-success")
+    return jsonify({
+        "success": True,
+        "message": _("Merged %d plays") % plays_moved,
+        "plays_moved": plays_moved,
+    })
+
+
+@admin_history_bp.route("/admin/history/sessions/<session_id>", methods=["DELETE"])
+def delete_session(session_id: str):
+    """Delete a session and all its history.
+
+    Args:
+        session_id: The session UUID.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    plays_deleted, sessions_deleted = k.db.delete_session(session_id)
+    if sessions_deleted > 0:
+        flash(_("Session deleted with %d plays") % plays_deleted, "is-warning")
+        return jsonify({
+            "success": True,
+            "message": _("Session deleted"),
+            "plays_deleted": plays_deleted,
+        })
+    else:
+        return jsonify({"success": False, "message": _("Session not found")}), 404
+
+
+# --- User Alias Management (Phase 4) ---
+
+
+@admin_history_bp.route("/admin/history/aliases", methods=["GET"])
+def get_aliases():
+    """Get all user aliases."""
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    aliases = k.db.get_all_aliases()
+    return jsonify({"success": True, "aliases": aliases})
+
+
+@admin_history_bp.route("/admin/history/aliases", methods=["POST"])
+def add_alias():
+    """Add a new user alias.
+
+    Form data:
+        alias: The alias name.
+        canonical_name: The canonical user name to map to.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    alias = request.form.get("alias", "").strip()
+    canonical_name = request.form.get("canonical_name", "").strip()
+
+    if not alias or not canonical_name:
+        return jsonify({"success": False, "message": _("Alias and canonical name required")}), 400
+
+    if alias == canonical_name:
+        return jsonify({"success": False, "message": _("Alias cannot be same as canonical name")}), 400
+
+    success = k.db.add_alias(alias, canonical_name)
+    if success:
+        flash(_("Alias added: %s -> %s") % (alias, canonical_name), "is-success")
+        return jsonify({"success": True, "message": _("Alias added")})
+    else:
+        return jsonify({"success": False, "message": _("Alias already exists")}), 409
+
+
+@admin_history_bp.route("/admin/history/aliases/<path:alias>", methods=["DELETE"])
+def remove_alias(alias: str):
+    """Remove a user alias.
+
+    Args:
+        alias: The alias to remove (URL-encoded).
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    success = k.db.remove_alias(alias)
+    if success:
+        flash(_("Alias removed: %s") % alias, "is-warning")
+        return jsonify({"success": True, "message": _("Alias removed")})
+    else:
+        return jsonify({"success": False, "message": _("Alias not found")}), 404
+
+
+@admin_history_bp.route("/admin/history/aliases/<path:alias>", methods=["PUT"])
+def update_alias(alias: str):
+    """Update a user alias mapping.
+
+    Args:
+        alias: The alias to update (URL-encoded).
+
+    Form data:
+        canonical_name: The new canonical user name.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    canonical_name = request.form.get("canonical_name", "").strip()
+    if not canonical_name:
+        return jsonify({"success": False, "message": _("Canonical name required")}), 400
+
+    success = k.db.update_alias_canonical_user(alias, canonical_name)
+    if success:
+        flash(_("Alias updated: %s -> %s") % (alias, canonical_name), "is-success")
+        return jsonify({"success": True, "message": _("Alias updated")})
+    else:
+        return jsonify({"success": False, "message": _("Alias not found")}), 404
+
+
+# --- Admin Play Editing (Phase 8) ---
+
+
+@admin_history_bp.route("/admin/history/plays/<int:play_id>", methods=["GET"])
+def get_play(play_id: int):
+    """Get a play record for editing.
+
+    Args:
+        play_id: The play record ID.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    play = k.db.get_play(play_id)
+    if not play:
+        return jsonify({"success": False, "message": _("Play not found")}), 404
+
+    return jsonify({"success": True, "play": play})
+
+
+@admin_history_bp.route("/admin/history/plays/<int:play_id>/user", methods=["POST"])
+def update_play_user(play_id: int):
+    """Update a play's user/display name (admin only).
+
+    Args:
+        play_id: The play record ID.
+
+    Form data:
+        display_name: New display name for the play.
+        canonical_name: Optional canonical user name.
+    """
+    if not is_admin():
+        return jsonify({"success": False, "message": _("Admin access required")}), 403
+
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    display_name = request.form.get("display_name", "").strip()
+    canonical_name = request.form.get("canonical_name", "").strip() or None
+
+    if not display_name:
+        return jsonify({"success": False, "message": _("Display name required")}), 400
+
+    success = k.db.update_play_user(play_id, display_name, canonical_name)
+    if success:
+        flash(_("Play user updated to: %s") % display_name, "is-success")
+        return jsonify({"success": True, "message": _("Play updated")})
+    else:
+        return jsonify({"success": False, "message": _("Play not found")}), 404

--- a/pikaraoke/routes/history.py
+++ b/pikaraoke/routes/history.py
@@ -1,0 +1,385 @@
+"""History routes for viewing play history."""
+
+from __future__ import annotations
+
+from urllib.parse import unquote
+
+import flask_babel
+from flask import Blueprint, flash, jsonify, render_template, request, url_for
+from flask_paginate import Pagination, get_page_parameter
+
+from pikaraoke.lib.current_app import get_karaoke_instance, get_site_name, is_admin
+
+_ = flask_babel.gettext
+
+history_bp = Blueprint("history", __name__)
+
+
+@history_bp.route("/history/play/<int:play_id>", methods=["DELETE"])
+def delete_play(play_id: int):
+    """Delete a play record from history.
+
+    Users can delete their own plays. Admins can delete any play.
+
+    Args:
+        play_id: The play record ID.
+
+    Query params:
+        user: The requesting user's name (for permission check).
+    """
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "message": _("Database not available")}), 500
+
+    db = k.db
+    play = db.get_play(play_id)
+    if not play:
+        return jsonify({"success": False, "message": _("Play not found")}), 404
+
+    # Check permission
+    admin = is_admin()
+    username = request.args.get("user", "").strip()
+
+    if not admin:
+        if not username:
+            return jsonify({"success": False, "message": _("User identification required")}), 400
+
+        if not db.can_user_delete_play(play_id, username):
+            return jsonify({"success": False, "message": _("Permission denied")}), 403
+
+    # Delete the play
+    success = db.delete_play(play_id)
+    if success:
+        return jsonify({"success": True, "message": _("Play deleted")})
+    else:
+        return jsonify({"success": False, "message": _("Failed to delete play")}), 500
+
+
+@history_bp.route("/history/api/session-dates")
+def get_session_dates():
+    """Get dates that have sessions with session names.
+
+    Returns JSON with dates and their session info for calendar highlighting.
+    """
+    k = get_karaoke_instance()
+    if not k.db:
+        return jsonify({"success": False, "dates": {}})
+
+    db = k.db
+
+    try:
+        # Get all sessions with their dates
+        sessions = db.get_sessions_with_names()
+        dates_data = {}
+
+        for session in sessions:
+            if session.get("started_at"):
+                date_str = session["started_at"][:10]  # Extract YYYY-MM-DD
+                if date_str not in dates_data:
+                    dates_data[date_str] = []
+                dates_data[date_str].append(session["name"])
+
+        return jsonify({"success": True, "dates": dates_data})
+    except Exception:
+        return jsonify({"success": False, "dates": {}})
+
+
+@history_bp.route("/history/performers")
+def performers():
+    """View all performers with play counts and aliases.
+
+    Query parameters:
+        page: Page number (default 1)
+        limit: Results per page (default 20)
+        date_from: Start date filter (YYYY-MM-DD)
+        date_to: End date filter (YYYY-MM-DD)
+        sort_by: Column to sort by (canonical_name, play_count)
+        sort_order: ASC or DESC (default DESC)
+    """
+    k = get_karaoke_instance()
+    site_name = get_site_name()
+
+    if not k.db:
+        flash(_("Play history database is not available"), "is-danger")
+        return render_template(
+            "performers.html",
+            site_title=site_name,
+            title=_("Performers"),
+            performers=[],
+            pagination=None,
+            admin=is_admin(),
+        )
+
+    db = k.db
+
+    # Get filter parameters
+    page = request.args.get(get_page_parameter(), type=int, default=1)
+    limit = request.args.get("limit", type=int, default=20)
+    date_from = request.args.get("date_from")
+    date_to = request.args.get("date_to")
+    sort_by = request.args.get("sort_by", "play_count")
+    sort_order = request.args.get("sort_order", "DESC")
+
+    offset = (page - 1) * limit
+
+    try:
+        performers_list = db.get_performers(
+            limit=limit,
+            offset=offset,
+            date_from=date_from,
+            date_to=date_to,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        total_count = db.get_performers_count(date_from=date_from, date_to=date_to)
+    except Exception as e:
+        flash(_("Error loading performers: %s") % str(e), "is-danger")
+        performers_list = []
+        total_count = 0
+
+    # Build pagination URL
+    args = request.args.copy()
+    args.pop("_", None)
+    page_param = get_page_parameter()
+    args[page_param] = "{0}"
+    args_dict = args.to_dict()
+    pagination_href = unquote(url_for("history.performers", **args_dict))
+
+    pagination = Pagination(
+        css_framework="bulma",
+        page=page,
+        total=total_count,
+        search=False,
+        record_name="performers",
+        per_page=limit,
+        display_msg=_("Showing <b>{start} - {end}</b> of <b>{total}</b> performers"),
+        href=pagination_href,
+    )
+
+    return render_template(
+        "performers.html",
+        site_title=site_name,
+        title=_("Performers"),
+        performers=performers_list,
+        pagination=pagination,
+        total_count=total_count,
+        date_from=date_from or "",
+        date_to=date_to or "",
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        admin=is_admin(),
+    )
+
+
+@history_bp.route("/history/rankings")
+def rankings():
+    """View rankings (top users, songs, sessions, days).
+
+    Query parameters:
+        date_from: Start date filter (YYYY-MM-DD)
+        date_to: End date filter (YYYY-MM-DD)
+        session_id: Filter by specific session
+        sessions_count: Filter by last N sessions
+        limit: Number of results per ranking (default 10)
+    """
+    k = get_karaoke_instance()
+    site_name = get_site_name()
+
+    if not k.db:
+        flash(_("Play history database is not available"), "is-danger")
+        return render_template(
+            "rankings.html",
+            site_title=site_name,
+            title=_("Rankings"),
+            top_users=[],
+            top_songs=[],
+            busiest_sessions=[],
+            busiest_days=[],
+            admin=is_admin(),
+        )
+
+    db = k.db
+
+    # Get filter parameters
+    date_from = request.args.get("date_from")
+    date_to = request.args.get("date_to")
+    session_id = request.args.get("session_id")
+    sessions_count = request.args.get("sessions_count", type=int)
+    limit = request.args.get("limit", type=int, default=10)
+
+    # Build session_ids list
+    session_ids = None
+    if session_id:
+        session_ids = [session_id]
+    elif sessions_count and sessions_count > 0:
+        session_ids = db.get_session_ids_last_n(sessions_count)
+
+    try:
+        top_users = db.get_top_users(limit, date_from, date_to, session_ids)
+        top_songs = db.get_top_songs(limit, date_from, date_to, session_ids)
+        busiest_sessions = db.get_busiest_sessions(limit, date_from, date_to)
+        busiest_days = db.get_busiest_days(limit, date_from, date_to)
+        sessions = db.get_sessions_with_names(date_from=date_from, date_to=date_to)
+    except Exception as e:
+        flash(_("Error loading rankings: %s") % str(e), "is-danger")
+        top_users = []
+        top_songs = []
+        busiest_sessions = []
+        busiest_days = []
+        sessions = []
+
+    return render_template(
+        "rankings.html",
+        site_title=site_name,
+        title=_("Rankings"),
+        top_users=top_users,
+        top_songs=top_songs,
+        busiest_sessions=busiest_sessions,
+        busiest_days=busiest_days,
+        sessions=sessions,
+        date_from=date_from or "",
+        date_to=date_to or "",
+        session_id=session_id or "",
+        sessions_count=sessions_count or "",
+        limit=limit,
+        admin=is_admin(),
+    )
+
+
+@history_bp.route("/history")
+def history():
+    """View play history with filtering and pagination.
+
+    Query parameters:
+        page: Page number (default 1)
+        limit: Results per page (default 20)
+        date_from: Start date filter (YYYY-MM-DD)
+        date_to: End date filter (YYYY-MM-DD)
+        session_id: Filter by specific session
+        sessions_count: Filter by last N sessions
+        user: Filter by user (canonical name)
+        alias: Filter to specific display_name (requires user)
+        sort_by: Column to sort by (timestamp, song, canonical_name)
+        sort_order: ASC or DESC (default DESC)
+    """
+    k = get_karaoke_instance()
+    site_name = get_site_name()
+
+    if not k.db:
+        flash(_("Play history database is not available"), "is-danger")
+        return render_template(
+            "history.html",
+            site_title=site_name,
+            title=_("History"),
+            plays=[],
+            pagination=None,
+            sessions=[],
+            distinct_users=[],
+            admin=is_admin(),
+        )
+
+    db = k.db
+
+    # Get filter parameters from URL
+    page = request.args.get(get_page_parameter(), type=int, default=1)
+    limit = request.args.get("limit", type=int, default=20)
+    date_from = request.args.get("date_from")
+    date_to = request.args.get("date_to")
+    session_id = request.args.get("session_id")
+    sessions_count = request.args.get("sessions_count", type=int)
+    user_filter = request.args.get("user")
+    alias_filter = request.args.get("alias")
+    song_filter = request.args.get("song")
+    sort_by = request.args.get("sort_by", "timestamp")
+    sort_order = request.args.get("sort_order", "DESC")
+
+    # Build session_ids list from either session_id or sessions_count
+    session_ids = None
+    if session_id:
+        session_ids = [session_id]
+    elif sessions_count and sessions_count > 0:
+        session_ids = db.get_session_ids_last_n(sessions_count)
+
+    # Calculate offset from page
+    offset = (page - 1) * limit
+
+    try:
+        # Get plays with filters
+        plays = db.get_last_plays(
+            limit=limit,
+            offset=offset,
+            date_from=date_from,
+            date_to=date_to,
+            session_ids=session_ids,
+            user_filter=user_filter,
+            alias_filter=alias_filter,
+            song_filter=song_filter,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+
+        # Get total count for pagination
+        total_count = db.get_plays_count(
+            date_from=date_from,
+            date_to=date_to,
+            session_ids=session_ids,
+            user_filter=user_filter,
+            alias_filter=alias_filter,
+            song_filter=song_filter,
+        )
+
+        # Get sessions for dropdown
+        sessions = db.get_sessions_with_names(date_from=date_from, date_to=date_to)
+
+        # Get distinct users for autocomplete
+        distinct_users = db.get_distinct_users()
+
+    except Exception as e:
+        flash(_("Error loading history: %s") % str(e), "is-danger")
+        plays = []
+        total_count = 0
+        sessions = []
+        distinct_users = []
+
+    # Build pagination URL with current filters preserved
+    args = request.args.copy()
+    args.pop("_", None)  # Remove cache buster if present
+    page_param = get_page_parameter()
+    args[page_param] = "{0}"
+    args_dict = args.to_dict()
+    pagination_href = unquote(url_for("history.history", **args_dict))
+
+    pagination = Pagination(
+        css_framework="bulma",
+        page=page,
+        total=total_count,
+        search=False,
+        record_name="plays",
+        per_page=limit,
+        display_msg=_("Showing <b>{start} - {end}</b> of <b>{total}</b> plays"),
+        href=pagination_href,
+    )
+
+    return render_template(
+        "history.html",
+        site_title=site_name,
+        title=_("History"),
+        plays=plays,
+        pagination=pagination,
+        sessions=sessions,
+        distinct_users=distinct_users,
+        total_count=total_count,
+        # Current filter values for form state
+        date_from=date_from or "",
+        date_to=date_to or "",
+        session_id=session_id or "",
+        sessions_count=sessions_count or "",
+        user_filter=user_filter or "",
+        alias_filter=alias_filter or "",
+        song_filter=song_filter or "",
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        admin=is_admin(),
+    )

--- a/pikaraoke/static/screensaver.css
+++ b/pikaraoke/static/screensaver.css
@@ -18,16 +18,38 @@ body {
   position: absolute;
   left: 0px;
   top: 0px;
-  height: 200px;
-  width: 420px;
+  width: 28vw;
+  height: 14vw;
+  min-width: 280px;
+  min-height: 140px;
   z-index: 11;
-  border-radius: 10px;
+  border-radius: 0.7vw;
   display: flex;
   justify-content: right;
   align-items: flex-end;
-  padding: 10px;
+  padding: 0.7vw;
   background-image: url("/logo");
   background-repeat: no-repeat;
-  background-size: 300px;
-  background-position: contain;
+  background-size: 70%;
+  background-position: left center;
+}
+
+#dvd .qr-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+#dvd .qr-container img {
+  width: 8vw;
+  min-width: 80px;
+  image-rendering: pixelated;
+}
+
+#dvd .qr-url {
+  font-size: clamp(0.7rem, 1.2vw, 1.1rem);
+  margin-top: 0.3vw;
+  color: #333;
+  font-weight: 500;
 }

--- a/pikaraoke/templates/admin_history.html
+++ b/pikaraoke/templates/admin_history.html
@@ -1,0 +1,306 @@
+{% extends 'base.html' %}
+
+{% block scripts %}
+<script>
+$(function() {
+    // Edit session name
+    $(".edit-session-btn").click(function(e) {
+        e.preventDefault();
+        var sessionId = $(this).data("session-id");
+        var currentName = $(this).data("session-name");
+        var newName = prompt("{% trans %}Enter new session name:{% endtrans %}", currentName);
+        if (newName && newName.trim() !== currentName) {
+            $.post("/admin/history/sessions/" + sessionId + "/name", 
+                { name: newName.trim() },
+                function(data) {
+                    if (data.success) {
+                        showNotification(data.message, "is-success");
+                        location.reload();
+                    } else {
+                        showNotification(data.message, "is-danger");
+                    }
+                }
+            ).fail(function(xhr) {
+                var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+                showNotification(msg, "is-danger");
+            });
+        }
+    });
+
+    // Delete session
+    $(".delete-session-btn").click(function(e) {
+        e.preventDefault();
+        var sessionId = $(this).data("session-id");
+        var sessionName = $(this).data("session-name");
+        if (confirm("{% trans %}Are you sure you want to delete session{% endtrans %} '" + sessionName + "' {% trans %}and all its history?{% endtrans %}")) {
+            $.ajax({
+                url: "/admin/history/sessions/" + sessionId,
+                type: "DELETE",
+                success: function(data) {
+                    if (data.success) {
+                        showNotification(data.message, "is-success");
+                        location.reload();
+                    } else {
+                        showNotification(data.message, "is-danger");
+                    }
+                },
+                error: function(xhr) {
+                    var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+                    showNotification(msg, "is-danger");
+                }
+            });
+        }
+    });
+
+    // Merge sessions form
+    $("#merge-form").submit(function(e) {
+        e.preventDefault();
+        var sourceChecked = $("input.merge-source:checked");
+        if (sourceChecked.length < 1) {
+            showNotification("{% trans %}Select at least one source session{% endtrans %}", "is-warning");
+            return;
+        }
+        var targetSession = $("#merge-target").val();
+        if (!targetSession) {
+            showNotification("{% trans %}Select a target session{% endtrans %}", "is-warning");
+            return;
+        }
+        var sourceIds = [];
+        sourceChecked.each(function() {
+            if ($(this).val() !== targetSession) {
+                sourceIds.push($(this).val());
+            }
+        });
+        if (sourceIds.length < 1) {
+            showNotification("{% trans %}Source and target cannot be the same{% endtrans %}", "is-warning");
+            return;
+        }
+        if (confirm("{% trans %}Merge{% endtrans %} " + sourceIds.length + " {% trans %}sessions into target?{% endtrans %}")) {
+            $.post("/admin/history/sessions/merge", {
+                source_sessions: sourceIds.join(","),
+                target_session: targetSession
+            }, function(data) {
+                if (data.success) {
+                    showNotification(data.message, "is-success");
+                    location.reload();
+                } else {
+                    showNotification(data.message, "is-danger");
+                }
+            }).fail(function(xhr) {
+                var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+                showNotification(msg, "is-danger");
+            });
+        }
+    });
+
+    // Add alias form
+    $("#add-alias-form").submit(function(e) {
+        e.preventDefault();
+        var alias = $(this).find("input[name='alias']").val().trim();
+        var canonicalName = $(this).find("input[name='canonical_name']").val().trim();
+        if (!alias || !canonicalName) {
+            showNotification("{% trans %}Alias and canonical name required{% endtrans %}", "is-warning");
+            return;
+        }
+        $.post("/admin/history/aliases", { alias: alias, canonical_name: canonicalName }, function(data) {
+            if (data.success) {
+                showNotification(data.message, "is-success");
+                location.reload();
+            } else {
+                showNotification(data.message, "is-danger");
+            }
+        }).fail(function(xhr) {
+            var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+            showNotification(msg, "is-danger");
+        });
+    });
+
+    // Delete alias
+    $(".delete-alias-btn").click(function(e) {
+        e.preventDefault();
+        var alias = $(this).data("alias");
+        if (confirm("{% trans %}Remove alias{% endtrans %} '" + alias + "'?")) {
+            $.ajax({
+                url: "/admin/history/aliases/" + encodeURIComponent(alias),
+                type: "DELETE",
+                success: function(data) {
+                    if (data.success) {
+                        showNotification(data.message, "is-success");
+                        location.reload();
+                    } else {
+                        showNotification(data.message, "is-danger");
+                    }
+                },
+                error: function(xhr) {
+                    var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+                    showNotification(msg, "is-danger");
+                }
+            });
+        }
+    });
+});
+</script>
+<style>
+    .session-table td {
+        vertical-align: middle;
+    }
+    .action-buttons a, .action-buttons button {
+        margin-right: 0.5rem;
+    }
+</style>
+{% endblock %}
+
+{% block header %}
+<h1>{% block title %}{% trans %}Manage History{% endtrans %}{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+
+<div class="box">
+    <h2 class="subtitle">{% trans %}Sessions{% endtrans %}</h2>
+    
+    {% if sessions %}
+    <table class="table is-striped is-hoverable is-fullwidth session-table">
+        <thead>
+            <tr>
+                <th>{% trans %}Select{% endtrans %}</th>
+                <th>{% trans %}Name{% endtrans %}</th>
+                <th>{% trans %}Started{% endtrans %}</th>
+                <th>{% trans %}Actions{% endtrans %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for session in sessions %}
+            <tr>
+                <td>
+                    <input type="checkbox" class="merge-source" value="{{ session.session_id }}">
+                </td>
+                <td>{{ session.name }}</td>
+                <td>{{ session.started_at[:16] if session.started_at else '' }}</td>
+                <td class="action-buttons">
+                    <a href="#" class="button is-small is-info edit-session-btn" 
+                       data-session-id="{{ session.session_id }}"
+                       data-session-name="{{ session.name }}"
+                       title="{% trans %}Edit name{% endtrans %}">
+                        <i class="icon icon-edit"></i>
+                    </a>
+                    <a href="#" class="button is-small is-danger delete-session-btn"
+                       data-session-id="{{ session.session_id }}"
+                       data-session-name="{{ session.name }}"
+                       title="{% trans %}Delete session{% endtrans %}">
+                        <i class="icon icon-trash"></i>
+                    </a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    
+    <h3 class="subtitle is-5">{% trans %}Merge Sessions{% endtrans %}</h3>
+    <form id="merge-form">
+        <div class="field">
+            <label class="label">{% trans %}Target Session (merge into){% endtrans %}</label>
+            <div class="control">
+                <div class="select">
+                    <select id="merge-target" name="target_session">
+                        <option value="">{% trans %}Select target...{% endtrans %}</option>
+                        {% for session in sessions %}
+                        <option value="{{ session.session_id }}">{{ session.name }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+            <p class="help">{% trans %}Select checkboxes above for source sessions to merge{% endtrans %}</p>
+        </div>
+        <div class="field">
+            <div class="control">
+                <button type="submit" class="button is-warning">
+                    {% trans %}Merge Selected Sessions{% endtrans %}
+                </button>
+            </div>
+        </div>
+    </form>
+    {% else %}
+    <div class="notification is-info">
+        {% trans %}No sessions found.{% endtrans %}
+    </div>
+    {% endif %}
+</div>
+
+<div class="box">
+    <h2 class="subtitle">{% trans %}User Aliases{% endtrans %}</h2>
+    
+    <h3 class="subtitle is-5">{% trans %}Add New Alias{% endtrans %}</h3>
+    <form id="add-alias-form" class="mb-4">
+        <div class="columns">
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Alias{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input" type="text" name="alias" placeholder="{% trans %}Alias name{% endtrans %}" required>
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Canonical User{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input" type="text" name="canonical_name" list="user-list" placeholder="{% trans %}Canonical user name{% endtrans %}" required>
+                        <datalist id="user-list">
+                            {% for user in distinct_users %}
+                            <option value="{{ user }}">
+                            {% endfor %}
+                        </datalist>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <button type="submit" class="button is-success">{% trans %}Add{% endtrans %}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+    
+    {% if aliases %}
+    <table class="table is-striped is-hoverable is-fullwidth">
+        <thead>
+            <tr>
+                <th>{% trans %}Alias{% endtrans %}</th>
+                <th>{% trans %}Canonical User{% endtrans %}</th>
+                <th>{% trans %}Actions{% endtrans %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for a in aliases %}
+            <tr>
+                <td>{{ a.alias }}</td>
+                <td>{{ a.canonical_name }}</td>
+                <td class="action-buttons">
+                    <a href="#" class="button is-small is-danger delete-alias-btn"
+                       data-alias="{{ a.alias }}"
+                       title="{% trans %}Remove alias{% endtrans %}">
+                        <i class="icon icon-trash"></i>
+                    </a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="notification is-info">
+        {% trans %}No aliases defined. When users sign up with different names, you can map them to a canonical user here.{% endtrans %}
+    </div>
+    {% endif %}
+</div>
+
+<p>
+    <a href="{{ url_for('history.history') }}" class="button">
+        {% trans %}Back to History{% endtrans %}
+    </a>
+</p>
+
+{% endblock %}

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -122,6 +122,9 @@
       if (currentPath == "/browse") {
         $("#browse").addClass("is-active")
       }
+      if (currentPath.startsWith("/history")) {
+        $("#history").addClass("is-active")
+      }
       if (currentPath == "/info") {
         $("#info").addClass("is-active")
       }
@@ -213,6 +216,11 @@
           <i class="icon icon-folder-open-empty" title="Browse"></i>
           {# MSG: Navigation link for the page where the user can add existing songs to the queue. #}
           <span>{% trans %}Browse{% endtrans %}</span>
+        </a>
+        <a id="history" class="navbar-item" href="{{ url_for('history.history') }}">
+          <i class="icon icon-list-alt" title="History"></i>
+          {# MSG: Navigation link for the play history page. #}
+          <span>{% trans %}History{% endtrans %}</span>
         </a>
         <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
           <span aria-hidden="true"></span>

--- a/pikaraoke/templates/history.html
+++ b/pikaraoke/templates/history.html
@@ -1,0 +1,450 @@
+{% extends 'base.html' %}
+
+{% block scripts %}
+<style>
+    /* Calendar session highlighting */
+    .date-with-sessions {
+        background-color: #e8f5e9 !important;
+        border: 2px solid #4caf50 !important;
+    }
+    .session-date-info {
+        display: none;
+        position: absolute;
+        background: #333;
+        color: #fff;
+        padding: 5px 10px;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        z-index: 100;
+        white-space: nowrap;
+    }
+    .action-buttons a {
+        margin-right: 0.25rem;
+    }
+</style>
+<script>
+$(function() {
+    // Handle "Add to queue" clicks
+    $("a.add-song-link").click(function(e) {
+        e.preventDefault();
+        setUserCookie();
+        var user = Cookies.get("user") || "History";
+        var songTitle = $(this).data("song-title");
+        $.post("/queue/add_by_title", { song_title: songTitle, user: user }, function(data) {
+            var obj = typeof data === 'string' ? JSON.parse(data) : data;
+            if (obj.success[0]) {
+                showNotification(obj.success[1], "is-success");
+            } else {
+                showNotification(obj.success[1], "is-danger");
+            }
+        });
+    });
+
+    // Handle "Delete play" clicks
+    $("a.delete-play-btn").click(function(e) {
+        e.preventDefault();
+        setUserCookie();
+        var playId = $(this).data("play-id");
+        var displayName = $(this).data("display-name");
+        var user = Cookies.get("user") || "";
+        var row = $(this).closest("tr");
+        if (confirm("{% trans %}Delete this play from history?{% endtrans %}")) {
+            $.ajax({
+                url: "/history/play/" + playId + "?user=" + encodeURIComponent(user),
+                type: "DELETE",
+                success: function(data) {
+                    if (data.success) {
+                        showNotification(data.message, "is-success");
+                        row.fadeOut(300, function() { $(this).remove(); });
+                    } else {
+                        showNotification(data.message, "is-danger");
+                    }
+                },
+                error: function(xhr) {
+                    var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+                    showNotification(msg, "is-danger");
+                }
+            });
+        }
+    });
+
+    // Handle "Edit play" clicks (admin only)
+    $("a.edit-play-btn").click(function(e) {
+        e.preventDefault();
+        var playId = $(this).data("play-id");
+        var currentName = $(this).data("display-name");
+        var newName = prompt("{% trans %}Enter new user/display name:{% endtrans %}", currentName);
+        if (newName && newName.trim() !== currentName) {
+            $.post("/admin/history/plays/" + playId + "/user", { display_name: newName.trim() }, function(data) {
+                if (data.success) {
+                    showNotification(data.message, "is-success");
+                    location.reload();
+                } else {
+                    showNotification(data.message, "is-danger");
+                }
+            }).fail(function(xhr) {
+                var msg = xhr.responseJSON ? xhr.responseJSON.message : "Error";
+                showNotification(msg, "is-danger");
+            });
+        }
+    });
+
+    // Handle filter form submission
+    $("#filter-form").on("submit", function(e) {
+        // Remove empty fields from submission to keep URLs clean
+        $(this).find("input, select").each(function() {
+            if (!$(this).val()) {
+                $(this).attr("disabled", true);
+            }
+        });
+    });
+
+    // Load session dates for calendar highlighting
+    var sessionDates = {};
+    $.get("/history/api/session-dates", function(data) {
+        if (data.success) {
+            sessionDates = data.dates;
+            updateDateInfo();
+        }
+    });
+
+    // Show session info when date inputs change
+    function updateDateInfo() {
+        var dateFrom = $("input[name='date_from']").val();
+        var dateTo = $("input[name='date_to']").val();
+        
+        // Show info for from date
+        if (dateFrom && sessionDates[dateFrom]) {
+            var sessions = sessionDates[dateFrom].join(", ");
+            $(".date-from-info").text("{% trans %}Sessions{% endtrans %}: " + sessions).show();
+        } else {
+            $(".date-from-info").hide();
+        }
+        
+        // Show info for to date
+        if (dateTo && sessionDates[dateTo]) {
+            var sessions = sessionDates[dateTo].join(", ");
+            $(".date-to-info").text("{% trans %}Sessions{% endtrans %}: " + sessions).show();
+        } else {
+            $(".date-to-info").hide();
+        }
+    }
+
+    $("input[name='date_from'], input[name='date_to']").on("change", updateDateInfo);
+});
+</script>
+<style>
+    .history-table {
+        width: 100%;
+        font-size: 0.9rem;
+        table-layout: auto;
+    }
+    .history-table th {
+        cursor: pointer;
+        white-space: nowrap;
+        padding: 0.4rem 0.5rem;
+    }
+    .history-table th:hover {
+        background-color: #f0f0f0;
+    }
+    .history-table td {
+        padding: 0.3rem 0.5rem;
+        vertical-align: middle;
+        line-height: 1.4;
+    }
+    .history-table td a {
+        line-height: inherit;
+    }
+    /* Fixed-width columns for compact display */
+    .history-table .col-datetime {
+        white-space: nowrap;
+        width: 1%;
+    }
+    .history-table .col-session {
+        white-space: nowrap;
+        max-width: 100px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .history-table .col-user {
+        white-space: nowrap;
+        max-width: 120px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .history-table .col-song {
+        /* Song column gets remaining space */
+    }
+    .history-table .col-actions {
+        white-space: nowrap;
+        width: 1%;
+    }
+    /* Compact action buttons */
+    .history-table .action-buttons {
+        display: flex;
+        gap: 0.15rem;
+    }
+    .history-table .action-buttons a {
+        padding: 0.1rem;
+        margin: 0;
+    }
+    .filter-form {
+        margin-bottom: 1rem;
+    }
+    .filter-form .columns {
+        margin-bottom: 0.5rem;
+    }
+    .filter-form .columns:last-of-type {
+        margin-bottom: 0;
+    }
+    .sort-indicator {
+        margin-left: 0.25rem;
+    }
+    /* Skipped song indicator */
+    .skipped-indicator {
+        margin-left: 0.3rem;
+        font-size: 0.85em;
+        cursor: help;
+    }
+</style>
+{% endblock %}
+
+{% block header %}
+<h1>{% block title %}{% trans %}Play History{% endtrans %}{% endblock %}</h1>
+<div class="buttons">
+    <button class="button is-info" disabled>
+        <i class="icon icon-clock"></i>
+        <span>{% trans %}History{% endtrans %}</span>
+    </button>
+    <a href="{{ url_for('history.rankings') }}" class="button is-info is-outlined">
+        <i class="icon icon-sort-up"></i>
+        <span>{% trans %}Rankings{% endtrans %}</span>
+    </a>
+    <a href="{{ url_for('history.performers') }}" class="button is-info is-outlined">
+        <i class="icon icon-mic-1"></i>
+        <span>{% trans %}Performers{% endtrans %}</span>
+    </a>
+    {% if admin %}
+    <a href="{{ url_for('admin_history.admin_history') }}" class="button is-warning is-outlined">
+        <i class="icon icon-cog"></i>
+        <span>{% trans %}Manage{% endtrans %}</span>
+    </a>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block content %}
+
+{# Filter Form - Rankings-style first row #}
+<div class="box filter-form">
+    <form id="filter-form" method="get" action="{{ url_for('history.history') }}">
+        {# Row 1: Date range, Session, Show, Apply (Rankings pattern) #}
+        <div class="columns">
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Date From{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="date" name="date_from" value="{{ date_from }}">
+                    </div>
+                    <p class="help date-from-info has-text-success" style="display:none;"></p>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Date To{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="date" name="date_to" value="{{ date_to }}">
+                    </div>
+                    <p class="help date-to-info has-text-success" style="display:none;"></p>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Session{% endtrans %}</label>
+                    <div class="control">
+                        <div class="select is-small is-fullwidth">
+                            <select name="session_id">
+                                <option value="">{% trans %}All Sessions{% endtrans %}</option>
+                                {% for session in sessions %}
+                                <option value="{{ session.session_id }}" {% if session_id == session.session_id %}selected{% endif %}>{{ session.name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Results{% endtrans %}</label>
+                    <div class="control">
+                        <div class="select is-small is-fullwidth">
+                            <select name="limit">
+                                <option value="20" {% if limit == 20 %}selected{% endif %}>20</option>
+                                <option value="50" {% if limit == 50 %}selected{% endif %}>50</option>
+                                <option value="100" {% if limit == 100 %}selected{% endif %}>100</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <a href="{{ url_for('history.history') }}" class="button is-primary is-small">{% trans %}Clear{% endtrans %}</a>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <button type="submit" class="button is-primary is-small">{% trans %}Apply{% endtrans %}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {# Row 2: User, Song (full width) #}
+        <div class="columns">
+            <div class="column is-2">
+                <div class="field">
+                    <label class="label">{% trans %}User{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="text" name="user" value="{{ user_filter }}" list="users-list" placeholder="{% trans %}All{% endtrans %}">
+                        <datalist id="users-list">{% for user in distinct_users %}<option value="{{ user }}">{% endfor %}</datalist>
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Song{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="text" name="song" value="{{ song_filter }}" placeholder="{% trans %}Filter by song title{% endtrans %}">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <input type="hidden" name="sort_by" value="{{ sort_by }}">
+        <input type="hidden" name="sort_order" value="{{ sort_order }}">
+    </form>
+</div>
+
+{# Results summary and pagination #}
+{% if pagination %}
+{{ pagination.links }}
+{{ pagination.info }}
+{% endif %}
+
+{# History Table #}
+{% if plays %}
+<table class="history-table">
+    <thead>
+        <tr>
+            {# Sortable headers - clicking toggles sort order #}
+            {% macro sort_header(column, label, css_class='') %}
+            {% set new_order = 'ASC' if sort_by == column and sort_order == 'DESC' else 'DESC' %}
+            <th class="{{ css_class }}">
+                <a href="{{ url_for('history.history', 
+                    date_from=date_from, date_to=date_to, session_id=session_id, 
+                    sessions_count=sessions_count, user=user_filter, song=song_filter, limit=limit,
+                    sort_by=column, sort_order=new_order) }}">
+                    {{ label }}
+                    {% if sort_by == column %}
+                    <span class="sort-indicator">{% if sort_order == 'DESC' %}&#9660;{% else %}&#9650;{% endif %}</span>
+                    {% endif %}
+                </a>
+            </th>
+            {% endmacro %}
+            
+            {{ sort_header('timestamp', _('Date/Time'), 'col-datetime') }}
+            <th class="col-session">{% trans %}Session{% endtrans %}</th>
+            {{ sort_header('canonical_name', _('User'), 'col-user') }}
+            {{ sort_header('song', _('Song'), 'col-song') }}
+            <th class="col-actions">{% trans %}Actions{% endtrans %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for play in plays %}
+        <tr>
+            <td class="col-datetime">{{ play.timestamp[:16] if play.timestamp else '' }}</td>
+            <td class="col-session" title="{{ play.session_name or '' }}">
+                <a href="{{ url_for('history.history', 
+                    session_id=play.session_id,
+                    date_from=date_from, date_to=date_to, 
+                    user=user_filter, song=song_filter, limit=limit,
+                    sort_by=sort_by, sort_order=sort_order) }}">
+                    {{ play.session_name or '' }}
+                </a>
+            </td>
+            <td class="col-user" title="{{ play.display_name or play.canonical_name }}">
+                <a href="{{ url_for('history.history', user=play.canonical_name,
+                    date_from=date_from, date_to=date_to, session_id=session_id,
+                    sessions_count=sessions_count, song=song_filter, limit=limit,
+                    sort_by=sort_by, sort_order=sort_order) }}">
+                    {{ play.display_name or play.canonical_name }}
+                </a>
+            </td>
+            <td class="col-song">
+                <a href="{{ url_for('history.history', 
+                    song=play.song,
+                    date_from=date_from, date_to=date_to, 
+                    session_id=session_id, sessions_count=sessions_count,
+                    limit=limit, sort_by=sort_by, sort_order=sort_order) }}">
+                    {{ play.song }}
+                </a>
+                {% if not play.completed %}
+                <i class="icon icon-info-circled has-text-warning skipped-indicator" 
+                   title="{% trans %}Song was skipped{% endtrans %}"></i>
+                {% endif %}
+            </td>
+            <td class="col-actions action-buttons">
+                <a class="add-song-link has-text-success" href="#"
+                   data-song-title="{{ play.song }}"
+                   title="{% trans %}Add to queue{% endtrans %}">
+                    <i class="icon icon-list-add"></i>
+                </a>
+                {% if admin %}
+                <a class="edit-play-btn has-text-info" href="#"
+                   data-play-id="{{ play.id }}"
+                   data-display-name="{{ play.display_name }}"
+                   title="{% trans %}Edit user{% endtrans %}">
+                    <i class="icon icon-edit"></i>
+                </a>
+                {% endif %}
+                <a class="delete-play-btn has-text-danger" href="#"
+                   data-play-id="{{ play.id }}"
+                   data-display-name="{{ play.display_name }}"
+                   title="{% trans %}Delete play{% endtrans %}">
+                    <i class="icon icon-trash"></i>
+                </a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% if pagination %}
+{{ pagination.links }}
+{% endif %}
+
+{% else %}
+<div class="notification is-info">
+    {% trans %}No play history found.{% endtrans %}
+    {% if date_from or date_to or session_id or user_filter or song_filter %}
+    <a href="{{ url_for('history.history') }}">{% trans %}Clear filters{% endtrans %}</a>
+    {% endif %}
+</div>
+{% endif %}
+
+{% if admin %}
+<div class="box">
+    <h2 class="subtitle">{% trans %}Admin Actions{% endtrans %}</h2>
+    <p>
+        <a href="{{ url_for('admin_history.admin_history') }}" class="button is-small">
+            {% trans %}Manage History{% endtrans %}
+        </a>
+    </p>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/pikaraoke/templates/performers.html
+++ b/pikaraoke/templates/performers.html
@@ -1,0 +1,172 @@
+{% extends 'base.html' %}
+
+{% block scripts %}
+<style>
+    .alias-tag {
+        margin-right: 0.25rem;
+        margin-bottom: 0.25rem;
+    }
+    .performers-table {
+        width: 100%;
+        table-layout: auto;
+        background-color: transparent;
+        border: none;
+    }
+    .performers-table td,
+    .performers-table th {
+        padding: 5px 0.5rem;
+        vertical-align: middle;
+        border: none;
+    }
+    .performers-table th {
+        font-weight: bold;
+        text-align: left;
+    }
+</style>
+{% endblock %}
+
+{% block header %}
+<h1>{% block title %}{% trans %}Play History{% endtrans %}: {% trans %}Performers{% endtrans %}{% endblock %}</h1>
+<div class="buttons">
+    <a href="{{ url_for('history.history') }}" class="button is-info is-outlined">
+        <i class="icon icon-clock"></i>
+        <span>{% trans %}History{% endtrans %}</span>
+    </a>
+    <a href="{{ url_for('history.rankings') }}" class="button is-info is-outlined">
+        <i class="icon icon-sort-up"></i>
+        <span>{% trans %}Rankings{% endtrans %}</span>
+    </a>
+    <button class="button is-info" disabled>
+        <i class="icon icon-mic-1"></i>
+        <span>{% trans %}Performers{% endtrans %}</span>
+    </button>
+    {% if admin %}
+    <a href="{{ url_for('admin_history.admin_history') }}" class="button is-warning is-outlined">
+        <i class="icon icon-cog"></i>
+        <span>{% trans %}Manage{% endtrans %}</span>
+    </a>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block content %}
+
+<!-- Filter Form -->
+<div class="box">
+    <form method="GET" action="{{ url_for('history.performers') }}">
+        <div class="columns">
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Date From{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="date" name="date_from" value="{{ date_from }}">
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Date To{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="date" name="date_to" value="{{ date_to }}">
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Sort By{% endtrans %}</label>
+                    <div class="control">
+                        <div class="select is-fullwidth">
+                            <select name="sort_by">
+                                <option value="play_count" {% if sort_by == 'play_count' %}selected{% endif %}>{% trans %}Play Count{% endtrans %}</option>
+                                <option value="canonical_name" {% if sort_by == 'canonical_name' %}selected{% endif %}>{% trans %}Name{% endtrans %}</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Order{% endtrans %}</label>
+                    <div class="control">
+                        <div class="select is-fullwidth">
+                            <select name="sort_order">
+                                <option value="DESC" {% if sort_order == 'DESC' %}selected{% endif %}>{% trans %}Descending{% endtrans %}</option>
+                                <option value="ASC" {% if sort_order == 'ASC' %}selected{% endif %}>{% trans %}Ascending{% endtrans %}</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <a href="{{ url_for('history.performers') }}" class="button is-primary is-small">{% trans %}Clear{% endtrans %}</a>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <button type="submit" class="button is-primary is-small">{% trans %}Apply{% endtrans %}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+{% if performers %}
+<div class="box">
+    <p class="mb-3">{% trans %}Total{% endtrans %}: <strong>{{ total_count }}</strong> {% trans %}performers{% endtrans %}</p>
+
+    <table class="performers-table">
+        <thead>
+            <tr>
+                <th>{% trans %}Name{% endtrans %}</th>
+                <th>{% trans %}Songs Played{% endtrans %}</th>
+                <th>{% trans %}Aliases{% endtrans %}</th>
+                <th>{% trans %}Actions{% endtrans %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for performer in performers %}
+            <tr>
+                <td>
+                    <a href="{{ url_for('history.history', user=performer.canonical_name, date_from=date_from, date_to=date_to) }}">
+                        {{ performer.canonical_name }}
+                    </a>
+                </td>
+                <td>{{ performer.play_count }}</td>
+                <td>
+                    {% for alias in performer.aliases %}
+                    <a href="{{ url_for('history.history', user=performer.canonical_name, alias=alias, date_from=date_from, date_to=date_to) }}" 
+                       class="tag is-light alias-tag" title="{% trans %}View plays as{% endtrans %} {{ alias }}">
+                        {{ alias }}
+                    </a>
+                    {% endfor %}
+                    {% if not performer.aliases %}
+                    <span class="has-text-grey-light">-</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <a href="{{ url_for('history.history', user=performer.canonical_name, date_from=date_from, date_to=date_to) }}" class="button is-small is-info" title="{% trans %}View history{% endtrans %}">
+                        <i class="icon icon-search-1"></i>
+                    </a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {{ pagination.links }}
+</div>
+{% else %}
+<div class="notification is-info">
+    {% trans %}No performers found.{% endtrans %}
+</div>
+{% endif %}
+
+
+{% endblock %}

--- a/pikaraoke/templates/rankings.html
+++ b/pikaraoke/templates/rankings.html
@@ -1,0 +1,355 @@
+{% extends 'base.html' %}
+
+{% block scripts %}
+<style>
+    .ranking-table {
+        margin: 0 auto;
+        width: auto;
+        max-width: 800px;
+        background-color: transparent;
+        border: none;
+    }
+    .ranking-table td {
+        padding: 5px 0.75rem;
+        white-space: nowrap;
+        vertical-align: middle;
+        border: none;
+    }
+    .ranking-table .col-name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 500px;
+        min-width: 200px;
+    }
+    .ranking-table .col-count {
+        text-align: right;
+        white-space: nowrap;
+        min-width: 50px;
+    }
+    .ranking-number {
+        font-weight: bold;
+        width: 2em;
+        text-align: center;
+    }
+    .collapsible-section {
+        margin-bottom: 1px;
+    }
+    .collapsible-section.box {
+        padding: 0.4rem 0.75rem;
+    }
+    .collapsible-header {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        user-select: none;
+        min-height: 0;
+        padding: 0;
+    }
+    .collapsible-header .toggle-btn {
+        margin: 0 0.5rem 0 0;
+        padding: 0.2rem 0.35rem;
+        border: none;
+        background: transparent;
+        line-height: 1;
+        height: auto;
+        min-height: 0;
+        flex-shrink: 0;
+        align-self: center;
+    }
+    .collapsible-header .toggle-btn:hover {
+        background: transparent;
+    }
+    .collapsible-header .collapsible-title {
+        margin: 0;
+        padding: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        line-height: 1.25;
+        align-self: center;
+    }
+    .collapsible-content {
+        margin-top: 0.25rem;
+        margin-bottom: 0;
+        display: flex;
+        justify-content: center;
+    }
+    .toggle-btn i {
+        transition: transform 0.2s ease;
+        display: inline-block;
+    }
+    .toggle-btn.expanded i {
+        transform: rotate(90deg);
+    }
+</style>
+
+<script>
+function toggleSection(header) {
+    const content = header.nextElementSibling;
+    const toggleBtn = header.querySelector('.toggle-btn');
+    
+    if (content.style.display === 'none' || content.style.display === '') {
+        content.style.display = 'flex';
+        toggleBtn.classList.add('expanded');
+    } else {
+        content.style.display = 'none';
+        toggleBtn.classList.remove('expanded');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    const showAllBtn = document.getElementById('show-all-btn');
+    const showAllText = "{{ _('Show All') }}";
+    const hideAllText = "{{ _('Hide All') }}";
+    
+    if (showAllBtn) {
+        showAllBtn.addEventListener('click', function() {
+            const allSections = document.querySelectorAll('.collapsible-section');
+            const allExpanded = Array.from(allSections).every(section => {
+                const content = section.querySelector('.collapsible-content');
+                return content.style.display === 'flex';
+            });
+            
+            allSections.forEach(section => {
+                const content = section.querySelector('.collapsible-content');
+                const toggleBtn = section.querySelector('.toggle-btn');
+                
+                if (allExpanded) {
+                    content.style.display = 'none';
+                    toggleBtn.classList.remove('expanded');
+                } else {
+                    content.style.display = 'flex';
+                    toggleBtn.classList.add('expanded');
+                }
+            });
+            
+            // Update button text and icon
+            if (allExpanded) {
+                showAllBtn.querySelector('span').textContent = showAllText;
+                showAllBtn.querySelector('.icon').className = 'icon icon-down-big';
+            } else {
+                showAllBtn.querySelector('span').textContent = hideAllText;
+                showAllBtn.querySelector('.icon').className = 'icon icon-up-big';
+            }
+        });
+    }
+});
+</script>
+{% endblock %}
+
+{% block header %}
+<h1>{% block title %}{% trans %}Play History{% endtrans %}: {% trans %}Rankings{% endtrans %}{% endblock %}</h1>
+<div class="buttons">
+    <a href="{{ url_for('history.history') }}" class="button is-info is-outlined">
+        <i class="icon icon-clock"></i>
+        <span>{% trans %}History{% endtrans %}</span>
+    </a>
+    <button class="button is-info" disabled>
+        <i class="icon icon-sort-up"></i>
+        <span>{% trans %}Rankings{% endtrans %}</span>
+    </button>
+    <a href="{{ url_for('history.performers') }}" class="button is-info is-outlined">
+        <i class="icon icon-mic-1"></i>
+        <span>{% trans %}Performers{% endtrans %}</span>
+    </a>
+    {% if admin %}
+    <a href="{{ url_for('admin_history.admin_history') }}" class="button is-warning is-outlined">
+        <i class="icon icon-cog"></i>
+        <span>{% trans %}Manage{% endtrans %}</span>
+    </a>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block content %}
+
+<!-- Filter Form -->
+<div class="box">
+    <form method="GET" action="{{ url_for('history.rankings') }}">
+        <div class="columns">
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Date From{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="date" name="date_from" value="{{ date_from }}">
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Date To{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="date" name="date_to" value="{{ date_to }}">
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Last N Sessions{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="number" name="sessions_count" value="{{ sessions_count }}" min="1" placeholder="e.g., 5">
+                    </div>
+                </div>
+            </div>
+            <div class="column">
+                <div class="field">
+                    <label class="label">{% trans %}Results{% endtrans %}</label>
+                    <div class="control">
+                        <input class="input is-small" type="number" name="limit" value="{{ limit }}" min="1" max="100">
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <a href="{{ url_for('history.rankings') }}" class="button is-primary is-small">{% trans %}Clear{% endtrans %}</a>
+                    </div>
+                </div>
+            </div>
+            <div class="column is-narrow">
+                <div class="field">
+                    <label class="label">&nbsp;</label>
+                    <div class="control">
+                        <button type="submit" class="button is-primary is-small">{% trans %}Apply{% endtrans %}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+<!-- Show All Button -->
+<div class="box">
+    <button id="show-all-btn" class="button is-primary is-small">
+        <i class="icon icon-down-big"></i>
+        <span>{% trans %}Show All{% endtrans %}</span>
+    </button>
+</div>
+
+<!-- Top Performers -->
+<div class="box collapsible-section">
+    <div class="collapsible-header" onclick="toggleSection(this)">
+        <button class="button is-small is-text toggle-btn">
+            <i class="icon icon-right-big"></i>
+        </button>
+        <span class="collapsible-title">{% trans %}Top Performers{% endtrans %}</span>
+    </div>
+    <div class="collapsible-content" style="display: none;">
+        {% if top_users %}
+        <table class="ranking-table">
+            <tbody>
+                {% for user in top_users %}
+                <tr>
+                    <td class="ranking-number">{{ loop.index }}</td>
+                    <td class="col-name">
+                        <a href="{{ url_for('history.history', user=user.canonical_name, date_from=date_from, date_to=date_to) }}">
+                            {{ user.canonical_name }}
+                        </a>
+                    </td>
+                    <td class="col-count">{{ user.play_count }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="has-text-grey">{% trans %}No data available{% endtrans %}</p>
+        {% endif %}
+    </div>
+</div>
+
+<!-- Most Requested Songs -->
+<div class="box collapsible-section">
+    <div class="collapsible-header" onclick="toggleSection(this)">
+        <button class="button is-small is-text toggle-btn">
+            <i class="icon icon-right-big"></i>
+        </button>
+        <span class="collapsible-title">{% trans %}Most Requested Songs{% endtrans %}</span>
+    </div>
+    <div class="collapsible-content" style="display: none;">
+        {% if top_songs %}
+        <table class="ranking-table">
+            <tbody>
+                {% for song in top_songs %}
+                <tr>
+                    <td class="ranking-number">{{ loop.index }}</td>
+                    <td class="col-name">
+                        <a href="{{ url_for('history.history', song=song.song, date_from=date_from, date_to=date_to) }}">
+                            {{ song.song }}
+                        </a>
+                    </td>
+                    <td class="col-count">{{ song.play_count }}x</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="has-text-grey">{% trans %}No data available{% endtrans %}</p>
+        {% endif %}
+    </div>
+</div>
+
+<!-- Busiest Sessions -->
+<div class="box collapsible-section">
+    <div class="collapsible-header" onclick="toggleSection(this)">
+        <button class="button is-small is-text toggle-btn">
+            <i class="icon icon-right-big"></i>
+        </button>
+        <span class="collapsible-title">{% trans %}Busiest Sessions{% endtrans %}</span>
+    </div>
+    <div class="collapsible-content" style="display: none;">
+        {% if busiest_sessions %}
+        <table class="ranking-table">
+            <tbody>
+                {% for sess in busiest_sessions %}
+                <tr>
+                    <td class="ranking-number">{{ loop.index }}</td>
+                    <td class="col-name">
+                        <a href="{{ url_for('history.history', session_id=sess.session_id, date_from=date_from, date_to=date_to) }}">
+                            {{ sess.session_name or sess.session_id[:8] }}
+                        </a>
+                    </td>
+                    <td class="col-count">{{ sess.play_count }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="has-text-grey">{% trans %}No data available{% endtrans %}</p>
+        {% endif %}
+    </div>
+</div>
+
+<!-- Busiest Days -->
+<div class="box collapsible-section">
+    <div class="collapsible-header" onclick="toggleSection(this)">
+        <button class="button is-small is-text toggle-btn">
+            <i class="icon icon-right-big"></i>
+        </button>
+        <span class="collapsible-title">{% trans %}Busiest Days{% endtrans %}</span>
+    </div>
+    <div class="collapsible-content" style="display: none;">
+        {% if busiest_days %}
+        <table class="ranking-table">
+            <tbody>
+                {% for day in busiest_days %}
+                <tr>
+                    <td class="ranking-number">{{ loop.index }}</td>
+                    <td class="col-name">
+                        <a href="{{ url_for('history.history', date_from=day.date, date_to=day.date) }}">
+                            {{ day.date }}
+                        </a>
+                    </td>
+                    <td class="col-count">{{ day.play_count }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="has-text-grey">{% trans %}No data available{% endtrans %}</p>
+        {% endif %}
+    </div>
+</div>
+
+
+{% endblock %}

--- a/pikaraoke/templates/splash.html
+++ b/pikaraoke/templates/splash.html
@@ -95,7 +95,6 @@
   <div id="qr-code">
     <img
       src="{{ url_for('images.qrcode') }}"
-      width="100px"
       style="image-rendering: pixelated"
       alt="qrcode"
     />
@@ -204,11 +203,9 @@
   <div id="screensaver" style="visibility: hidden">
     <div id="dvd">
       {% if not hide_url %}
-      <div>
-        <div style="text-align: right">
-          <img src="{{ url_for('images.qrcode') }}" width="30%" height="30%" />
-        </div>
-        <div>{{ hostap_info[0] }}<br />{{ url }}</div>
+      <div class="qr-container">
+        <img src="{{ url_for('images.qrcode') }}" alt="QR code" />
+        <div class="qr-url">{{ url }}</div>
       </div>
       {% endif %}
     </div>
@@ -267,7 +264,11 @@
     align-items: flex-end;
   }
   #qr-code {
-    max-width: 25%;
+    max-width: 20vw;
+  }
+  #qr-code img {
+    width: 18vw;
+    min-width: 150px;
   }
   #up-next {
     max-width: 75%;

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,706 @@
+"""Tests for the PlayDatabase class."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from pikaraoke.lib.database import PlayDatabase
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database for testing."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    db = PlayDatabase(db_path)
+    yield db
+    # Cleanup
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+@pytest.fixture
+def temp_db_path():
+    """Create a temporary path for database testing."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    yield db_path
+    # Cleanup
+    if os.path.exists(db_path):
+        os.unlink(db_path)
+
+
+class TestDatabaseSchema:
+    """Tests for database schema creation."""
+
+    def test_init_creates_tables(self, temp_db):
+        """Test that init_db creates all required tables."""
+        import sqlite3
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            )
+            tables = [row[0] for row in cursor.fetchall()]
+
+        assert "users" in tables
+        assert "user_aliases" in tables
+        assert "sessions" in tables
+        assert "plays" in tables
+
+    def test_init_creates_indexes(self, temp_db):
+        """Test that init_db creates required indexes."""
+        import sqlite3
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name"
+            )
+            indexes = [row[0] for row in cursor.fetchall()]
+
+        assert "idx_plays_canonical_name" in indexes
+        assert "idx_plays_timestamp" in indexes
+        assert "idx_plays_session_id" in indexes
+
+
+class TestIntegrityCheck:
+    """Tests for database integrity checking."""
+
+    def test_check_integrity_on_valid_db(self, temp_db):
+        """Test integrity check passes on valid database."""
+        is_ok, message = temp_db.check_integrity()
+        assert is_ok is True
+        assert "passed" in message.lower()
+
+    def test_check_and_recover_creates_new_db(self, temp_db_path):
+        """Test that check_and_recover returns True for non-existent db."""
+        # Remove the temp file first
+        if os.path.exists(temp_db_path):
+            os.unlink(temp_db_path)
+
+        result = PlayDatabase.check_and_recover_db(temp_db_path, force_recreate=False)
+        assert result is True
+
+    def test_check_and_recover_passes_on_valid_db(self, temp_db):
+        """Test that check_and_recover passes on valid database."""
+        result = PlayDatabase.check_and_recover_db(temp_db.db_path, force_recreate=False)
+        assert result is True
+
+
+class TestSessionManagement:
+    """Tests for session management."""
+
+    def test_ensure_session_creates_session(self, temp_db):
+        """Test that ensure_session creates a new session."""
+        import sqlite3
+
+        session_id = "test-session-123"
+        temp_db.ensure_session(session_id, "Test Session")
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT session_id, name FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        assert row[0] == session_id
+        assert row[1] == "Test Session"
+
+    def test_ensure_session_uses_default_name(self, temp_db):
+        """Test that ensure_session uses date as default name."""
+        import sqlite3
+        from datetime import datetime
+
+        session_id = "test-session-456"
+        temp_db.ensure_session(session_id)
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+
+        # Default name should be today's date
+        expected_date = datetime.now().strftime("%Y-%m-%d")
+        assert row[0] == expected_date
+
+    def test_ensure_session_idempotent(self, temp_db):
+        """Test that ensure_session doesn't duplicate sessions."""
+        import sqlite3
+
+        session_id = "test-session-789"
+        temp_db.ensure_session(session_id, "First Name")
+        temp_db.ensure_session(session_id, "Second Name")
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            count = cursor.fetchone()[0]
+            cursor = conn.execute(
+                "SELECT name FROM sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            name = cursor.fetchone()[0]
+
+        assert count == 1
+        # Should keep the first name
+        assert name == "First Name"
+
+
+class TestUserResolution:
+    """Tests for user and alias resolution."""
+
+    def test_resolve_canonical_user_creates_user(self, temp_db):
+        """Test that resolving a new user creates it."""
+        import sqlite3
+
+        canonical = temp_db._resolve_canonical_user("NewUser")
+
+        assert canonical == "NewUser"
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT canonical_name FROM users WHERE canonical_name = ?",
+                ("NewUser",),
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+
+    def test_resolve_canonical_user_with_alias(self, temp_db):
+        """Test that resolving an alias returns the canonical name."""
+        import sqlite3
+
+        # First create a user and alias
+        with sqlite3.connect(temp_db.db_path) as conn:
+            conn.execute("INSERT INTO users (canonical_name) VALUES (?)", ("John",))
+            conn.execute(
+                "INSERT INTO user_aliases (alias, canonical_name) VALUES (?, ?)",
+                ("Johnny", "John"),
+            )
+            conn.commit()
+
+        canonical = temp_db._resolve_canonical_user("Johnny")
+
+        assert canonical == "John"
+
+
+class TestPlayRecords:
+    """Tests for play record management."""
+
+    def test_add_play_returns_id(self, temp_db):
+        """Test that add_play returns a valid play ID."""
+        session_id = "test-session"
+        temp_db.ensure_session(session_id)
+
+        play_id = temp_db.add_play("Test Song", "TestUser", session_id)
+
+        assert play_id is not None
+        assert isinstance(play_id, int)
+        assert play_id > 0
+
+    def test_add_play_stores_display_name(self, temp_db):
+        """Test that add_play stores the original display name."""
+        import sqlite3
+
+        session_id = "test-session"
+        temp_db.ensure_session(session_id)
+
+        # Create alias
+        with sqlite3.connect(temp_db.db_path) as conn:
+            conn.execute("INSERT INTO users (canonical_name) VALUES (?)", ("John",))
+            conn.execute(
+                "INSERT INTO user_aliases (alias, canonical_name) VALUES (?, ?)",
+                ("Johnny", "John"),
+            )
+            conn.commit()
+
+        play_id = temp_db.add_play("Test Song", "Johnny", session_id)
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT canonical_name, display_name FROM plays WHERE id = ?",
+                (play_id,),
+            )
+            row = cursor.fetchone()
+
+        assert row[0] == "John"  # Resolved canonical name
+        assert row[1] == "Johnny"  # Original display name
+
+    def test_add_play_defaults_incomplete(self, temp_db):
+        """Test that new plays default to incomplete."""
+        import sqlite3
+
+        session_id = "test-session"
+        temp_db.ensure_session(session_id)
+
+        play_id = temp_db.add_play("Test Song", "TestUser", session_id)
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT completed FROM plays WHERE id = ?",
+                (play_id,),
+            )
+            row = cursor.fetchone()
+
+        assert row[0] == 0  # Not completed
+
+    def test_update_play_sets_completed(self, temp_db):
+        """Test that update_play sets completion status."""
+        import sqlite3
+
+        session_id = "test-session"
+        temp_db.ensure_session(session_id)
+
+        play_id = temp_db.add_play("Test Song", "TestUser", session_id)
+        temp_db.update_play(play_id, completed=True)
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT completed FROM plays WHERE id = ?",
+                (play_id,),
+            )
+            row = cursor.fetchone()
+
+        assert row[0] == 1  # Completed
+
+    def test_update_play_skipped(self, temp_db):
+        """Test that update_play can mark a song as skipped."""
+        import sqlite3
+
+        session_id = "test-session"
+        temp_db.ensure_session(session_id)
+
+        play_id = temp_db.add_play("Test Song", "TestUser", session_id)
+        temp_db.update_play(play_id, completed=False)
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT completed FROM plays WHERE id = ?",
+                (play_id,),
+            )
+            row = cursor.fetchone()
+
+        assert row[0] == 0  # Not completed (skipped)
+
+    def test_get_play_returns_record(self, temp_db):
+        """Test that get_play returns the play record."""
+        session_id = "test-session"
+        temp_db.ensure_session(session_id, "Test Session Name")
+
+        play_id = temp_db.add_play("Test Song", "TestUser", session_id)
+        temp_db.update_play(play_id, completed=True)
+
+        play = temp_db.get_play(play_id)
+
+        assert play is not None
+        assert play["id"] == play_id
+        assert play["song"] == "Test Song"
+        assert play["canonical_name"] == "TestUser"
+        assert play["display_name"] == "TestUser"
+        assert play["session_id"] == session_id
+        assert play["session_name"] == "Test Session Name"
+        assert play["completed"] == 1
+
+    def test_get_play_not_found(self, temp_db):
+        """Test that get_play returns None for non-existent record."""
+        play = temp_db.get_play(99999)
+        assert play is None
+
+
+class TestKaraokeIntegration:
+    """Tests for Karaoke class integration with database."""
+
+    @patch("pikaraoke.lib.database.PlayDatabase.check_and_recover_db")
+    def test_start_song_calls_add_play(self, mock_check):
+        """Test that Karaoke.start_song calls db.add_play."""
+        mock_check.return_value = True
+
+        # Create a minimal mock karaoke instance
+        from unittest.mock import MagicMock
+
+        from pikaraoke.lib.database import PlayDatabase
+
+        # Create temp db
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            db = PlayDatabase(db_path)
+            db.ensure_session("test-session")
+
+            # Mock the add_play method
+            db.add_play = MagicMock(return_value=42)
+
+            # Simulate what karaoke.start_song does
+            now_playing = "Test Song"
+            now_playing_user = "TestUser"
+            session_id = "test-session"
+
+            if db and now_playing and now_playing_user and session_id:
+                play_id = db.add_play(
+                    song=now_playing,
+                    user=now_playing_user,
+                    session_id=session_id,
+                )
+
+            db.add_play.assert_called_once_with(
+                song="Test Song",
+                user="TestUser",
+                session_id="test-session",
+            )
+            assert play_id == 42
+        finally:
+            if os.path.exists(db_path):
+                os.unlink(db_path)
+
+    def test_end_song_calls_update_play(self):
+        """Test that Karaoke.end_song calls db.update_play."""
+        from unittest.mock import MagicMock
+
+        from pikaraoke.lib.database import PlayDatabase
+
+        # Create temp db
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            db = PlayDatabase(db_path)
+            db.ensure_session("test-session")
+
+            # Mock the update_play method
+            db.update_play = MagicMock()
+
+            # Simulate what karaoke.end_song does
+            current_play_id = 42
+            reason = "complete"
+
+            if db and current_play_id is not None:
+                completed = reason == "complete"
+                db.update_play(current_play_id, completed)
+
+            db.update_play.assert_called_once_with(42, True)
+        finally:
+            if os.path.exists(db_path):
+                os.unlink(db_path)
+
+
+class TestSessionManagementPhase2b:
+    """Tests for session name editing (Phase 2b)."""
+
+    def test_get_session_returns_data(self, temp_db):
+        """Test that get_session returns session details."""
+        session_id = "test-session-get"
+        temp_db.ensure_session(session_id, "Test Session")
+
+        session = temp_db.get_session(session_id)
+
+        assert session is not None
+        assert session["session_id"] == session_id
+        assert session["name"] == "Test Session"
+        assert "started_at" in session
+
+    def test_get_session_not_found(self, temp_db):
+        """Test that get_session returns None for non-existent session."""
+        session = temp_db.get_session("non-existent-session")
+        assert session is None
+
+    def test_update_session_name(self, temp_db):
+        """Test that update_session_name changes the session name."""
+        session_id = "test-session-update"
+        temp_db.ensure_session(session_id, "Original Name")
+
+        success = temp_db.update_session_name(session_id, "New Name")
+
+        assert success is True
+        session = temp_db.get_session(session_id)
+        assert session["name"] == "New Name"
+
+    def test_update_session_name_not_found(self, temp_db):
+        """Test that update_session_name returns False for non-existent session."""
+        success = temp_db.update_session_name("non-existent", "New Name")
+        assert success is False
+
+
+class TestSessionManagementPhase2c:
+    """Tests for session merge and delete (Phase 2c)."""
+
+    def test_merge_sessions(self, temp_db):
+        """Test that merge_sessions moves plays to target session."""
+        import sqlite3
+
+        # Create sessions and plays
+        temp_db.ensure_session("source-1", "Source 1")
+        temp_db.ensure_session("source-2", "Source 2")
+        temp_db.ensure_session("target", "Target")
+
+        temp_db.add_play("Song A", "User1", "source-1")
+        temp_db.add_play("Song B", "User2", "source-1")
+        temp_db.add_play("Song C", "User3", "source-2")
+
+        # Merge
+        plays_moved = temp_db.merge_sessions(["source-1", "source-2"], "target")
+
+        assert plays_moved == 3
+
+        # Check all plays are now in target
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute("SELECT session_id FROM plays")
+            sessions = [row[0] for row in cursor.fetchall()]
+        assert all(s == "target" for s in sessions)
+
+        # Check source sessions are deleted
+        assert temp_db.get_session("source-1") is None
+        assert temp_db.get_session("source-2") is None
+        assert temp_db.get_session("target") is not None
+
+    def test_merge_sessions_no_self_merge(self, temp_db):
+        """Test that merge_sessions doesn't merge target into itself."""
+        temp_db.ensure_session("session-1", "Session 1")
+        temp_db.add_play("Song A", "User1", "session-1")
+
+        plays_moved = temp_db.merge_sessions(["session-1"], "session-1")
+
+        assert plays_moved == 0
+
+    def test_delete_session(self, temp_db):
+        """Test that delete_session removes session and all plays."""
+        import sqlite3
+
+        temp_db.ensure_session("to-delete", "To Delete")
+        temp_db.add_play("Song A", "User1", "to-delete")
+        temp_db.add_play("Song B", "User2", "to-delete")
+
+        plays_deleted, sessions_deleted = temp_db.delete_session("to-delete")
+
+        assert plays_deleted == 2
+        assert sessions_deleted == 1
+        assert temp_db.get_session("to-delete") is None
+
+        with sqlite3.connect(temp_db.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT COUNT(*) FROM plays WHERE session_id = ?", ("to-delete",)
+            )
+            assert cursor.fetchone()[0] == 0
+
+    def test_delete_session_not_found(self, temp_db):
+        """Test that delete_session returns zeros for non-existent session."""
+        plays_deleted, sessions_deleted = temp_db.delete_session("non-existent")
+        assert plays_deleted == 0
+        assert sessions_deleted == 0
+
+
+class TestUserAliasManagement:
+    """Tests for user alias management (Phase 4)."""
+
+    def test_add_alias(self, temp_db):
+        """Test adding a user alias."""
+        success = temp_db.add_alias("Bobby", "Bob")
+        assert success is True
+
+        # Verify alias was added
+        aliases = temp_db.get_aliases_for_user("Bob")
+        assert "Bobby" in aliases
+
+    def test_add_alias_duplicate(self, temp_db):
+        """Test that adding duplicate alias returns False."""
+        temp_db.add_alias("Bobby", "Bob")
+        success = temp_db.add_alias("Bobby", "Bob")
+        assert success is False
+
+    def test_get_aliases_for_user(self, temp_db):
+        """Test getting aliases for a user."""
+        temp_db.add_alias("Bobby", "Bob")
+        temp_db.add_alias("Robert", "Bob")
+
+        aliases = temp_db.get_aliases_for_user("Bob")
+        assert len(aliases) == 2
+        assert "Bobby" in aliases
+        assert "Robert" in aliases
+
+    def test_get_all_aliases(self, temp_db):
+        """Test getting all aliases."""
+        temp_db.add_alias("Bobby", "Bob")
+        temp_db.add_alias("Ally", "Alice")
+
+        all_aliases = temp_db.get_all_aliases()
+        assert len(all_aliases) == 2
+        assert any(a["alias"] == "Bobby" and a["canonical_name"] == "Bob" for a in all_aliases)
+        assert any(a["alias"] == "Ally" and a["canonical_name"] == "Alice" for a in all_aliases)
+
+    def test_remove_alias(self, temp_db):
+        """Test removing an alias."""
+        temp_db.add_alias("Bobby", "Bob")
+        success = temp_db.remove_alias("Bobby")
+        assert success is True
+
+        aliases = temp_db.get_aliases_for_user("Bob")
+        assert "Bobby" not in aliases
+
+    def test_remove_alias_not_found(self, temp_db):
+        """Test removing non-existent alias returns False."""
+        success = temp_db.remove_alias("NonExistent")
+        assert success is False
+
+    def test_update_alias_canonical_user(self, temp_db):
+        """Test changing an alias's canonical user."""
+        temp_db.add_alias("Bobby", "Bob")
+        success = temp_db.update_alias_canonical_user("Bobby", "Robert")
+        assert success is True
+
+        # Verify alias now points to Robert
+        canonical = temp_db.get_canonical_name_for_alias("Bobby")
+        assert canonical == "Robert"
+
+    def test_get_canonical_name_for_alias(self, temp_db):
+        """Test looking up canonical name for alias."""
+        temp_db.add_alias("Bobby", "Bob")
+        canonical = temp_db.get_canonical_name_for_alias("Bobby")
+        assert canonical == "Bob"
+
+    def test_get_canonical_name_for_alias_not_found(self, temp_db):
+        """Test that non-existent alias returns None."""
+        canonical = temp_db.get_canonical_name_for_alias("NonExistent")
+        assert canonical is None
+
+    def test_alias_resolution_in_add_play(self, temp_db):
+        """Test that aliases are resolved when adding plays."""
+        temp_db.add_alias("Bobby", "Bob")
+        temp_db.ensure_session("test-session")
+
+        play_id = temp_db.add_play("Song A", "Bobby", "test-session")
+        play = temp_db.get_play(play_id)
+
+        # canonical_name should be Bob, display_name should be Bobby
+        assert play["canonical_name"] == "Bob"
+        assert play["display_name"] == "Bobby"
+
+
+class TestDeletePlayPermissions:
+    """Tests for play deletion and permission checks (Phase 5)."""
+
+    def test_can_user_delete_own_play_by_display_name(self, temp_db):
+        """Test user can delete their own play by display name."""
+        temp_db.ensure_session("test-session")
+        play_id = temp_db.add_play("Song A", "Alice", "test-session")
+
+        assert temp_db.can_user_delete_play(play_id, "Alice") is True
+
+    def test_can_user_delete_own_play_by_canonical_name(self, temp_db):
+        """Test user can delete play when matching canonical name."""
+        temp_db.add_alias("Ally", "Alice")
+        temp_db.ensure_session("test-session")
+        play_id = temp_db.add_play("Song A", "Ally", "test-session")
+
+        # Alice (canonical) can delete play made by Ally (alias)
+        assert temp_db.can_user_delete_play(play_id, "Alice") is True
+
+    def test_can_user_delete_as_alias_of_canonical(self, temp_db):
+        """Test user with alias can delete play by canonical user."""
+        temp_db.add_alias("Ally", "Alice")
+        temp_db.ensure_session("test-session")
+        play_id = temp_db.add_play("Song A", "Alice", "test-session")
+
+        # Ally (alias of Alice) can delete Alice's play
+        assert temp_db.can_user_delete_play(play_id, "Ally") is True
+
+    def test_cannot_delete_other_users_play(self, temp_db):
+        """Test user cannot delete another user's play."""
+        temp_db.ensure_session("test-session")
+        play_id = temp_db.add_play("Song A", "Alice", "test-session")
+
+        assert temp_db.can_user_delete_play(play_id, "Bob") is False
+
+    def test_cannot_delete_nonexistent_play(self, temp_db):
+        """Test permission check returns False for nonexistent play."""
+        assert temp_db.can_user_delete_play(99999, "Alice") is False
+
+    def test_delete_play_success(self, temp_db):
+        """Test successfully deleting a play."""
+        temp_db.ensure_session("test-session")
+        play_id = temp_db.add_play("Song A", "Alice", "test-session")
+
+        success = temp_db.delete_play(play_id)
+        assert success is True
+
+        # Verify play is gone
+        assert temp_db.get_play(play_id) is None
+
+    def test_delete_play_not_found(self, temp_db):
+        """Test deleting nonexistent play returns False."""
+        success = temp_db.delete_play(99999)
+        assert success is False
+
+
+class TestRankings:
+    """Tests for rankings methods (Phase 6)."""
+
+    def test_get_top_users(self, temp_db):
+        """Test getting users ranked by play count."""
+        temp_db.ensure_session("test-session")
+        temp_db.add_play("Song A", "Alice", "test-session")
+        temp_db.add_play("Song B", "Alice", "test-session")
+        temp_db.add_play("Song C", "Alice", "test-session")
+        temp_db.add_play("Song A", "Bob", "test-session")
+
+        top_users = temp_db.get_top_users(limit=10)
+
+        assert len(top_users) == 2
+        assert top_users[0]["canonical_name"] == "Alice"
+        assert top_users[0]["play_count"] == 3
+        assert top_users[1]["canonical_name"] == "Bob"
+        assert top_users[1]["play_count"] == 1
+
+    def test_get_top_songs(self, temp_db):
+        """Test getting songs ranked by play count."""
+        temp_db.ensure_session("test-session")
+        temp_db.add_play("Popular Song", "Alice", "test-session")
+        temp_db.add_play("Popular Song", "Bob", "test-session")
+        temp_db.add_play("Popular Song", "Charlie", "test-session")
+        temp_db.add_play("Other Song", "Alice", "test-session")
+
+        top_songs = temp_db.get_top_songs(limit=10)
+
+        assert len(top_songs) == 2
+        assert top_songs[0]["song"] == "Popular Song"
+        assert top_songs[0]["play_count"] == 3
+        assert top_songs[1]["song"] == "Other Song"
+        assert top_songs[1]["play_count"] == 1
+
+    def test_get_busiest_sessions(self, temp_db):
+        """Test getting sessions ranked by play count."""
+        temp_db.ensure_session("busy-session", "Busy Night")
+        temp_db.ensure_session("quiet-session", "Quiet Night")
+        temp_db.add_play("Song A", "Alice", "busy-session")
+        temp_db.add_play("Song B", "Bob", "busy-session")
+        temp_db.add_play("Song C", "Charlie", "busy-session")
+        temp_db.add_play("Song A", "Alice", "quiet-session")
+
+        busiest = temp_db.get_busiest_sessions(limit=10)
+
+        assert len(busiest) == 2
+        assert busiest[0]["session_name"] == "Busy Night"
+        assert busiest[0]["play_count"] == 3
+        assert busiest[1]["session_name"] == "Quiet Night"
+        assert busiest[1]["play_count"] == 1
+
+    def test_get_busiest_days(self, temp_db):
+        """Test getting days ranked by play count."""
+        temp_db.ensure_session("test-session")
+        # Add plays (they'll all be on today's date due to how add_play works)
+        temp_db.add_play("Song A", "Alice", "test-session")
+        temp_db.add_play("Song B", "Bob", "test-session")
+
+        busiest = temp_db.get_busiest_days(limit=10)
+
+        assert len(busiest) == 1
+        assert busiest[0]["play_count"] == 2

--- a/tests/unit/test_history_routes.py
+++ b/tests/unit/test_history_routes.py
@@ -1,0 +1,356 @@
+"""Tests for history routes."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import werkzeug
+
+# Monkeypatch werkzeug.__version__ for Flask compatibility if missing
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3.0.0"
+
+
+class TestHistoryRouteLogic:
+    """Tests for history route logic using mocked template rendering."""
+
+    @patch("pikaraoke.routes.history.render_template")
+    @patch("pikaraoke.routes.history.is_admin", return_value=False)
+    @patch("pikaraoke.routes.history.get_site_name", return_value="TestSite")
+    @patch("pikaraoke.routes.history.get_karaoke_instance")
+    @patch("pikaraoke.routes.history._", side_effect=lambda x: x)
+    def test_history_calls_db_with_default_params(
+        self, mock_gettext, mock_get_instance, mock_site_name, mock_is_admin, mock_render
+    ):
+        """Test that history route calls DB with correct default params."""
+        from flask import Flask
+
+        from pikaraoke.routes.history import history_bp
+
+        mock_karaoke = MagicMock()
+        mock_db = MagicMock()
+        mock_db.get_last_plays.return_value = []
+        mock_db.get_plays_count.return_value = 0
+        mock_db.get_sessions_with_names.return_value = []
+        mock_db.get_distinct_users.return_value = []
+        mock_karaoke.db = mock_db
+        mock_get_instance.return_value = mock_karaoke
+        mock_render.return_value = "rendered"
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        app.register_blueprint(history_bp)
+
+        with app.test_client() as client:
+            response = client.get("/history")
+
+        assert response.status_code == 200
+        mock_db.get_last_plays.assert_called_once()
+        call_kwargs = mock_db.get_last_plays.call_args[1]
+        assert call_kwargs["limit"] == 20
+        assert call_kwargs["offset"] == 0
+        assert call_kwargs["sort_by"] == "timestamp"
+        assert call_kwargs["sort_order"] == "DESC"
+
+    @patch("pikaraoke.routes.history.render_template")
+    @patch("pikaraoke.routes.history.is_admin", return_value=False)
+    @patch("pikaraoke.routes.history.get_site_name", return_value="TestSite")
+    @patch("pikaraoke.routes.history.get_karaoke_instance")
+    @patch("pikaraoke.routes.history._", side_effect=lambda x: x)
+    def test_history_with_date_filters(
+        self, mock_gettext, mock_get_instance, mock_site_name, mock_is_admin, mock_render
+    ):
+        """Test that date filters are passed to DB."""
+        from flask import Flask
+
+        from pikaraoke.routes.history import history_bp
+
+        mock_karaoke = MagicMock()
+        mock_db = MagicMock()
+        mock_db.get_last_plays.return_value = []
+        mock_db.get_plays_count.return_value = 0
+        mock_db.get_sessions_with_names.return_value = []
+        mock_db.get_distinct_users.return_value = []
+        mock_karaoke.db = mock_db
+        mock_get_instance.return_value = mock_karaoke
+        mock_render.return_value = "rendered"
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        app.register_blueprint(history_bp)
+
+        with app.test_client() as client:
+            client.get("/history?date_from=2025-01-01&date_to=2025-01-31")
+
+        call_kwargs = mock_db.get_last_plays.call_args[1]
+        assert call_kwargs["date_from"] == "2025-01-01"
+        assert call_kwargs["date_to"] == "2025-01-31"
+
+    @patch("pikaraoke.routes.history.render_template")
+    @patch("pikaraoke.routes.history.is_admin", return_value=False)
+    @patch("pikaraoke.routes.history.get_site_name", return_value="TestSite")
+    @patch("pikaraoke.routes.history.get_karaoke_instance")
+    @patch("pikaraoke.routes.history._", side_effect=lambda x: x)
+    def test_history_with_user_filter(
+        self, mock_gettext, mock_get_instance, mock_site_name, mock_is_admin, mock_render
+    ):
+        """Test that user filter is passed to DB."""
+        from flask import Flask
+
+        from pikaraoke.routes.history import history_bp
+
+        mock_karaoke = MagicMock()
+        mock_db = MagicMock()
+        mock_db.get_last_plays.return_value = []
+        mock_db.get_plays_count.return_value = 0
+        mock_db.get_sessions_with_names.return_value = []
+        mock_db.get_distinct_users.return_value = []
+        mock_karaoke.db = mock_db
+        mock_get_instance.return_value = mock_karaoke
+        mock_render.return_value = "rendered"
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        app.register_blueprint(history_bp)
+
+        with app.test_client() as client:
+            client.get("/history?user=Alice")
+
+        call_kwargs = mock_db.get_last_plays.call_args[1]
+        assert call_kwargs["user_filter"] == "Alice"
+
+    @patch("pikaraoke.routes.history.render_template")
+    @patch("pikaraoke.routes.history.is_admin", return_value=False)
+    @patch("pikaraoke.routes.history.get_site_name", return_value="TestSite")
+    @patch("pikaraoke.routes.history.get_karaoke_instance")
+    @patch("pikaraoke.routes.history._", side_effect=lambda x: x)
+    def test_history_with_sessions_count(
+        self, mock_gettext, mock_get_instance, mock_site_name, mock_is_admin, mock_render
+    ):
+        """Test that sessions_count param fetches last N sessions."""
+        from flask import Flask
+
+        from pikaraoke.routes.history import history_bp
+
+        mock_karaoke = MagicMock()
+        mock_db = MagicMock()
+        mock_db.get_session_ids_last_n.return_value = ["sess-1", "sess-2", "sess-3"]
+        mock_db.get_last_plays.return_value = []
+        mock_db.get_plays_count.return_value = 0
+        mock_db.get_sessions_with_names.return_value = []
+        mock_db.get_distinct_users.return_value = []
+        mock_karaoke.db = mock_db
+        mock_get_instance.return_value = mock_karaoke
+        mock_render.return_value = "rendered"
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        app.register_blueprint(history_bp)
+
+        with app.test_client() as client:
+            client.get("/history?sessions_count=3")
+
+        mock_db.get_session_ids_last_n.assert_called_once_with(3)
+        call_kwargs = mock_db.get_last_plays.call_args[1]
+        assert call_kwargs["session_ids"] == ["sess-1", "sess-2", "sess-3"]
+
+    @patch("pikaraoke.routes.history.render_template")
+    @patch("pikaraoke.routes.history.is_admin", return_value=False)
+    @patch("pikaraoke.routes.history.get_site_name", return_value="TestSite")
+    @patch("pikaraoke.routes.history.get_karaoke_instance")
+    @patch("pikaraoke.routes.history._", side_effect=lambda x: x)
+    def test_history_with_sort_params(
+        self, mock_gettext, mock_get_instance, mock_site_name, mock_is_admin, mock_render
+    ):
+        """Test that sort params are passed to DB."""
+        from flask import Flask
+
+        from pikaraoke.routes.history import history_bp
+
+        mock_karaoke = MagicMock()
+        mock_db = MagicMock()
+        mock_db.get_last_plays.return_value = []
+        mock_db.get_plays_count.return_value = 0
+        mock_db.get_sessions_with_names.return_value = []
+        mock_db.get_distinct_users.return_value = []
+        mock_karaoke.db = mock_db
+        mock_get_instance.return_value = mock_karaoke
+        mock_render.return_value = "rendered"
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        app.register_blueprint(history_bp)
+
+        with app.test_client() as client:
+            client.get("/history?sort_by=song&sort_order=ASC")
+
+        call_kwargs = mock_db.get_last_plays.call_args[1]
+        assert call_kwargs["sort_by"] == "song"
+        assert call_kwargs["sort_order"] == "ASC"
+
+    @patch("pikaraoke.routes.history.render_template")
+    @patch("pikaraoke.routes.history.flash")
+    @patch("pikaraoke.routes.history.is_admin", return_value=False)
+    @patch("pikaraoke.routes.history.get_site_name", return_value="TestSite")
+    @patch("pikaraoke.routes.history.get_karaoke_instance")
+    @patch("pikaraoke.routes.history._", side_effect=lambda x: x)
+    def test_history_no_db(
+        self, mock_gettext, mock_get_instance, mock_site_name, mock_is_admin, mock_flash, mock_render
+    ):
+        """Test that history handles missing DB gracefully."""
+        from flask import Flask
+
+        from pikaraoke.routes.history import history_bp
+
+        mock_karaoke = MagicMock()
+        mock_karaoke.db = None
+        mock_get_instance.return_value = mock_karaoke
+        mock_render.return_value = "rendered"
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        app.register_blueprint(history_bp)
+
+        with app.test_client() as client:
+            response = client.get("/history")
+
+        assert response.status_code == 200
+        mock_flash.assert_called_once()
+
+
+class TestHistoryDatabaseMethods:
+    """Tests for history-related database methods."""
+
+    def test_get_last_plays_with_date_filter(self, temp_db_with_plays):
+        """Test get_last_plays filters by date range."""
+        db = temp_db_with_plays
+
+        plays = db.get_last_plays(limit=100, date_from="2025-01-15", date_to="2025-01-16")
+
+        # Should only include plays within the date range
+        for play in plays:
+            date = play["timestamp"][:10]
+            assert date >= "2025-01-15"
+            assert date <= "2025-01-16"
+
+    def test_get_last_plays_with_user_filter(self, temp_db_with_plays):
+        """Test get_last_plays filters by user."""
+        db = temp_db_with_plays
+
+        plays = db.get_last_plays(limit=100, user_filter="Alice")
+
+        # Should only include plays by Alice
+        for play in plays:
+            assert play["canonical_name"] == "Alice"
+
+    def test_get_last_plays_with_session_filter(self, temp_db_with_plays):
+        """Test get_last_plays filters by session IDs."""
+        db = temp_db_with_plays
+
+        # Get sessions and filter by first one
+        sessions = db.get_sessions_with_names()
+        if sessions:
+            session_id = sessions[0]["session_id"]
+            plays = db.get_last_plays(limit=100, session_ids=[session_id])
+
+            for play in plays:
+                assert play["session_id"] == session_id
+
+    def test_get_last_plays_sorting(self, temp_db_with_plays):
+        """Test get_last_plays respects sort order."""
+        db = temp_db_with_plays
+
+        plays_desc = db.get_last_plays(limit=100, sort_by="timestamp", sort_order="DESC")
+        plays_asc = db.get_last_plays(limit=100, sort_by="timestamp", sort_order="ASC")
+
+        if len(plays_desc) > 1:
+            assert plays_desc[0]["timestamp"] >= plays_desc[-1]["timestamp"]
+        if len(plays_asc) > 1:
+            assert plays_asc[0]["timestamp"] <= plays_asc[-1]["timestamp"]
+
+    def test_get_plays_count(self, temp_db_with_plays):
+        """Test get_plays_count returns correct count."""
+        db = temp_db_with_plays
+
+        total = db.get_plays_count()
+        assert total > 0
+
+        # Count with filter should be <= total
+        filtered = db.get_plays_count(user_filter="Alice")
+        assert filtered <= total
+
+    def test_get_session_ids_last_n(self, temp_db_with_plays):
+        """Test get_session_ids_last_n returns correct number of sessions."""
+        db = temp_db_with_plays
+
+        sessions = db.get_session_ids_last_n(2)
+        assert len(sessions) <= 2
+        assert all(isinstance(s, str) for s in sessions)
+
+    def test_get_sessions_with_names(self, temp_db_with_plays):
+        """Test get_sessions_with_names returns session data."""
+        db = temp_db_with_plays
+
+        sessions = db.get_sessions_with_names()
+        assert isinstance(sessions, list)
+        for session in sessions:
+            assert "session_id" in session
+            assert "name" in session
+
+    def test_get_distinct_users(self, temp_db_with_plays):
+        """Test get_distinct_users returns unique users."""
+        db = temp_db_with_plays
+
+        users = db.get_distinct_users()
+        assert isinstance(users, list)
+        assert len(users) == len(set(users))  # All unique
+
+
+@pytest.fixture
+def temp_db_with_plays():
+    """Create a temporary database with sample plays for testing."""
+    import os
+    import sqlite3
+    import tempfile
+
+    from pikaraoke.lib.database import PlayDatabase
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+
+    db = PlayDatabase(db_path)
+
+    # Add sessions
+    db.ensure_session("session-1", "2025-01-15")
+    db.ensure_session("session-2", "2025-01-20")
+
+    # Add some plays with specific timestamps
+    with sqlite3.connect(db_path) as conn:
+        plays = [
+            ("2025-01-15 10:00:00", "session-1", "Alice", "Alice", "Song A", 1),
+            ("2025-01-15 10:30:00", "session-1", "Bob", "Bob", "Song B", 1),
+            ("2025-01-15 11:00:00", "session-1", "Alice", "Alice", "Song C", 0),
+            ("2025-01-20 14:00:00", "session-2", "Charlie", "Charlie", "Song D", 1),
+            ("2025-01-20 14:30:00", "session-2", "Alice", "Alice", "Song E", 1),
+        ]
+        for play in plays:
+            conn.execute(
+                "INSERT INTO users (canonical_name) VALUES (?) ON CONFLICT DO NOTHING",
+                (play[2],),
+            )
+            conn.execute(
+                """
+                INSERT INTO plays (timestamp, session_id, canonical_name, display_name, song, completed)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                play,
+            )
+        conn.commit()
+
+    yield db
+
+    # Cleanup
+    if os.path.exists(db_path):
+        os.unlink(db_path)


### PR DESCRIPTION
- SQLite database for plays, sessions, users, and aliases
- History page: pageable play log with filters (date, session, user, song)
- Rankings page: top performers, most requested songs, busiest sessions/days (collapsible)
- Performers page: paginated list with date filters
- Admin: manage history (edit plays, sessions, user aliases)
- CLI: --db-path for custom database location
- Backwards compatible; queue and playback unchanged