### PR TITLE
fix(splash): start screensaver idle timer on initialization

### DIFF
--- a/pikaraoke/static/js/splash.js
+++ b/pikaraoke/static/js/splash.js
@@ -1,7 +1,7 @@
 // Global variables
 var socket = io();
 var mouseTimer = null,
-  cursorVisible = true;
+  cursorVisible = false;
 var nowPlaying = {};
 var octopusInstance = null;
 var showMenu = false;
@@ -380,6 +380,14 @@ const setupOverlayMenus = () => {
     $('#top-container').hide();
   }
   $("#menu a").fadeOut(); // start hidden
+  const triggerInactivity = () => {
+    mouseTimer = null;
+    document.body.style.cursor = 'none';
+    cursorVisible = false;
+    $("#menu a").fadeOut();
+    menuButtonVisible = false;
+  };
+
   document.onmousemove = function () {
     if (mouseTimer) window.clearTimeout(mouseTimer);
     if (!cursorVisible) {
@@ -390,14 +398,11 @@ const setupOverlayMenus = () => {
       $("#menu a").fadeIn();
       menuButtonVisible = true;
     }
-    mouseTimer = window.setTimeout(() => {
-      mouseTimer = null;
-      document.body.style.cursor = 'none';
-      cursorVisible = false;
-      $("#menu a").fadeOut();
-      menuButtonVisible = false;
-    }, 5000);
+    mouseTimer = window.setTimeout(triggerInactivity, 5000);
   };
+
+  // Set initial state to hidden
+  triggerInactivity();
   $('#menu a').click(function () {
     if (showMenu) {
       $('#menu-container').hide();


### PR DESCRIPTION
Fixes the issue where the splash screensaver would not start until after the first user interaction by defaulting cursor visibility to hidden and triggering the inactivity timer on load. #745 