### PR TITLE
fix: installation on windows to include C++ distributable

### DIFF
--- a/build_scripts/install/install.ps1
+++ b/build_scripts/install/install.ps1
@@ -159,4 +159,5 @@ Write-Host "`n--------------------------------------------------------" -Foregro
 Write-Host "Installation complete!" -ForegroundColor Green
 Write-Host "Please restart your terminal (PowerShell) to ensure all PATH changes are loaded."
 Write-Host "Then, simply run: `pikaraoke` or launch PiKaraoke from the desktop shortcuts."
+Write-Host "`nTIP: Put your karaoke files in: $(Join-Path $HOME 'pikaraoke-songs')" -ForegroundColor Cyan
 Write-Host "--------------------------------------------------------"


### PR DESCRIPTION
Fixes #761 by including the C++ redistributable.

Tested on Windows 10 fresh install after uninstalling the redistributable to reproduce the error.