### PR TITLE
fix: docker yt-dlp upgrade fails, bump yt-dlp version

### DIFF
--- a/build_scripts/docker/Dockerfile
+++ b/build_scripts/docker/Dockerfile
@@ -18,14 +18,21 @@ COPY pyproject.toml uv.lock ./
 
 # Install dependencies using uv (this layer is cached)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-cache-dir -r pyproject.toml
+    uv venv /app/.venv && \
+    uv pip install --no-cache-dir -r pyproject.toml
+
+ENV VIRTUAL_ENV=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Install pip into the venv so that python -m pip works for yt-dlp self-upgrade
+RUN uv pip install pip
 
 COPY docs ./docs
 COPY pikaraoke ./pikaraoke
 
 # Final install of the package itself (fast)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system --no-cache-dir --no-deps .
+    uv pip install --no-cache-dir --no-deps .
 
 # Set up volumes and ports
 
@@ -35,7 +42,7 @@ RUN adduser -D -u 1000 pikaraoke
 # Directories must exist prior to run, otherwise the local volume persistence won't work
 RUN mkdir -p /home/pikaraoke/.pikaraoke && \
     mkdir -p /app/pikaraoke-songs && \
-    chown -R pikaraoke:pikaraoke /app/pikaraoke-songs /home/pikaraoke
+    chown -R pikaraoke:pikaraoke /app/pikaraoke-songs /home/pikaraoke /app/.venv
 
 # Set environment variables for the user
 ENV HOME=/home/pikaraoke

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "Babel==2.17.0",
   "Flask-Babel==4.0.0",
   "ffmpeg-python==0.2.0",
-  "yt-dlp[default]>=2026.1.31",
+  "yt-dlp[default]>=2026.02.04",
   "flask-socketio>=5.5.0",
   "gevent>=24.11.1",
   "flasgger>=0.9.5",

--- a/uv.lock
+++ b/uv.lock
@@ -862,7 +862,7 @@ wheels = [
 
 [[package]]
 name = "pikaraoke"
-version = "1.18.2"
+version = "1.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
Fixes docker image no able to self-update yt-dlp, also bumps yt-dlp version to 2026.02.04 Ticket: #762