### PR TITLE
fix: use os.path.join for download path instead of trailing slash hack

### DIFF
--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -335,8 +335,6 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         print(f"Background video not found: {bg_video_path}. Setting to None")
 
     dl_path = os.path.expanduser(arg_path_parse(args.download_path) or default_dl_dir)
-    if not dl_path.endswith("/"):
-        dl_path += "/"
 
     args.logo_path = logo_path
     args.bg_music_path = bg_music_path

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import shlex
 import subprocess
 import sys
@@ -121,7 +122,7 @@ def build_ytdl_download_command(
     Returns:
         List of command-line arguments for subprocess execution.
     """
-    dl_path = download_path + "%(title)s---%(id)s.%(ext)s"
+    dl_path = os.path.join(download_path, "%(title)s---%(id)s.%(ext)s")
     file_quality = (
         "bestvideo[ext!=webm][height<=1080]+bestaudio[ext!=webm]/best[ext!=webm]"
         if high_quality

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -11,7 +11,7 @@ class MockKaraokeForDownload:
     """Mock Karaoke instance for DownloadManager tests."""
 
     def __init__(self):
-        self.download_path = "/songs/"
+        self.download_path = "/songs"
         self.high_quality = False
         self.youtubedl_proxy = None
         self.additional_ytdl_args = None
@@ -138,7 +138,7 @@ class TestDownloadManagerExecuteDownload:
         rc = dm._execute_download("https://youtube.com/watch?v=abc123", False, "User", "Title")
 
         assert rc == 0
-        mock_karaoke.available_songs.find_by_id.assert_called_once_with("/songs/", "abc123")
+        mock_karaoke.available_songs.find_by_id.assert_called_once_with("/songs", "abc123")
         mock_karaoke.available_songs.add_if_valid.assert_called_once_with(
             "/songs/Artist - Song---abc123.mp4"
         )

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -62,14 +62,16 @@ class TestBuildYtdlDownloadCommand:
         """Test building basic download command."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
         )
         assert cmd[0] == sys.executable
         assert cmd[1] == "-m"
         assert cmd[2] == "yt_dlp"
         assert "-f" in cmd
         assert "-o" in cmd
-        assert "/songs/%(title)s---%(id)s.%(ext)s" in cmd
+        output_idx = cmd.index("-o") + 1
+        assert cmd[output_idx].endswith("%(title)s---%(id)s.%(ext)s")
+        assert "/songs" in cmd[output_idx]
         assert "https://www.youtube.com/watch?v=test123" in cmd
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
@@ -77,7 +79,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that high quality uses correct format string."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
             high_quality=True,
         )
         format_idx = cmd.index("-f") + 1
@@ -89,7 +91,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that standard quality uses mp4 format."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
             high_quality=False,
         )
         format_idx = cmd.index("-f") + 1
@@ -100,7 +102,7 @@ class TestBuildYtdlDownloadCommand:
         """Test command with proxy setting."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
             youtubedl_proxy="http://proxy:8080",
         )
         assert "--proxy" in cmd
@@ -112,7 +114,7 @@ class TestBuildYtdlDownloadCommand:
         """Test command with additional arguments."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
             additional_args="--no-playlist --age-limit 18",
         )
         assert "--no-playlist" in cmd
@@ -124,7 +126,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that node JS runtime is added to command."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
         )
         assert "--js-runtimes" in cmd
         js_idx = cmd.index("--js-runtimes") + 1
@@ -135,7 +137,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that deno JS runtime is NOT added (it's yt-dlp default)."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
         )
         assert "--js-runtimes" not in cmd
 
@@ -144,7 +146,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that bun JS runtime is added to command."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
         )
         assert "--js-runtimes" in cmd
         js_idx = cmd.index("--js-runtimes") + 1
@@ -155,7 +157,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that h264 codec sorting is included."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
         )
         assert "-S" in cmd
         sort_idx = cmd.index("-S") + 1
@@ -166,7 +168,7 @@ class TestBuildYtdlDownloadCommand:
         """Test that video URL is always the last argument."""
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
-            download_path="/songs/",
+            download_path="/songs",
             youtubedl_proxy="http://proxy:8080",
             additional_args="--no-playlist",
         )


### PR DESCRIPTION
args.py appended a trailing slash to download_path to compensate for string concatenation in youtube_dl.py.

Replace concatenation with os.path.join and remove the hack so download_path is a clean directory.