### PR TITLE
fix: add admin security around edit, delete and addrandom routes

### DIFF
--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -120,6 +120,10 @@ def delete_file(query):
     """Delete a song file."""
     k = get_karaoke_instance()
     song_path = query["song"]
+    referrer = query.get("referrer") or url_for("files.browse")
+    if not is_admin():
+        flash(_("You don't have permission to delete songs"), "is-danger")
+        return redirect(referrer)
     if k.queue_manager.is_song_in_queue(song_path):
         flash(
             # MSG: Message shown after trying to delete a song that is in the queue.
@@ -131,7 +135,10 @@ def delete_file(query):
     else:
         k.song_manager.delete(song_path)
         # MSG: Message shown after deleting a song. Followed by the song path
-        flash(_("Song deleted: %s") % k.song_manager.filename_from_path(song_path), "is-warning")
+        flash(
+            _("Song deleted: %s") % k.song_manager.filename_from_path(song_path),
+            "is-warning",
+        )
     referrer = query.get("referrer") or url_for("files.browse")
     return redirect(referrer)
 
@@ -144,6 +151,9 @@ def edit_file(query):
     site_name = get_site_name()
     song_path = query["song"]
     referrer = query.get("referrer") or url_for("files.browse")
+    if not is_admin():
+        flash(_("You don't have permission to edit songs"), "is-danger")
+        return redirect(referrer)
     if k.queue_manager.is_song_in_queue(song_path):
         # MSG: Message shown after trying to edit a song that is in the queue.
         flash(

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -139,7 +139,6 @@ def delete_file(query):
             _("Song deleted: %s") % k.song_manager.filename_from_path(song_path),
             "is-warning",
         )
-    referrer = query.get("referrer") or url_for("files.browse")
     return redirect(referrer)
 
 
@@ -178,6 +177,9 @@ def rename_file(form):
     referrer = form.get("referrer") or url_for("files.browse")
     new_name = form["new_file_name"]
     old_name = form["old_file_name"]
+    if not is_admin():
+        flash(_("You don't have permission to edit songs"), "is-danger")
+        return redirect(referrer)
     if k.queue_manager.is_song_in_queue(old_name):
         # check one more time just in case someone added it during editing
         # MSG: Message shown after trying to edit a song that is in the queue.

--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -76,6 +76,9 @@ def get_queue():
 @queue_bp.route("/queue/addrandom/<int:amount>", methods=["GET"])
 def add_random(amount):
     """Add random songs to the queue."""
+    if not is_admin():
+        flash(_("You don't have permission to add random songs"), "is-danger")
+        return redirect(url_for("queue.queue"))
     k = get_karaoke_instance()
     rc = k.queue_manager.queue_add_random(amount)
     if rc:


### PR DESCRIPTION
## Problem
No authentication was wrapped around file or queue admin management functions.

## Solution
Add `is_admin` around `queue/addrandom`, `/files/edit` and `/files/delete` routes

This is good practice and could help with resolving #801