### PR TITLE
fix: prevent CJK characters from being stripped from YouTube filenames

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -226,7 +226,7 @@ def main() -> None:
     app.config["SITE_NAME"] = "PiKaraoke"
 
     # Expose some functions to jinja templates
-    app.jinja_env.globals.update(filename_from_path=SongManager.filename_from_path)
+    app.jinja_env.globals.update(filename_from_path=k.song_manager.display_name_from_path)
     app.jinja_env.globals.update(url_escape=quote)
 
     spawn(upgrade_youtubedl)

--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -120,6 +120,7 @@ class Karaoke:
         show_splash_clock: bool | None = None,
         splash_delay: int | None = None,
         volume: float | None = None,
+        enable_title_tidy: bool | None = None,
     ) -> None:
         """Initialize the Karaoke instance.
 
@@ -204,7 +205,9 @@ class Karaoke:
 
         # Initialize database, scanner, and song manager (startup runs at end of __init__)
         self.db = KaraokeDatabase()
-        self.song_manager = SongManager(self.download_path, db=self.db)
+        self.song_manager = SongManager(
+            self.download_path, db=self.db, get_title_tidy=lambda: self.enable_title_tidy
+        )
         self._scanner = LibraryScanner(self.db)
         self._sync_lock = threading.Lock()
 
@@ -219,7 +222,7 @@ class Karaoke:
         self.playback_controller = PlaybackController(
             preferences=self.preferences,
             events=self.events,
-            filename_from_path=SongManager.filename_from_path,
+            filename_from_path=self.song_manager.display_name_from_path,
             streaming_format=self.streaming_format,
         )
 
@@ -248,7 +251,7 @@ class Karaoke:
             preferences=self.preferences,
             events=self.events,
             get_now_playing_user=lambda: self.playback_controller.now_playing_user,
-            filename_from_path=SongManager.filename_from_path,
+            filename_from_path=self.song_manager.display_name_from_path,
             get_available_songs=lambda: self.song_manager.songs,
         )
 

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -25,7 +25,9 @@ EMOJI_PATTERN = re.compile(
     "\U0001FA00-\U0001FA6F"
     "\U0001FA70-\U0001FAFF"
     "\U00002702-\U000027B0"
-    "\U000024C2-\U0001F251"
+    "\U000024C2-\U000024FF"  # enclosed alphanumerics
+    "\U00002600-\U000026FF"  # miscellaneous symbols
+    "\U0001F200-\U0001F251"  # enclosed ideographic supplement
     "]+"
 )
 

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -110,9 +110,10 @@ ATTRIBUTION_PATTERNS = [
 ]
 
 TRAILING_NOISE_PATTERNS = [
-    # "karaoke" at the trailing end means everything after it is noise
-    # (source channels, version labels, etc.) — no need to enumerate them
-    re.compile(r"\s*\bkaraoke\b.*$", re.IGNORECASE),
+    # Strip bracketed karaoke anywhere
+    re.compile(r"\s*[\(\[]\s*\bkaraoke\b[^\)\]]*[\)\]]", re.IGNORECASE),
+    # Strip trailing karaoke (only if nothing significant follows it besides noise)
+    re.compile(r"\s+\bkaraoke\b(?:\s*version)?[\s.!]*$", re.IGNORECASE),
     re.compile(
         r"\s*\b(?:official\s+(?:music\s+)?video|lyrics?"
         r"|hd|hq|instrumental|with\s+lyrics|no\s+lead\s+vocal|cc)\b[\s.!]*$",

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -10,8 +10,6 @@ import re
 import time
 import unicodedata
 
-import requests
-
 EMOJI_PATTERN = re.compile(
     "["
     "\U0001F1E0-\U0001F1FF"
@@ -67,6 +65,11 @@ NOISE_WORDS = [
 ]
 NOISE_PATTERN = re.compile("|".join(NOISE_WORDS), flags=re.IGNORECASE)
 
+# Matches parenthesised content EXCEPT featuring credits like "(feat. X)" / "(ft. X)"
+_FEAT_LOOKAHEAD = r"(?!\s*(?:feat(?:uring)?|ft)\.?\s)"
+_PAREN_NOT_FEAT = re.compile(rf"\s*\({_FEAT_LOOKAHEAD}[^)]*\)", flags=re.IGNORECASE)
+_PAREN_NOT_FEAT_TRAILING = re.compile(rf"\s*\({_FEAT_LOOKAHEAD}[^)]*\)\s*$", flags=re.IGNORECASE)
+
 SPECIAL_VERSION_KEYWORDS = [
     " - ",
     "ao vivo",
@@ -79,7 +82,18 @@ SPECIAL_VERSION_KEYWORDS = [
     "cover",
     "radio edit",
     "extended",
+    "re-recorded",
+    "rerecorded",
+    "remastered",
+    "encore",
+    "deluxe",
+    "bonus track",
+    "demo",
 ]
+_SPECIAL_VERSION_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(kw) for kw in SPECIAL_VERSION_KEYWORDS if kw != " - ") + r")\b",
+    re.IGNORECASE,
+)
 
 LASTFM_API_KEY = "058c382f5fd686b4146f6028961c14da"
 LASTFM_API_URL = "http://ws.audioscrobbler.com/2.0/"
@@ -94,6 +108,20 @@ _RATE_LIMITED = object()
 _last_api_request_time = 0.0
 
 # Attribution phrases that embed the artist name in karaoke filenames
+# Karaoke-related keywords shared across leading/trailing/bracket noise patterns.
+_KARAOKE_KEYWORDS = r"karaoke|karaokê|カラオケ|卡拉OK|KTV|노래방"
+
+# Leading noise: "KARAOKE - Title" or "Official Video | Title" etc.
+_LEADING_NOISE = re.compile(
+    rf"^(?:{_KARAOKE_KEYWORDS}|instrumental|official\s+(?:music\s+)?video)\s*[-|:】》」』]\s*",
+    re.IGNORECASE,
+)
+# Leading [square brackets] containing a karaoke keyword — strip entirely.
+_LEADING_BRACKET_NOISE_RE = re.compile(
+    rf"^\s*\[[^\]]*?(?:{_KARAOKE_KEYWORDS})[^\]]*?\]\s*",
+    re.IGNORECASE,
+)
+
 ATTRIBUTION_PATTERNS = [
     # Parenthetical: "(Made Famous by Artist)", "(In the Style of Artist)", etc.
     re.compile(
@@ -110,16 +138,68 @@ ATTRIBUTION_PATTERNS = [
 ]
 
 TRAILING_NOISE_PATTERNS = [
-    # Strip bracketed karaoke anywhere
-    re.compile(r"\s*[\(\[]\s*\bkaraoke\b[^\)\]]*[\)\]]", re.IGNORECASE),
-    # Strip trailing karaoke (only if nothing significant follows it besides noise)
-    re.compile(r"\s+\bkaraoke\b(?:\s*version)?[\s.!]*$", re.IGNORECASE),
+    # "karaoke" at the trailing end means everything after it is noise
+    # (source channels, version labels, etc.) — no need to enumerate them
+    re.compile(r"\s*\bkaraoke\b.*$", re.IGNORECASE),
     re.compile(
         r"\s*\b(?:official\s+(?:music\s+)?video|lyrics?"
         r"|hd|hq|instrumental|with\s+lyrics|no\s+lead\s+vocal|cc)\b[\s.!]*$",
         re.IGNORECASE,
     ),
+    # CJK noise words (Chinese Traditional/Simplified, Japanese, Korean)
+    re.compile(
+        r"\s*(?:伴奏|卡拉OK|KTV"
+        r"|純音樂|纯音乐"  # pure music / instrumental (zh)
+        r"|無人聲|无人声"  # no vocals (zh)
+        r"|導唱|导唱"  # guide vocal (zh)
+        r"|消音"  # vocal removed (zh)
+        r"|翻唱"  # cover (zh)
+        r"|現場|现场"  # live (zh)
+        r"|高清"  # HD (zh)
+        r"|歌詞|歌词"  # lyrics (zh)
+        r"|MV"  # music video
+        r"|原版"  # original version (zh)
+        r"|歌ってみた"  # "tried singing" / cover (ja)
+        r"|オフボーカル"  # off vocal (ja)
+        r"|ボカロ"  # vocaloid (ja)
+        r"|カバー"  # cover (ja)
+        r"|노래방"  # noraebang / karaoke (ko)
+        r"|금영"  # Keumyoung karaoke brand (ko)
+        r"|태진|TJ"  # Taejin karaoke brand (ko)
+        r"|MR"  # accompaniment track (ko)
+        r")[\s.!]*$",
+        re.IGNORECASE,
+    ),
 ]
+
+# A dash adjacent to a CJK/Kana/Hangul character is always a separator (never a hyphen
+# within a word). Uses lookaround so the replacement is just the dash, not surrounding chars.
+_CJK = (
+    r"\u4e00-\u9fff"  # CJK Unified Ideographs
+    r"\u3400-\u4dbf"  # CJK Unified Ideographs Extension A
+    r"\uf900-\ufaff"  # CJK Compatibility Ideographs
+    r"\u3040-\u309f"  # Hiragana
+    r"\u30a0-\u30ff"  # Katakana
+    r"\uac00-\ud7af"  # Hangul Syllables
+    r"\u1100-\u11ff"  # Hangul Jamo
+    r"\u31f0-\u31ff"  # Katakana Phonetic Extensions
+    r"\uff65-\uff9f"  # Halfwidth Katakana
+)
+_CJK_DASH_RE = re.compile(rf"(?<=[{_CJK}])\s*-\s*|\s*-\s*(?=[{_CJK}])")
+
+# 【lenticular】and「corner」brackets contain metadata labels — strip entirely
+_CJK_STRIP_LABEL_RE = re.compile(r"\s*(?:【[^】]*】|「[^」]*」)")
+# 《double angle》and『white corner』brackets wrap titles — unwrap (keep content)
+# unless the content is noise (KTV, karaoke labels), in which case strip entirely.
+_CJK_UNWRAP_TITLE_RE = re.compile(r"[《『]([^》』]*)[》』]")
+_CJK_TITLE_NOISE_RE = re.compile(_KARAOKE_KEYWORDS, re.IGNORECASE)
+
+
+def _replace_cjk_title_bracket(match: re.Match) -> str:
+    content = match.group(1)
+    if _CJK_TITLE_NOISE_RE.search(content):
+        return " "
+    return f" {content} "
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +207,7 @@ TRAILING_NOISE_PATTERNS = [
 # ---------------------------------------------------------------------------
 
 
-def _remove_accents(text: str) -> str:
+def remove_accents(text: str) -> str:
     """Strip diacritical marks for accent-insensitive comparison."""
     return "".join(c for c in unicodedata.normalize("NFD", text) if unicodedata.category(c) != "Mn")
 
@@ -159,7 +239,7 @@ def _split_query_parts(query: str) -> tuple[str, str]:
 
 def clean_search_query(song_name: str) -> str:
     """Strip noise words, brackets, and emoji to isolate the core song identity."""
-    song_name = EMOJI_PATTERN.sub("", song_name)
+    song_name = EMOJI_PATTERN.sub(" ", song_name)
     song_name = song_name.replace("_", " ")
     song_name = re.sub(r"\([^)]*\)", "", song_name)
     song_name = re.sub(r"\[[^\]]*\]", "", song_name)
@@ -202,10 +282,10 @@ def score_result(result: dict, original_query: str) -> int:
 
     part1, part2 = _split_query_parts(original_query)
 
-    part1_normalized = clean_search_query(_remove_accents(part1))
-    part2_normalized = clean_search_query(_remove_accents(part2))
-    track_normalized = _remove_accents(track_name)
-    artist_normalized = _remove_accents(artist_name)
+    part1_normalized = clean_search_query(remove_accents(part1))
+    part2_normalized = clean_search_query(remove_accents(part2))
+    track_normalized = remove_accents(track_name)
+    artist_normalized = remove_accents(artist_name)
 
     score += _score_query_match(
         part1_normalized, part2_normalized, track_normalized, artist_normalized
@@ -279,10 +359,8 @@ def _score_penalties(
     if artist_name in track_name:
         penalty -= 50
 
-    for keyword in SPECIAL_VERSION_KEYWORDS:
-        if keyword in track_name:
-            penalty -= 30
-            break
+    if " - " in track_name or _SPECIAL_VERSION_RE.search(track_name):
+        penalty -= 30
 
     if len(track_name) > 60:
         penalty -= 20
@@ -297,7 +375,7 @@ def _score_penalties(
 
 def _normalize_for_detection(text: str) -> str:
     """Normalize text for artist/title format detection."""
-    return _remove_accents(clean_search_query(text.strip().lower()))
+    return remove_accents(clean_search_query(text.strip().lower()))
 
 
 def _is_similar(a: str, b: str) -> bool:
@@ -342,9 +420,12 @@ def _detect_artist_first(original_query: str, artist: str, title: str) -> bool:
     return False
 
 
-def _normalize_for_comparison(text: str) -> str:
+def normalize_for_comparison(text: str) -> str:
     """Normalize text for artist/track comparison by removing punctuation."""
-    normalized = re.sub(r"[._\-']", " ", text.lower())
+    normalized = text.lower().replace("&", " and ")
+    # Strip apostrophes entirely (possessives/contractions aren't word boundaries)
+    normalized = normalized.replace("'", "").replace("\u2019", "")
+    normalized = re.sub(r"[^\w\s]", " ", normalized)
     normalized = re.sub(r"\s+", " ", normalized)
     return normalized.strip()
 
@@ -352,11 +433,12 @@ def _normalize_for_comparison(text: str) -> str:
 def _strip_artist_from_track(track_name: str, artist_name: str) -> str:
     """Remove artist name from track title if it's embedded.
 
-    Last.fm sometimes returns track names like 'Artist - Title' or 'Artist-Title'.
-    Handles variations like "a-ha" vs "A ha" where punctuation differs.
+    Metadata APIs sometimes return track names like 'Artist - Title' or
+    'Artist-Title'. Handles variations like "a-ha" vs "A ha" where
+    punctuation differs.
     """
-    track_normalized = _normalize_for_comparison(track_name)
-    artist_normalized = _normalize_for_comparison(artist_name)
+    track_normalized = normalize_for_comparison(track_name)
+    artist_normalized = normalize_for_comparison(artist_name)
 
     if track_normalized.startswith(artist_normalized + " "):
         separator_pattern = r"^.{0,50}?(?:\s*[-\u2013\u2014|:]\s*|\s+/\s+)(.+)$"
@@ -366,7 +448,7 @@ def _strip_artist_from_track(track_name: str, artist_name: str) -> str:
             before_separator = track_name[: match.start(1)].strip()
             before_separator = re.sub(r"\s*[-\u2013\u2014|:/]\s*$", "", before_separator)
 
-            if _normalize_for_comparison(before_separator) == artist_normalized:
+            if normalize_for_comparison(before_separator) == artist_normalized:
                 return match.group(1)
 
     return track_name
@@ -392,7 +474,7 @@ def _preserve_original_artist(original_name: str, lastfm_artist: str) -> str | N
         return original_artist
 
     # Preserve original artist when Last.fm returned the accent-stripped equivalent
-    if _remove_accents(original_lower) == _remove_accents(lastfm_lower):
+    if remove_accents(original_lower) == remove_accents(lastfm_lower):
         return original_artist
 
     return None
@@ -407,8 +489,8 @@ def get_best_result(
 
     best = max(results, key=lambda r: score_result(r, original_query))
 
-    # Strip parenthetical extras like "(feat. ...)" or "(Single 2014)" from track names
-    clean_track_name = re.sub(r"\s*\([^)]*\)", "", best["name"])
+    # Strip parenthetical extras like "(Single 2014)" but preserve featuring credits
+    clean_track_name = _PAREN_NOT_FEAT.sub("", best["name"])
 
     # Strip artist from track name if it's duplicated
     clean_track_name = _strip_artist_from_track(clean_track_name, best["artist"])
@@ -449,6 +531,8 @@ def _lastfm_track_search(cleaned_query: str, limit: int | None = None) -> list[d
     }
     if limit is not None:
         params["limit"] = str(limit)
+
+    import requests
 
     for attempt in range(_MAX_RETRIES):
         if attempt > 0:
@@ -559,16 +643,17 @@ def _strip_attribution_and_noise(name: str) -> str:
     """Remove the matched attribution phrase and trailing noise from the title."""
     for pattern in ATTRIBUTION_PATTERNS:
         name = pattern.sub("", name)
-    # Strip remaining trailing bracketed/parenthesised content
-    name = re.sub(r"\s*[\(\[][^\)\]]*[\)\]]\s*$", "", name)
+    # Strip remaining trailing bracketed/parenthesised content, preserving featuring credits
+    name = re.sub(r"\s*\[[^\]]*\]\s*$", "", name)
+    name = _PAREN_NOT_FEAT_TRAILING.sub("", name)
     for noise_pat in TRAILING_NOISE_PATTERNS:
         prev = None
         while prev != name:
             prev = name
             name = noise_pat.sub("", name)
-    # Strip dangling separator left by noise removal (e.g. "Title -")
-    # before the caller composes "Title - Artist"
-    name = re.sub(r"\s*-\s*$", "", name)
+    # Strip dangling separator or open paren/bracket left by noise removal
+    # (e.g. "Title -" or "Title (") before the caller composes "Title - Artist"
+    name = re.sub(r"\s*[-(\[]\s*$", "", name)
     return name.strip()
 
 
@@ -580,8 +665,19 @@ def regex_tidy(filename: str) -> str:
     3. Otherwise strip trailing noise
     4. Normalize separators and whitespace
     """
-    name = EMOJI_PATTERN.sub("", filename)
+    name = EMOJI_PATTERN.sub(" ", filename)
     name = name.replace("_", " ")
+
+    # Strip leading noise labels like "KARAOKE - Title" or "[TJ노래방] Title"
+    name = _LEADING_NOISE.sub("", name)
+    name = _LEADING_BRACKET_NOISE_RE.sub("", name)
+
+    # Strip CJK metadata labels 【...】「...」; unwrap title brackets 《...》『...』
+    name = _CJK_STRIP_LABEL_RE.sub(" ", name)
+    name = _CJK_UNWRAP_TITLE_RE.sub(_replace_cjk_title_bracket, name)
+
+    # Normalize CJK dashes early so downstream patterns (noise, attribution) see " - "
+    name = _CJK_DASH_RE.sub(" - ", name)
 
     # Try to extract artist from attribution phrases
     artist = _extract_attribution_artist(name)
@@ -589,9 +685,9 @@ def regex_tidy(filename: str) -> str:
         title = _strip_attribution_and_noise(name)
         name = f"{title} - {artist}"
     else:
-        # Strip trailing parenthesised/bracketed content
-        name = re.sub(r"\s*\([^)]*\)\s*$", "", name)
-        name = re.sub(r"\s*\[[^\]]*\]\s*$", "", name)
+        # Strip trailing parenthesised/bracketed content, but preserve featuring credits
+        name = _PAREN_NOT_FEAT_TRAILING.sub("", name)
+        name = re.sub(r"\s*\[[^\]]*\]\s*$", "", name, flags=re.IGNORECASE)
         # Iteratively strip trailing noise patterns
         for noise_pat in TRAILING_NOISE_PATTERNS:
             prev = None
@@ -599,8 +695,10 @@ def regex_tidy(filename: str) -> str:
                 prev = name
                 name = noise_pat.sub("", name)
 
-    # Normalize separators: en-dash/em-dash -> " - "
-    name = re.sub(r"\s*[\u2013\u2014]\s*", " - ", name)
+    # Strip dangling open paren/bracket left by noise removal (e.g. "Title (")
+    name = re.sub(r"\s*[\(\[]\s*$", "", name)
+    # Normalize separators: en-dash, em-dash, big solidus, fullwidth solidus -> " - "
+    name = re.sub(r"\s*[\u2013\u2014\u29f8\uff0f]\s*", " - ", name)
     # Collapse whitespace
     name = re.sub(r"\s+", " ", name).strip()
     # Strip trailing dash left over from noise removal

--- a/pikaraoke/lib/preference_manager.py
+++ b/pikaraoke/lib/preference_manager.py
@@ -45,7 +45,7 @@ class PreferenceManager:
         "mid_score_phrases": "",
         "high_score_phrases": "",
         "show_splash_clock": False,
-        "enable_title_tidy": True,
+        "enable_title_tidy": False,
     }
 
     def __init__(self, config_file_path: str = "config.ini", target: object | None = None) -> None:

--- a/pikaraoke/lib/preference_manager.py
+++ b/pikaraoke/lib/preference_manager.py
@@ -45,6 +45,7 @@ class PreferenceManager:
         "mid_score_phrases": "",
         "high_score_phrases": "",
         "show_splash_clock": False,
+        "enable_title_tidy": True,
     }
 
     def __init__(self, config_file_path: str = "config.ini", target: object | None = None) -> None:

--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os
 import re
+from collections.abc import Callable
 
 from pikaraoke.lib.get_platform import is_windows
 from pikaraoke.lib.karaoke_database import KaraokeDatabase
@@ -29,10 +30,16 @@ class SongManager:
     delete, rename, and display name operations.
     """
 
-    def __init__(self, download_path: str, db: KaraokeDatabase) -> None:
+    def __init__(
+        self,
+        download_path: str,
+        db: KaraokeDatabase,
+        get_title_tidy: Callable[[], bool] | None = None,
+    ) -> None:
         self.download_path = download_path
         self.songs = SongList()
         self._db = db
+        self._get_title_tidy = get_title_tidy
 
     @staticmethod
     def filename_from_path(
@@ -57,6 +64,11 @@ class SongManager:
             if tidied:
                 name = tidied
         return name
+
+    def display_name_from_path(self, file_path: str, remove_youtube_id: bool = True) -> str:
+        """Extract display name from path, respecting the enable_title_tidy preference."""
+        tidy = self._get_title_tidy() if self._get_title_tidy else True
+        return self.filename_from_path(file_path, remove_youtube_id=remove_youtube_id, tidy=tidy)
 
     def _get_companion_files(self, song_path: str) -> list[str]:
         """Return paths to companion files (.cdg, .ass) that exist alongside a song."""

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -56,12 +56,12 @@ def browse():
         result = []
         if letter == "numeric":
             for song in available_songs:
-                f = k.song_manager.filename_from_path(song)[0]
+                f = k.song_manager.display_name_from_path(song)[0]
                 if f.isnumeric():
                     result.append(song)
         else:
             for song in available_songs:
-                f = k.song_manager.filename_from_path(song).lower()
+                f = k.song_manager.display_name_from_path(song).lower()
                 # Normalize accented characters so e.g. "Édith" matches "e"
                 normalized = unicodedata.normalize("NFD", f)
                 base_char = normalized[0] if normalized else ""
@@ -137,7 +137,7 @@ def delete_file(query):
         k.song_manager.delete(song_path)
         # MSG: Message shown after deleting a song. Followed by the song path
         flash(
-            _("Song deleted: %s") % k.song_manager.filename_from_path(song_path),
+            _("Song deleted: %s") % k.song_manager.display_name_from_path(song_path),
             "is-warning",
         )
     return redirect(referrer)

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -74,6 +74,7 @@ def info():
         languages=LANGUAGES,
         preferred_language=preferred_language,
         browse_results_per_page=k.browse_results_per_page,
+        enable_title_tidy=k.enable_title_tidy,
         score_phrases={
             "low": k.low_score_phrases,
             "mid": k.mid_score_phrases,

--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -136,7 +136,7 @@ def queue_edit(query):
         success = True
     else:
         song = unquote(query.get("song", ""))
-        song_title = k.song_manager.filename_from_path(song)
+        song_title = k.song_manager.display_name_from_path(song)
 
         # MSG labels for each action
         success_labels = {
@@ -181,7 +181,7 @@ def _do_enqueue(song: str, user: str) -> str:
     k = get_karaoke_instance()
     rc = k.queue_manager.enqueue(song, user)
     broadcast_event("queue_update")
-    song_title = k.song_manager.filename_from_path(song)
+    song_title = k.song_manager.display_name_from_path(song)
     return json.dumps({"song": song_title, "success": rc})
 
 

--- a/pikaraoke/routes/search.py
+++ b/pikaraoke/routes/search.py
@@ -75,7 +75,7 @@ def autocomplete(query):
             result.append(
                 {
                     "path": each,
-                    "fileName": k.song_manager.filename_from_path(each),
+                    "fileName": k.song_manager.display_name_from_path(each),
                     "type": "autocomplete",
                 }
             )

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -431,6 +431,12 @@
 					</label>
 					</div>
 
+					<div class="user-preference-container">
+					<input id="pref-enable-title-tidy" type="checkbox" class="user-preference-checkbox checkbox" data-pref="enable_title_tidy" {% if enable_title_tidy == True %}checked{% endif %}>
+					<label class="label" for="pref-enable-title-tidy">{# MSG: Checkbox label which enables automatic cleanup of YouTube song titles #} {% trans %}Enable automatic YouTube title cleanup (strips noise words like "Karaoke Version HD"){% endtrans %}
+					</label>
+					</div>
+
 					<div class="user-preference-container is-align-items-center">
 					<input id="pref-avsync" class="user-preference-input input" type="number" step="0.1" min="-10" max="10" data-pref="avsync" data-start-value="{{ avsync }}" value="{{ avsync }}" />
 					<label class="label" for="pref-avsync">

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -88,6 +88,18 @@ class TestCleanSearchQuery:
         assert "\U0001f3a4" not in result
         assert "\U0001f3b5" not in result
 
+    def test_preserves_cjk_characters(self):
+        result = clean_search_query("\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba KARAOKE")
+        assert "\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba" in result
+
+    def test_preserves_japanese_characters(self):
+        result = clean_search_query("\u30ab\u30e9\u30aa\u30b1 \u30bd\u30f3\u30b0")
+        assert "\u30ab\u30e9\u30aa\u30b1" in result
+
+    def test_preserves_hangul(self):
+        result = clean_search_query("\uac00\ub098\ub2e4\ub77c - \ub178\ub798")
+        assert "\uac00\ub098\ub2e4\ub77c" in result
+
     def test_strips_whitespace(self):
         result = clean_search_query("  Artist - Song  ")
         assert not result.startswith(" ")
@@ -518,6 +530,13 @@ class TestRegexTidy:
     def test_no_dangling_separator_after_noise_and_attribution_removal(self):
         result = regex_tidy("Fernando - KARAOKE VERSION - as popularized by ABBA")
         assert result == "Fernando - ABBA"
+
+    def test_preserves_cjk_title(self):
+        result = regex_tidy(
+            "\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba-\u738b\u9756\u96ef-\u4f34\u594f KARAOKE"
+        )
+        assert "\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba" in result
+        assert "\u738b\u9756\u96ef" in result
 
     def test_no_change_when_clean(self):
         assert regex_tidy("Artist - Song Title") == "Artist - Song Title"

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -88,6 +88,10 @@ class TestCleanSearchQuery:
         assert "\U0001f3a4" not in result
         assert "\U0001f3b5" not in result
 
+    def test_emoji_removal_preserves_word_boundaries(self):
+        result = clean_search_query("I Will Survive\U0001f3a4HQ")
+        assert result == "I Will Survive"
+
     def test_preserves_cjk_characters(self):
         result = clean_search_query("\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba KARAOKE")
         assert "\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba" in result
@@ -189,6 +193,14 @@ class TestScoreResult:
         score_live = score_result(result_live, "Artist - Song")
         score_normal = score_result(result_normal, "Artist - Song")
         assert score_live < score_normal
+
+    def test_version_keyword_uses_word_boundaries(self):
+        """'Oliver's Army' should not be penalized for containing 'live'."""
+        result = {"name": "Oliver's Army", "artist": "Elvis Costello"}
+        score = score_result(result, "Elvis Costello - Oliver's Army")
+        result_live = {"name": "Oliver's Army - Live", "artist": "Elvis Costello"}
+        score_live = score_result(result_live, "Elvis Costello - Oliver's Army")
+        assert score > score_live
 
     def test_bad_keyword_penalization_remix(self):
         result = {"name": "Song remix", "artist": "Artist"}
@@ -296,20 +308,20 @@ class TestGetBestResult:
 class TestLookupLastfm:
     """Tests for the lookup_lastfm function (pure Last.fm path)."""
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_returns_none_on_api_error(self, mock_get):
         mock_get.return_value.status_code = 500
         result = lookup_lastfm("Artist - Song")
         assert result is None
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_returns_none_on_empty_results(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {"results": {"trackmatches": {"track": []}}}
         result = lookup_lastfm("Unknown Song That Doesn't Exist")
         assert result is None
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_returns_best_match(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {
@@ -324,7 +336,7 @@ class TestLookupLastfm:
         result = lookup_lastfm("Coldplay - Viva La Vida")
         assert result == "Coldplay - Viva La Vida"
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_cleans_query_before_search(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {"results": {"trackmatches": {"track": []}}}
@@ -334,7 +346,7 @@ class TestLookupLastfm:
         assert "karaoke" not in params["track"].lower()
         assert "official" not in params["track"].lower()
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_preserves_format_from_original_filename(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {
@@ -349,7 +361,7 @@ class TestLookupLastfm:
         result = lookup_lastfm("Artist Name - Song Title (Official Video) karaoke")
         assert result == "Artist Name - Song Title"
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_returns_none_on_missing_trackmatches(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {"results": {}}
@@ -368,7 +380,7 @@ class TestRateLimiting:
     """Tests for Last.fm rate limiting, retry, and cache-skip behavior."""
 
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_error_29_triggers_retry_and_succeeds(self, mock_get, mock_sleep):
         rate_limit_resp = MagicMock(status_code=200)
         rate_limit_resp.json.return_value = RATE_LIMIT_RESPONSE
@@ -383,7 +395,7 @@ class TestRateLimiting:
         assert mock_get.call_count == 2
 
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_http_429_triggers_retry_and_succeeds(self, mock_get, mock_sleep):
         http_429_resp = MagicMock(status_code=429)
 
@@ -396,7 +408,7 @@ class TestRateLimiting:
         assert "Viva La Vida" in result
 
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_rate_limited_result_not_cached(self, mock_get, mock_sleep):
         rate_limit_resp = MagicMock(status_code=200)
         rate_limit_resp.json.return_value = RATE_LIMIT_RESPONSE
@@ -413,7 +425,7 @@ class TestRateLimiting:
         assert "Viva La Vida" in result
 
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_genuine_no_results_is_cached(self, mock_get, mock_sleep):
         ok_resp = MagicMock(status_code=200)
         ok_resp.json.return_value = {"results": {"trackmatches": {"track": []}}}
@@ -426,7 +438,7 @@ class TestRateLimiting:
         assert mock_get.call_count == 1
 
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_max_retries_exhausted(self, mock_get, mock_sleep):
         rate_limit_resp = MagicMock(status_code=200)
         rate_limit_resp.json.return_value = RATE_LIMIT_RESPONSE
@@ -436,7 +448,7 @@ class TestRateLimiting:
         assert result is None
         assert mock_get.call_count == 3
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
     def test_backoff_timing(self, mock_sleep, mock_get):
         rate_limit_resp = MagicMock(status_code=200)
@@ -483,6 +495,10 @@ class TestRegexTidy:
     def test_removes_emoji(self):
         result = regex_tidy("Artist - Song \U0001f3a4")
         assert "\U0001f3a4" not in result
+
+    def test_emoji_removal_preserves_word_boundaries(self):
+        result = regex_tidy("CAKE _ I Will Survive\U0001f3a4HQ Karaoke\U0001f3a4")
+        assert result == "CAKE I Will Survive"
 
     def test_normalizes_em_dash(self):
         assert regex_tidy("Artist \u2014 Song") == "Artist - Song"
@@ -538,8 +554,129 @@ class TestRegexTidy:
         assert "\u5bb9\u6613\u53d7\u50b7\u7684\u5973\u4eba" in result
         assert "\u738b\u9756\u96ef" in result
 
+    def test_no_dangling_open_paren_after_noise_removal(self):
+        result = regex_tidy(
+            "Paul Kelly - Firewood and Candles (Karaoke Version) with Lyrics HD Vocal-Star Karaoke"
+        )
+        assert result == "Paul Kelly - Firewood and Candles"
+
+    def test_preserves_feat_parenthetical(self):
+        assert regex_tidy("Artist - Song (feat. Other)") == "Artist - Song (feat. Other)"
+
+    def test_preserves_ft_parenthetical(self):
+        assert regex_tidy("Artist - Song (ft. Other Artist)") == "Artist - Song (ft. Other Artist)"
+
+    def test_strips_feat_bracketed(self):
+        assert regex_tidy("Artist - Song [feat. Other]") == "Artist - Song"
+
+    def test_strips_leading_karaoke_label(self):
+        result = regex_tidy("KARAOKE - Cry Me a River by Julie London")
+        assert result == "Cry Me a River by Julie London"
+
+    def test_strips_leading_instrumental_label(self):
+        assert regex_tidy("Instrumental - Artist - Song") == "Artist - Song"
+
+    def test_strips_leading_official_video_with_pipe(self):
+        assert regex_tidy("Official Video | Artist - Song") == "Artist - Song"
+
+    def test_strips_leading_official_music_video(self):
+        assert regex_tidy("Official Music Video - Artist - Song") == "Artist - Song"
+
     def test_no_change_when_clean(self):
         assert regex_tidy("Artist - Song Title") == "Artist - Song Title"
+
+    # -- CJK dash normalization (Kana / Hangul) --------------------------------
+
+    def test_cjk_dash_normalizes_katakana(self):
+        assert regex_tidy("アーティスト-曲名") == "アーティスト - 曲名"
+
+    def test_cjk_dash_normalizes_hangul(self):
+        assert regex_tidy("가수-노래제목") == "가수 - 노래제목"
+
+    def test_cjk_dash_normalizes_hiragana(self):
+        assert regex_tidy("あいみょん-マリーゴールド") == "あいみょん - マリーゴールド"
+
+    # -- Japanese corner brackets ----------------------------------------------
+
+    def test_strips_corner_bracket_label(self):
+        assert regex_tidy("Song Title「カラオケ」") == "Song Title"
+
+    def test_strips_corner_bracket_with_content(self):
+        assert regex_tidy("曲名「歌ってみた」- Artist") == "曲名 - Artist"
+
+    def test_unwraps_white_corner_bracket_title(self):
+        assert regex_tidy("Singer -『Song Title』") == "Singer - Song Title"
+
+    def test_strips_white_corner_bracket_noise(self):
+        assert regex_tidy("Song Title『カラオケ』") == "Song Title"
+
+    def test_strips_white_corner_bracket_ktv(self):
+        assert regex_tidy("Song Title『KTV』") == "Song Title"
+
+    # -- Japanese trailing noise -----------------------------------------------
+
+    def test_strips_trailing_uttemita(self):
+        assert regex_tidy("Artist - Song 歌ってみた") == "Artist - Song"
+
+    def test_strips_trailing_off_vocal_ja(self):
+        assert regex_tidy("Artist - Song オフボーカル") == "Artist - Song"
+
+    def test_strips_trailing_vocaloid(self):
+        assert regex_tidy("Artist - Song ボカロ") == "Artist - Song"
+
+    def test_strips_trailing_cover_ja(self):
+        assert regex_tidy("Artist - Song カバー") == "Artist - Song"
+
+    # -- Korean trailing noise -------------------------------------------------
+
+    def test_strips_trailing_noraebang(self):
+        assert regex_tidy("Artist - Song 노래방") == "Artist - Song"
+
+    def test_strips_trailing_keumyoung(self):
+        assert regex_tidy("Artist - Song 금영") == "Artist - Song"
+
+    def test_strips_trailing_taejin(self):
+        assert regex_tidy("Artist - Song 태진") == "Artist - Song"
+
+    def test_strips_trailing_tj(self):
+        assert regex_tidy("Artist - Song TJ") == "Artist - Song"
+
+    def test_strips_trailing_mr(self):
+        assert regex_tidy("Artist - Song MR") == "Artist - Song"
+
+    # -- Korean leading noise --------------------------------------------------
+
+    def test_strips_leading_noraebang(self):
+        assert regex_tidy("노래방 - Song Title") == "Song Title"
+
+    def test_strips_leading_bracket_tj_noraebang(self):
+        assert regex_tidy("[TJ노래방] APT. - Artist") == "APT. - Artist"
+
+    def test_strips_leading_bracket_karaoke(self):
+        assert regex_tidy("[Karaoke] Artist - Song") == "Artist - Song"
+
+    # -- Bracket noise detection with Korean -----------------------------------
+
+    def test_strips_angle_bracket_noraebang(self):
+        assert regex_tidy("Song Title《노래방》") == "Song Title"
+
+    def test_strips_white_corner_bracket_noraebang(self):
+        assert regex_tidy("Song Title『노래방』") == "Song Title"
+
+    # -- Realistic CJK integration tests ---------------------------------------
+
+    def test_japanese_karaoke_filename(self):
+        assert regex_tidy("YOASOBI-夜に駆ける「カラオケ」歌ってみた") == "YOASOBI - 夜に駆ける"
+
+    def test_korean_karaoke_filename(self):
+        assert regex_tidy("BTS - Dynamite 노래방 MR") == "BTS - Dynamite"
+
+    def test_korean_tj_noraebang_full(self):
+        result = regex_tidy("[TJ노래방] APT. - 로제(ROSE),Bruno Mars _ TJ Karaoke")
+        assert result == "APT. - 로제(ROSE),Bruno Mars"
+
+    def test_chinese_title_in_white_corner_brackets(self):
+        assert regex_tidy("周杰倫 -『稻香』") == "周杰倫 - 稻香"
 
 
 class TestYoutubeIdSuffix:
@@ -596,7 +733,7 @@ class TestHasArtistTitleSeparator:
 class TestSearchLastfmTracks:
     """Tests for the search_lastfm_tracks function."""
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_returns_formatted_results(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {
@@ -612,7 +749,7 @@ class TestSearchLastfmTracks:
         assert results == [{"name": "Song", "artist": "Artist"}]
 
     @patch("pikaraoke.lib.metadata_parser.time.sleep")
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_returns_empty_on_rate_limit(self, mock_get, mock_sleep):
         rate_limit_resp = MagicMock(status_code=200)
         rate_limit_resp.json.return_value = RATE_LIMIT_RESPONSE
@@ -621,7 +758,7 @@ class TestSearchLastfmTracks:
         results = search_lastfm_tracks("Artist - Song")
         assert results == []
 
-    @patch("pikaraoke.lib.metadata_parser.requests.get")
+    @patch("requests.get")
     def test_passes_limit_param(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {"results": {"trackmatches": {"track": []}}}

--- a/tests/unit/test_preference_manager.py
+++ b/tests/unit/test_preference_manager.py
@@ -284,6 +284,7 @@ def test_preference_manager_defaults_exist():
         "mid_score_phrases",
         "high_score_phrases",
         "show_splash_clock",
+        "enable_title_tidy",
     }
 
     assert set(PreferenceManager.DEFAULTS.keys()) == expected_keys

--- a/tests/unit/test_queue_reorder.py
+++ b/tests/unit/test_queue_reorder.py
@@ -80,7 +80,7 @@ class TestQueueReorderSocketUpdates:
         client,
         queue_with_events,
     ):
-        queue_with_events.song_manager.filename_from_path.return_value = "song2"
+        queue_with_events.song_manager.display_name_from_path.return_value = "song2"
         mock_get_instance.return_value = queue_with_events
 
         response = client.get("/queue/edit?action=top&song=song2")
@@ -101,7 +101,7 @@ class TestQueueReorderSocketUpdates:
         client,
         queue_with_events,
     ):
-        queue_with_events.song_manager.filename_from_path.return_value = "song1"
+        queue_with_events.song_manager.display_name_from_path.return_value = "song1"
         mock_get_instance.return_value = queue_with_events
 
         response = client.get("/queue/edit?action=bottom&song=song1")

--- a/tests/unit/test_queue_routes.py
+++ b/tests/unit/test_queue_routes.py
@@ -165,7 +165,7 @@ class TestQueueEditSocketUpdates:
 
         mock_karaoke = MagicMock()
         mock_karaoke.queue_manager = qm
-        mock_karaoke.song_manager.filename_from_path.return_value = "song"
+        mock_karaoke.song_manager.display_name_from_path.return_value = "song"
 
         return qm, mock_karaoke, queue_updates, now_playing_updates
 


### PR DESCRIPTION
Emoji patterns have been adjusted to not strip CJK characters when cleaning YouTube file names.