### PR TITLE
chore: bump yt-dlp version to 2026.07.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     name: Smoke Test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
     - name: Checkout code

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -82,6 +82,7 @@ def upgrade_youtubedl() -> str:
         logging.warning(f"Could not run yt-dlp for upgrade: {e}")
         return get_youtubedl_version()
 
+    logging.info(output)
     # Check if already up to date
     if "is up to date" in output.lower():
         logging.debug("yt-dlp is already up to date")
@@ -106,7 +107,7 @@ def upgrade_youtubedl() -> str:
     if upgrade_success:
         logging.info(f"Done. Installed version: {youtubedl_version}")
     else:
-        logging.error("Failed to upgrade yt-dlp.")
+        logging.error(f"Failed to upgrade yt-dlp. Current version: {youtubedl_version}")
     return youtubedl_version
 
 

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -76,13 +76,13 @@ def upgrade_youtubedl() -> str:
             .decode("utf8")
             .strip()
         )
+        logging.debug(output)
     except subprocess.CalledProcessError as e:
         output = e.output.decode("utf8")
     except (FileNotFoundError, PermissionError) as e:
         logging.warning(f"Could not run yt-dlp for upgrade: {e}")
         return get_youtubedl_version()
 
-    logging.info(output)
     # Check if already up to date
     if "is up to date" in output.lower():
         logging.debug("yt-dlp is already up to date")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "Babel==2.17.0",
   "Flask-Babel==4.0.0",
   "ffmpeg-python==0.2.0",
-  "yt-dlp[default]>=2026.03.03",
+  "yt-dlp[default]>=2026.07.04",
   "flask-socketio>=5.5.0",
   "gevent>=24.11.1",
   "sounddevice>=0.5.0; sys_platform != 'linux'",

--- a/uv.lock
+++ b/uv.lock
@@ -975,7 +975,7 @@ requires-dist = [
     { name = "qrcode", extras = ["png"], specifier = "==8.2" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "sounddevice", marker = "sys_platform != 'linux'", specifier = ">=0.5.0" },
-    { name = "yt-dlp", extras = ["default"], specifier = ">=2026.3.3" },
+    { name = "yt-dlp", extras = ["default"], specifier = ">=2026.7.4" },
 ]
 provides-extras = ["dev"]
 
@@ -1502,16 +1502,16 @@ wheels = [
 
 [[package]]
 name = "yt-dlp"
-version = "2026.3.3"
+version = "2026.7.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/6f/7427d23609353e5ef3470ff43ef551b8bd7b166dd4fef48957f0d0e040fe/yt_dlp-2026.3.3.tar.gz", hash = "sha256:3db7969e3a8964dc786bdebcffa2653f31123bf2a630f04a17bdafb7bbd39952", size = 3118658, upload-time = "2026-03-03T16:54:53.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/a4/8b5cd28ab87aef48ef15e74241befec3445496327db028f34147a9e0f14f/yt_dlp-2026.3.3-py3-none-any.whl", hash = "sha256:166c6e68c49ba526474bd400e0129f58aa522c2896204aa73be669c3d2f15e63", size = 3315599, upload-time = "2026-03-03T16:54:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
 ]
 
 [package.optional-dependencies]
 default = [
-    { name = "brotli", marker = "implementation_name == 'cpython'" },
+    { name = "brotli", marker = "implementation_name == 'cpython' and sys_platform != 'ios'" },
     { name = "brotlicffi", marker = "implementation_name != 'cpython'" },
     { name = "certifi" },
     { name = "mutagen" },
@@ -1524,11 +1524,11 @@ default = [
 
 [[package]]
 name = "yt-dlp-ejs"
-version = "0.5.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/0d/b9e4ab1b47cdeba0842df634b74b3c0144307640ad5b632a5e189c4ab7ce/yt_dlp_ejs-0.5.0.tar.gz", hash = "sha256:8dfae59e418232f485253dcf8e197fefa232423c3af7824fe19e4517b173293b", size = 98925, upload-time = "2026-02-21T19:29:16.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e6/cceb9530e8f4e5940f6f7822d90e9d94f1b85343329a16baaf47bbbb3de1/yt_dlp_ejs-0.8.0.tar.gz", hash = "sha256:d5fa1639f63b5c4af8d932495f60689d5370f1a095782c944f7f62a303eb104e", size = 96571, upload-time = "2026-03-17T22:49:19.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/5b/1283356b70d4893a8a050cee15092e1b08ea15310b94365f88067146721b/yt_dlp_ejs-0.5.0-py3-none-any.whl", hash = "sha256:674fc0efea741d3100cdf3f0f9e123150715ee41edf47ea7a62fbdeda204bdec", size = 54032, upload-time = "2026-02-21T19:29:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/520769863744b669440a924271a6159ddd82ad5ae26b4ac4d4b69e9f8d44/yt_dlp_ejs-0.8.0-py3-none-any.whl", hash = "sha256:79300e5fca7f937a1eeede11f0456862c1b41107ce1d726871e0207424f4bdb4", size = 53443, upload-time = "2026-03-17T22:49:17.736Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump yt-dlp version and remove osx smoke test for now (hitting rate limiting fetching the yt-dlp version on GHA for some reason)