### PR TITLE
fix: use per-port QR code filename for multi-instance setups

### DIFF
--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -409,9 +409,11 @@ class Karaoke:
         qr.add_data(self.url)
         qr.make()
         img = qr.make_image(image_factory=PyPNGImage)
-        # Use writable data directory instead of program directory
+        # Use writable data directory instead of program directory.
+        # Include the port so multiple instances on the same host don't
+        # overwrite each other's QR code (see issue #836).
         data_dir = get_data_directory()
-        self.qr_code_path = os.path.join(data_dir, "qrcode.png")
+        self.qr_code_path = os.path.join(data_dir, f"qrcode-{self.port}.png")
         img.save(self.qr_code_path)  # type: ignore[arg-type]
 
     def send_notification(self, message: str, color: str = "primary") -> None:


### PR DESCRIPTION
Fixes #836 - when multiple PiKaraoke instances run on the same host (different ports), the QR code shown on every splash screen points to the **last-started** instance's port instead of its own.