### PR TITLE
fix: server 500 error for invalid password

### DIFF
--- a/pikaraoke/routes/admin.py
+++ b/pikaraoke/routes/admin.py
@@ -177,7 +177,7 @@ def auth(form):
         # MSG: Message shown after logging in as admin successfully
         flash(_("Admin mode granted!"), "is-success")
     else:
-        resp = make_response(redirect(url_for("admin.login", next=next_url)))
+        resp = make_response(redirect(next_url))
         # MSG: Message shown after failing to login as admin
         flash(_("Incorrect admin password!"), "is-danger")
     return resp


### PR DESCRIPTION
When entering an incorrect admin password the system would produce a server 500 error because the redirect page no longer exists.

Now, the system shows the invalid password error correctly from the info.html page.