### PR TITLE
feat: CLI parameter to skip yt-dlp upgrade check

### DIFF
--- a/build_scripts/ci/smoketest.ps1
+++ b/build_scripts/ci/smoketest.ps1
@@ -14,7 +14,7 @@ Write-Host "Installing PiKaraoke for CI..."
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 
 Write-Host "Starting PiKaraoke in headless mode..."
-$proc = Start-Process pikaraoke -ArgumentList "--headless" -PassThru -RedirectStandardOutput output.log -RedirectStandardError error.log
+$proc = Start-Process pikaraoke -ArgumentList "--headless", "--skip-youtubedl-upgrade" -PassThru -RedirectStandardOutput output.log -RedirectStandardError error.log
 
 try {
     Write-Host "Waiting for PiKaraoke to initialize (max 30s)..."

--- a/build_scripts/ci/smoketest.sh
+++ b/build_scripts/ci/smoketest.sh
@@ -10,7 +10,7 @@ echo "Installing PiKaraoke for CI..."
 ./build_scripts/install/install.sh -y --local
 
 echo "Starting PiKaraoke in headless mode..."
-pikaraoke --headless > output.log 2>&1 &
+pikaraoke --headless --skip-youtubedl-upgrade > output.log 2>&1 &
 PID=$!
 
 # Function to cleanup on exit

--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -299,7 +299,10 @@ def main() -> None:
     app.jinja_env.globals.update(filename_from_path=k.song_manager.display_name_from_path)
     app.jinja_env.globals.update(url_escape=quote)
 
-    spawn(upgrade_youtubedl)
+    if not args.skip_youtubedl_upgrade:
+        spawn(upgrade_youtubedl)
+    else:
+        logging.info("Skipping yt-dlp upgrade on startup")
 
     server = WSGIServer(("0.0.0.0", int(args.port)), app, log=None, error_log=logging.getLogger())
     server.start()

--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -100,6 +100,13 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         required=False,
     )
     parser.add_argument(
+        "--skip-youtubedl-upgrade",
+        "--skip-ytdl-upgrade",
+        action="store_true",
+        help="Skip automatic yt-dlp upgrade check on startup.",
+        required=False,
+    )
+    parser.add_argument(
         "-l",
         "--log-level",
         help=f"Logging level int value (DEBUG: 10, INFO: 20, WARNING: 30, ERROR: 40, CRITICAL: 50). (default: {default_log_level})",

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from pikaraoke.lib.args import arg_path_parse, parse_volume
+from pikaraoke.lib.args import arg_path_parse, parse_pikaraoke_args, parse_volume
 
 
 class TestArgPathParse:
@@ -75,3 +75,22 @@ class TestParseVolume:
         """Test that decimal precision is preserved."""
         result = parse_volume("0.333", "test volume")
         assert result == 0.333
+
+
+class TestParsePikaraokeArgs:
+    """Tests for parse_pikaraoke_args."""
+
+    def test_skip_youtubedl_upgrade_default(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["pikaraoke"])
+        args = parse_pikaraoke_args()
+        assert args.skip_youtubedl_upgrade is False
+
+    def test_skip_youtubedl_upgrade_flag(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["pikaraoke", "--skip-youtubedl-upgrade"])
+        args = parse_pikaraoke_args()
+        assert args.skip_youtubedl_upgrade is True
+
+    def test_skip_ytdl_upgrade_alias(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["pikaraoke", "--skip-ytdl-upgrade"])
+        args = parse_pikaraoke_args()
+        assert args.skip_youtubedl_upgrade is True


### PR DESCRIPTION
yt-dlp upgrade check on start should be optional. In CI environment it is a bit flaky so remove it from the smoke test