### PR TITLE
fix: direct download queue checkbox

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
+from urllib.parse import parse_qs, urlparse
 
 from pikaraoke.lib.get_platform import get_installed_js_runtime
 
 yt_dlp_cmd = [sys.executable, "-m", "yt_dlp"]
+
+# YouTube video IDs are always exactly 11 characters
+YOUTUBE_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{11}")
 
 
 def _js_runtime_args() -> list[str]:
@@ -43,23 +48,26 @@ def get_youtube_id_from_url(url: str) -> str | None:
 
     Supports youtube.com/watch?v=, m.youtube.com/?v=, and youtu.be/ formats.
 
+    The ID is validated against the canonical 11-character shape so tracking
+    params (&pp=, &t=, &si=) can never leak into the ID and silently break
+    lookups of the downloaded file.
+
     Args:
         url: YouTube video URL.
 
     Returns:
         The video ID string, or None if parsing failed.
     """
-    if "v=" in url:  # accommodates youtube.com/watch?v= and m.youtube.com/?v=
-        s = url.split("watch?v=")
-    else:  # accommodates youtu.be/
-        s = url.split("u.be/")
-    if len(s) == 2:
-        if "?" in s[1]:  # Strip unneeded YouTube params
-            s[1] = s[1][0 : s[1].index("?")]
-        return s[1]
+    parsed = urlparse(url)
+    if parsed.hostname and parsed.hostname.endswith("youtu.be"):
+        video_id = parsed.path.lstrip("/").split("/")[0]
     else:
+        video_id = parse_qs(parsed.query).get("v", [""])[0]
+
+    if not YOUTUBE_ID_PATTERN.fullmatch(video_id):
         logging.error(f"Error parsing youtube id from url: {url}")
         return None
+    return video_id
 
 
 def upgrade_youtubedl() -> str:

--- a/pikaraoke/templates/search.html
+++ b/pikaraoke/templates/search.html
@@ -233,7 +233,7 @@
 		$("#direct-download-button").click(function () {
 			var url = $("#direct-download-url").val();
 			if (!url) return;
-			downloadSong(url, "", this);
+			downloadSong(url, "", this, $("#add-to-queue-direct").is(":checked"));
 		});
 
 		$("#add-queue-link").click(function () {});
@@ -472,7 +472,7 @@
 			$("#add-to-queue-direct, #add-to-queue-search").prop("checked", isChecked);
 		});
 
-		function downloadSong(songUrl, songTitle, button) {
+		function downloadSong(songUrl, songTitle, button, addToQueue) {
 			var $btn = $(button);
 			var originalText = $btn.html();
 			$btn.css("min-width", $btn.outerWidth() + "px");
@@ -485,7 +485,7 @@
 					song_url: songUrl,
 					song_title: songTitle || "",
 					song_added_by: getUserCookie() || "",
-					queue: $("#add-to-queue-search").is(":checked"),
+					queue: addToQueue,
 				}),
 				success: function () {
 					$btn.removeClass("is-loading").addClass("is-success")
@@ -511,7 +511,7 @@
 			item.querySelector("button").addEventListener("click", function () {
 				const url = item.getAttribute("value");
 				const title = item.getAttribute("data-ytTitle");
-				downloadSong(url, title, this);
+				downloadSong(url, title, this, $("#add-to-queue-search").is(":checked"));
 			})
 		);
 

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -164,14 +164,14 @@ class TestDownloadManagerExecuteDownload:
         mock_popen.return_value = mock_process
 
         # Mock find_by_id to return a path
-        song_manager.songs.find_by_id.return_value = "/songs/Artist - Song---abc123.mp4"
+        song_manager.songs.find_by_id.return_value = "/songs/Artist - Song---dQw4w9WgXcQ.mp4"
 
         rc = download_manager._execute_download(
-            "https://youtube.com/watch?v=abc123", False, "User", "Title"
+            "https://youtube.com/watch?v=dQw4w9WgXcQ", False, "User", "Title"
         )
 
         assert rc == 0
-        song_manager.songs.find_by_id.assert_called_once_with("/songs", "abc123")
+        song_manager.songs.find_by_id.assert_called_once_with("/songs", "dQw4w9WgXcQ")
         # add_if_valid is no longer called directly; a "song_downloaded" event is emitted instead
         assert any("Downloaded" in n for n in notifications)
 
@@ -197,15 +197,15 @@ class TestDownloadManagerExecuteDownload:
         mock_popen.return_value = mock_process
 
         # Mock find_by_id
-        song_manager.songs.find_by_id.return_value = "/songs/Song---abc.mp4"
+        song_manager.songs.find_by_id.return_value = "/songs/Song---dQw4w9WgXcQ.mp4"
         song_manager.songs.add_if_valid.return_value = True
 
         download_manager._execute_download(
-            "https://youtube.com/watch?v=abc", True, "TestUser", "Title"
+            "https://youtube.com/watch?v=dQw4w9WgXcQ", True, "TestUser", "Title"
         )
 
         queue_manager.enqueue.assert_called_once_with(
-            "/songs/Song---abc.mp4", "TestUser", log_action=False
+            "/songs/Song---dQw4w9WgXcQ.mp4", "TestUser", log_action=False
         )
 
     @patch("flask_babel._", side_effect=lambda x: x)

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -32,16 +32,30 @@ class TestGetYoutubeIdFromUrl:
         url = "https://youtu.be/dQw4w9WgXcQ"
         assert get_youtube_id_from_url(url) == "dQw4w9WgXcQ"
 
-    def test_url_with_extra_params(self):
-        """Test parsing URL with additional parameters after ?."""
-        # Note: current implementation only strips params after second ?
-        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ?extra=param"
+    def test_url_with_trailing_params(self):
+        """Test that params after the video ID are stripped."""
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&pp=ygUHa2FyYW9rZQ%3D%3D"
+        assert get_youtube_id_from_url(url) == "dQw4w9WgXcQ"
+
+    def test_url_with_leading_params(self):
+        """Test parsing when v= is not the first query parameter."""
+        url = "https://www.youtube.com/watch?app=desktop&v=dQw4w9WgXcQ"
         assert get_youtube_id_from_url(url) == "dQw4w9WgXcQ"
 
     def test_short_url_with_params(self):
         """Test parsing short URL with parameters."""
         url = "https://youtu.be/dQw4w9WgXcQ?t=30"
         assert get_youtube_id_from_url(url) == "dQw4w9WgXcQ"
+
+    def test_short_url_with_tracking_params(self):
+        """Test parsing share-style short URL with tracking params."""
+        url = "https://youtu.be/dQw4w9WgXcQ?si=abcdefghijkl"
+        assert get_youtube_id_from_url(url) == "dQw4w9WgXcQ"
+
+    def test_malformed_id_returns_none(self):
+        """Test that a value which isn't a valid 11-char ID is rejected."""
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ?extra=param"
+        assert get_youtube_id_from_url(url) is None
 
     def test_invalid_url_returns_none(self):
         """Test that invalid URL returns None."""


### PR DESCRIPTION
Fixes #824 — songs downloading but not landing in the queue

Two separate things were stopping a downloaded song from being added to the queue.

1. The "Add to queue once downloaded" checkbox was being ignored on the Advanced panel

There are two of these checkboxes — one next to the search results, and one in the Advanced "Direct download YouTube url" box. The download code always looked at the search-results one. If you pasted a URL into Advanced without searching first, that checkbox isn't on the page at all, so the code read it as unticked and quietly downloaded the song without queueing it — even though the box you could see was ticked.

Each form now reads its own checkbox.

2. Extra bits of the URL were being mistaken for part of the video ID

When you copy a YouTube link from your browser or a share button, it often has extra junk on the end, like ?v=abc123DEFgh&pp=ygUHa2FyYW9rZQ. PiKaraoke uses the video ID to find the file it just downloaded, but it was treating all that trailing junk as part of the ID. It then went looking for a file that didn't exist, gave up, and skipped queueing.

The URL is now parsed properly, and the ID is checked to make sure it looks like a real one before we go hunting for the file.

Closes #824 