### PR TITLE
chore: bump GitHub Actions versions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 
@@ -52,7 +52,7 @@ jobs:
           "
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # V4.1.7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         token: ${{ github.token }}
 
     - name: Cache pre-commit dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache
       with:
         path: ~/.cache/pre-commit
@@ -53,7 +53,7 @@ jobs:
     name: Commitlint
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Required to get all commits for linting
     - name: Run commitlint
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Preload ffmpeg (MacOS)
       if: runner.os == 'macOS'
@@ -88,10 +88,11 @@ jobs:
     name: Unit Tests
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      # setup-uv stopped publishing moving major tags at v8, so pin the exact version.
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Run tests
       run: uv run pytest tests/ -v --cov=pikaraoke --cov-report=term-missing --cov-report=xml:coverage.xml
@@ -101,13 +102,13 @@ jobs:
     name: Docker Build Smoketest (amd64)
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and Load for Smoketest (amd64)
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: build_scripts/docker/Dockerfile
@@ -127,13 +128,13 @@ jobs:
     name: Docker Build Smoketest (arm64)
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and Load for Smoketest (arm64)
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: build_scripts/docker/Dockerfile

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Release Please
       id: release
-      uses: googleapis/release-please-action@v4
+      uses: googleapis/release-please-action@v5
       with:
         token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
@@ -32,13 +32,14 @@ jobs:
     if: ${{ needs.release-please.outputs.prs_created == 'true' }}
     steps:
     - name: Check out the release PR branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
         token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      # setup-uv stopped publishing moving major tags at v8, so pin the exact version.
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Sync uv.lock with the released version
       run: |
@@ -64,15 +65,15 @@ jobs:
       url: https://pypi.org/p/pikaraoke
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Extract version number
       id: get_version
@@ -87,19 +88,19 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: build_scripts/docker/Dockerfile


### PR DESCRIPTION
Bumps GitHub Actions to their current releases.

Most of these are the same underlying change: the Node 20 runtime is EOL, so the
action ecosystem cut new majors to Node 24 (plus an ESM migration). That is why
release-please, checkout, cache, setup-python and all four Docker actions move at
once — the version jumps are larger than the behaviour changes.

| Action | From | To |
|---|---|---|
| `googleapis/release-please-action` | v4 | v5 |
| `astral-sh/setup-uv` | v4 | v9.0.0 |
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `actions/cache` | v4 | v6 |
| `docker/login-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

The SHA-pinned checkout in `ci.yml` moves to the v7.0.1 commit, keeping its pin.

## Notes

- **Node 24 requires Actions Runner >= 2.327.1.** Every job here runs on
  GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`,
  `ubuntu-22.04-arm`), which already exceed that. Only self-hosted runners would
  need attention.
- `setup-uv` is pinned to an exact version because upstream stopped publishing
  moving major tags at v8 — `@v9` does not resolve.
- `setup-uv` now enables caching by default and no longer prunes it (v5 and v9
  default changes). Adds uv entries to the repo's Actions cache; current usage is
  ~3 GB of the 10 GB quota, so there is headroom. `prune-cache: true` reverts it.
- Deprecated inputs removed in `setup-buildx-action@v4` and `build-push-action@v7`
  are not used here. Only `uses:` lines changed.

Unchanged: `wagoid/commitlint-github-action@v6` (no v7 exists) and
`pypa/gh-action-pypi-publish@release/v1` (PyPA's recommended ref).
