### PR TITLE
feat: KJ mode for queuing on behalf of singers

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -78,13 +78,15 @@ app.wsgi_app = BasePathMiddleware(app.wsgi_app, args.base_path)
 
 # Globals rather than per-route template args, so every page that extends
 # base.html agrees: it gates the admin-only nav links on is_admin and renders a
-# session ribbon from active_session_name. Registered at import rather than in
-# main() -- base.html calls them on every render, so binding them any later
-# leaves a render path that fails on an undefined name. The Karaoke instance is
-# resolved per call because it does not exist yet at import time.
+# session ribbon from active_session_name, and singer_field gates KJ mode on
+# has_active_session. Registered at import rather than in main() -- base.html
+# calls them on every render, so binding them any later leaves a render path
+# that fails on an undefined name. The Karaoke instance is resolved per call
+# because it does not exist yet at import time.
 app.jinja_env.globals.update(
     is_admin=is_admin,
     active_session_name=lambda: get_karaoke_instance().play_history.get_current_session_name(),
+    has_active_session=lambda: get_karaoke_instance().play_history.has_active_session(),
 )
 
 # Always initialize flask-smorest Api for error handling (@bp.arguments validation).

--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -589,6 +589,10 @@ class Karaoke:
             # The splash screen never reloads, so the session name rides this
             # payload rather than being rendered once at page load.
             "session_name": self.play_history.get_current_session_name(),
+            # Separate from session_name, which is None for an unnamed session
+            # too. The KJ singer field gates on this, and session_changed emits
+            # this payload, so starting a session elsewhere updates it live.
+            "has_session": self.play_history.has_active_session(),
         }
 
     def _relay_to_browser(self, event: str) -> None:

--- a/pikaraoke/lib/play_history_manager.py
+++ b/pikaraoke/lib/play_history_manager.py
@@ -301,6 +301,15 @@ class PlayHistoryManager:
         session = self.get_current_session()
         return session["name"] if session else None
 
+    def has_active_session(self) -> bool:
+        """Whether a session is open, regardless of whether it has been named.
+
+        Distinct from get_current_session_name(), which returns None for an
+        auto-started session too. KJ mode gates on this, so conflating the two
+        would lock the host out of a session that is running but not yet named.
+        """
+        return self.get_current_session() is not None
+
     def get_sessions(
         self, limit: int = 50, offset: int = 0, include_unnamed: bool = True
     ) -> list[dict]:

--- a/pikaraoke/static/custom.css
+++ b/pikaraoke/static/custom.css
@@ -77,6 +77,12 @@ table {
   width: 100%;
 }
 
+/* Admin-only field naming who is about to sing. */
+.singer-field {
+  max-width: 320px;
+  margin-bottom: 10px;
+}
+
 /* A timestamp cell holds either a time or a date, never both (see whenLabel),
    so it is short enough to keep whole. Only "31 Jul 2025" is long enough to
    want a second line, and it has spaces to break at. */

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -23,6 +23,8 @@
       basePath: "{{ base_path }}",
       cookiePath: "{{ cookie_path }}",
       socketioPath: "{{ socketio_path }}",
+      // Empty on the chromeless splash page, which has no singer field.
+      singersUrl: "{% if not blank_page %}{{ url_for('sessions_api.get_singers') }}{% endif %}"
     };
     // Translations for JS (static JS cannot use Jinja2 directly).
     // Gettext output is Markup, so Jinja never autoescapes it. Inside a <script> a
@@ -129,12 +131,76 @@
       return Cookies.get("user");
     }
 
-    // Who a queue add is attributed to: this device's own cookie name,
-    // prompting for one the first time it is needed. Every page that queues a
-    // song resolves it here, so the rule cannot drift between them.
+    // Who a queue add is attributed to. In KJ mode the visible singer field
+    // names who the host is queuing for; left blank (or hidden outside KJ mode)
+    // it falls back to this device's own cookie name, prompting for one the
+    // first time it is needed. Every page that queues a song resolves it here,
+    // so the fallback rule cannot drift between them.
     function resolveSinger() {
+      // The field is absent for non-admins, so val() can be undefined. Trimmed
+      // because a stray space would otherwise be stored as a performer name.
+      var singer = ($("#singer-name").val() || "").trim();
+      if (singer) {
+        return singer;
+      }
       setUserCookie();
       return getUserCookie() || "";
+    }
+
+    // KJ mode is opt-in for a host queuing on behalf of singers. It is not the
+    // default use case (a karaoke party between friends), so its extra search-UI
+    // controls stay hidden unless the URL carries ?kj_mode=true. The flag is
+    // remembered per tab because SPA navigation drops the query string.
+    (function () {
+      var mode = new URLSearchParams(window.location.search).get("kj_mode");
+      if (mode === "true") {
+        sessionStorage.setItem("kj_mode", "1");
+      } else if (mode === "false") {
+        sessionStorage.removeItem("kj_mode");
+      }
+    })();
+
+    function isKjMode() {
+      return sessionStorage.getItem("kj_mode") === "1";
+    }
+
+    // Swaps the KJ singer field for a "start a session" prompt. The server
+    // renders the right one at page load; this keeps it correct when the host
+    // starts or ends a session from another tab, since session_changed
+    // rebroadcasts the now_playing payload that carries has_session.
+    function setSingerFieldSessionState(hasSession) {
+      var $input = $("#singer-input");
+      if (!$input.length) {
+        return;
+      }
+      $input.toggleClass("is-hidden", !hasSession);
+      $("#singer-no-session").toggleClass("is-hidden", hasSession);
+      if (hasSession) {
+        loadSingerList();
+      } else {
+        // A stale name here would be attributed to the next song queued once a
+        // session starts.
+        $("#singer-name").val("");
+      }
+    }
+
+    // Fills the singer autocomplete from past performers. Only runs in KJ mode
+    // (the datalist is hidden otherwise) and only for admins -- the performer
+    // list is effectively the guest list, so the endpoint 403s for everyone
+    // else. Capped because the list grows without bound over a venue's lifetime
+    // and nobody scrolls an autocomplete past the most active handful.
+    function loadSingerList() {
+      var $list = $("#singer-list");
+      if (!$list.length || !isKjMode()) {
+        return;
+      }
+      $.getJSON(window.pikaraokeConfig.singersUrl, { limit: 50 }, function (data) {
+        var options = document.createDocumentFragment();
+        data.singers.forEach(function (singer) {
+          options.appendChild($("<option>").val(singer.performer)[0]);
+        });
+        $list.empty().append(options);
+      });
     }
 
     // Gettext output is Markup, which Jinja never autoescapes, so an apostrophe
@@ -176,6 +242,33 @@
       window.socket.on("now_playing", window.sessionRibbonHandler);
     }
 
+    // Keeps the singer field in step with the session, over a socket that
+    // outlives SPA page swaps. io() hands back the same instance every time, so
+    // this script re-running on each navigation would stack another handler
+    // unless the previous one is removed first.
+    function bindSingerFieldToSession() {
+      if (!window.socket) {
+        return;
+      }
+      if (window.kjSessionHandler) {
+        window.socket.off("now_playing", window.kjSessionHandler);
+      }
+      // now_playing also fires on every queue edit, pause and volume change,
+      // none of which move the session. Seeded from what the server just
+      // rendered, so those cost nothing rather than a singer fetch apiece.
+      var lastHasSession = $("#singer-input").length
+        ? !$("#singer-input").hasClass("is-hidden")
+        : null;
+      window.kjSessionHandler = function (np) {
+        if (np.has_session === lastHasSession) {
+          return;
+        }
+        lastHasSession = np.has_session;
+        setSingerFieldSessionState(np.has_session);
+      };
+      window.socket.on("now_playing", window.kjSessionHandler);
+    }
+
     // Queueing a song already on this machine. Delegated because the Songs page
     // swaps its whole result table per filter keystroke, and shared because
     // Songs and Add New render the identical link. Unbound first: SPA navigation
@@ -197,7 +290,8 @@
       connectSocket();
       bindAddSongLinks();
 
-      // Everyone in the room sees which session is running.
+      // Unlike the singer field, the ribbon is not a KJ-mode control: everyone
+      // in the room sees which session is running.
       bindSessionRibbon();
 
       $("#notification-close").click(function () {
@@ -211,6 +305,12 @@
 
       // handle auto-close flash notifications
       setTimeout(function() { $("#notification").fadeOut()}, 3000);
+
+      // Reveal KJ-only controls when a host has opted into KJ mode.
+      if (isKjMode()) {
+        $(".kj-only").removeClass("is-hidden");
+        bindSingerFieldToSession();
+      }
 
       // handle current user display
       var currentUser = Cookies.get("user");
@@ -407,7 +507,7 @@
     {# Always in the DOM, hidden when empty, so setSessionRibbon() can show and
        hide it rather than having to build it; the server settles only which
        state it starts in. An auto-started session has no name and so shows no
-       ribbon. #}
+       ribbon, which is why this turns on the name rather than on has_session. #}
     <div class="session-ribbon{% if not session_name %} is-hidden{% endif %}" id="session-ribbon"
       {# MSG: Accessible label for the banner naming the karaoke session in progress. SESSION_NAME is replaced with the session's name. #}
       aria-label="{{ _('Current session: SESSION_NAME').replace('SESSION_NAME', session_name) }}"

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %} {% block scripts %}
 <script>
 	$(function () {
+		loadSingerList();
+
 		// --- A-Z strip ----------------------------------------------------
 		// On a phone the strip is fixed, so it has to be told where to sit: it
 		// starts level with the top of the Songs box and rides up with the page
@@ -285,6 +287,8 @@
 	}
 </style>
 {% endblock %} {% block content %}
+
+{% include 'partials/singer_field.html' %}
 
 {# Filtering is server-side: the page is paginated, so a client-side filter over
    the ~100 rows in the DOM would silently miss songs on every other page. #}

--- a/pikaraoke/templates/partials/singer_field.html
+++ b/pikaraoke/templates/partials/singer_field.html
@@ -1,0 +1,38 @@
+{# KJ-mode field naming who the host is queuing for. Shared by the search and
+   files pages: base.html binds #singer-name and fills #singer-list, so the ids
+   here are a contract with loadSingerList() and must not be duplicated.
+
+   KJ mode requires an open session. A night's plays belong to a named session,
+   and without this gate record_play() silently auto-starts an unnamed one --
+   the history exists but the host never got to name it. Both branches render
+   and base.html swaps them on session_changed, so starting a session in another
+   tab does not leave a stale prompt here. #}
+{% if is_admin() %}
+<div class="field singer-field kj-only is-hidden">
+	<div id="singer-input" class="{% if not has_active_session() %}is-hidden{% endif %}">
+		{# MSG: Label for the KJ-mode field naming who is about to sing the songs being queued. #}
+		<label class="label is-small" for="singer-name">{% trans %}Queue for singer{% endtrans %}</label>
+		<input
+			id="singer-name"
+			class="input is-small"
+			list="singer-list"
+			autocomplete="off"
+			{# MSG: Placeholder in the KJ-mode singer field. #}
+			placeholder="{{ _('Name of the singer') }}"
+		/>
+		<datalist id="singer-list"></datalist>
+	</div>
+	{# Replaces the input rather than disabling it: a dead box invites clicking.
+	   Sized like the input it stands in for, and carrying the Sessions nav icon
+	   so it reads as a route to the fix rather than an error. #}
+	<a
+		id="singer-no-session"
+		class="button is-small is-fullwidth is-warning is-outlined {% if has_active_session() %}is-hidden{% endif %}"
+		href="{{ url_for('sessions.sessions') }}"
+	>
+		<i class="icon icon-list-alt"></i>
+		{# MSG: Button shown in place of the KJ singer field when no session is running. Links to the sessions page. #}
+		<span>{% trans %}Start a session to queue for singers{% endtrans %}</span>
+	</a>
+</div>
+{% endif %}

--- a/pikaraoke/templates/search.html
+++ b/pikaraoke/templates/search.html
@@ -302,6 +302,8 @@
 
 		setUserCookie(); // Don't reload page after setting cookie
 
+		loadSingerList();
+
 		// "Include non-karaoke matches" is the only setting left on this page, so its
 		// cookie is read and written right here rather than through a restore-everything
 		// helper.
@@ -498,6 +500,7 @@
 {% endblock %} {% block content %}
 
 <div>
+	{% include 'partials/singer_field.html' %}
 	<div class="field">
 		<div id="search-field" class="field has-addons mb-1">
 			<div class="control has-icons-left is-expanded">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,10 +54,11 @@ def make_route_app(blueprint, linked_endpoints):
 
     # app.py binds these at import for the same reason: base.html calls them on
     # every render, so a page rendered without them fails on an undefined name.
-    # Off by default -- a test that wants the admin markup overrides them.
+    # Off by default -- a test that wants the admin or KJ markup overrides them.
     app.jinja_env.globals.update(
         url_escape=quote,
         is_admin=lambda: False,
+        has_active_session=lambda: False,
         active_session_name=lambda: "",
     )
     return app
@@ -156,6 +157,9 @@ class MockPlayHistory:
 
     def get_current_session_name(self) -> str | None:
         return self.session["name"] if self.session else None
+
+    def has_active_session(self) -> bool:
+        return self.session is not None
 
 
 class MockKaraoke:

--- a/tests/unit/test_karaoke_utils.py
+++ b/tests/unit/test_karaoke_utils.py
@@ -108,6 +108,22 @@ class TestGetNowPlaying:
         """An unnamed or absent session must not surface a name on the splash."""
         assert mock_karaoke.get_now_playing()["session_name"] is None
 
+    def test_get_now_playing_reports_an_unnamed_session_as_active(self, mock_karaoke):
+        """The KJ singer field gates on has_session, so it cannot follow the name.
+
+        An unnamed session is still a session; conflating the two would lock a
+        host out of KJ mode until they got around to naming the night.
+        """
+        mock_karaoke.play_history.session = {"name": None}
+
+        result = mock_karaoke.get_now_playing()
+
+        assert result["has_session"] is True
+        assert result["session_name"] is None
+
+    def test_get_now_playing_reports_no_session(self, mock_karaoke):
+        assert mock_karaoke.get_now_playing()["has_session"] is False
+
     def test_get_now_playing_with_queue(self, mock_karaoke):
         """Test now playing shows up_next from queue."""
         mock_karaoke.queue_manager.enqueue("/songs/Next Song---dQw4w9WgXcQ.mp4", "NextUser")


### PR DESCRIPTION
## What this adds

An opt-in mode for a host running the night for a room of guests. Play history (#845) targets the default use case, a karaoke party between friends, where everyone queues under their own device name. A KJ queues on behalf of other people, which needs a field naming who is about to sing — but that field cluttered the default search UI, so it now sits behind a flag.

Visiting any page with `?kj_mode=true` reveals a **Queue for singer** field on Search and Songs; `?kj_mode=false` clears it. The flag lives in `sessionStorage`, so it is remembered per tab — SPA navigation drops the query string.

- The field sets who a queue add is attributed to, falling back to the device's own cookie name when blank, so nothing regresses for a host who reveals it and does not use it.
- Its autocomplete is filled from past performers via `/api/history/singers`, capped at 50. That endpoint is admin-only: the performer list is effectively the event's guest list.
- The field requires an open session. Without that gate `record_play()` silently auto-starts an unnamed one and the host never gets to name the night, so it is swapped for a link to the Sessions page instead. `has_active_session` rides the `now_playing` payload, keeping the swap live when a session starts or ends in another tab.

## Test plan

- [x] Visit `/search` normally — no singer field is shown. Queue a song; it is attributed to the device's cookie name.
- [x] Visit `/search?kj_mode=true` as admin with a session running — the **Queue for singer** field appears. It also appears on `/browse` without re-passing the flag.
- [x] Type a name and queue a song — the play is attributed to that name, not the device name. Leave it blank and queue — it falls back to the device name.
- [x] With past plays recorded, focus the field — the autocomplete lists previous performers.
- [x] End the session from the Sessions page in another tab — the field is replaced live by **Start a session to queue for singers**, which links to `/sessions`. Start a session again; the field returns.
- [x] Visit `/search?kj_mode=false` — the field is gone again.
- [x] As a non-admin, `?kj_mode=true` shows no field, and `/api/history/singers` returns 403.
