### PR TITLE
feat: add keep awake toggle to the info page

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -32,7 +32,6 @@ from pikaraoke.lib.get_platform import (
     has_js_runtime,
     is_windows,
 )
-from pikaraoke.lib.keep_awake import KeepAwake
 from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.lib.url_prefix import BasePathMiddleware
 from pikaraoke.lib.youtube_dl import upgrade_youtubedl
@@ -270,6 +269,7 @@ def main() -> None:
         high_quality=args.high_quality,
         logo_path=args.logo_path,
         hide_overlay=args.hide_overlay,
+        keep_awake=args.keep_awake,
         show_splash_clock=args.show_splash_clock,
         url=args.url,
         prefer_hostname=args.prefer_hostname,
@@ -344,13 +344,6 @@ def main() -> None:
         args.hide_splash_screen = True
         logging.info("Forced to run headless mode in Android")
 
-    # Keep the host awake so idle-sleep doesn't interrupt streaming (headless has
-    # no local player window to hold a wake lock).
-    keep_awake = None
-    if args.keep_awake:
-        keep_awake = KeepAwake()
-        keep_awake.start()
-
     # Start the splash screen browser
     if not args.hide_splash_screen:
         browser = Browser(k, args.window_size, args.external_monitor)
@@ -371,8 +364,8 @@ def main() -> None:
     if browser is not None:
         browser.close()
 
-    if keep_awake is not None:
-        keep_awake.stop()
+    # Ctrl-C leaves the run loop without going through stop().
+    k.stop()
 
     delete_tmp_dir()
     sys.exit()

--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -27,6 +27,7 @@ from pikaraoke.lib.get_platform import (
     is_raspberry_pi,
 )
 from pikaraoke.lib.karaoke_database import KaraokeDatabase
+from pikaraoke.lib.keep_awake import KeepAwake
 from pikaraoke.lib.library_scanner import LibraryScanner, ScanResult
 from pikaraoke.lib.network import get_ip
 from pikaraoke.lib.play_history_manager import PlayHistoryManager
@@ -126,6 +127,7 @@ class Karaoke:
         hide_session_name: bool | None = None,
         hide_url: bool | None = None,
         high_quality: bool | None = None,
+        keep_awake: bool | None = None,
         limit_user_songs_by: int | None = None,
         normalize_audio: bool | None = None,
         screensaver_timeout: int | None = None,
@@ -154,6 +156,7 @@ class Karaoke:
             youtubedl_proxy: Proxy URL for yt-dlp.
             logo_path: Custom logo image path.
             hide_overlay: Hide video overlay.
+            keep_awake: Prevent the host machine from sleeping.
             screensaver_timeout: Screensaver activation delay in seconds.
             url: Override auto-detected URL.
             prefer_hostname: Use hostname instead of IP in URL.
@@ -212,6 +215,9 @@ class Karaoke:
         self.url_override = url
         self.url_base_path = url_base_path
         self.url = self.get_url()
+
+        # Must exist before preferences are applied: the keep_awake setter uses it.
+        self._keep_awake = KeepAwake()
 
         # Load all preference-driven attributes from config (with CLI overrides as fallback)
         cli_args = {k: v for k, v in locals().items() if k != "self"}
@@ -369,6 +375,22 @@ class Karaoke:
         Priority: CLI argument (if provided) > config file > PreferenceManager.DEFAULTS
         """
         self.preferences.apply_all(**cli_overrides)
+
+    @property
+    def keep_awake(self) -> bool:
+        """Whether the host is being held awake.
+
+        A property so that preference writes acquire or release the wake lock
+        immediately, rather than at the next restart.
+        """
+        return self._keep_awake.active
+
+    @keep_awake.setter
+    def keep_awake(self, enabled: bool) -> None:
+        if enabled:
+            self._keep_awake.start()
+        else:
+            self._keep_awake.stop()
 
     def get_url(self):
         """Get the URL for accessing the PiKaraoke web interface.
@@ -553,6 +575,7 @@ class Karaoke:
     def stop(self) -> None:
         """Stop the karaoke run loop."""
         self.sound_manager.stop()
+        self._keep_awake.stop()
         self.running = False
 
     def handle_run_loop(self) -> None:

--- a/pikaraoke/lib/keep_awake.py
+++ b/pikaraoke/lib/keep_awake.py
@@ -10,16 +10,47 @@ import logging
 import shutil
 import subprocess
 
-from pikaraoke.lib.get_platform import is_linux, is_macos, is_windows
+from pikaraoke.lib.get_platform import (
+    is_linux,
+    is_macos,
+    is_running_in_docker,
+    is_windows,
+)
 
 # Windows SetThreadExecutionState flags
 _ES_CONTINUOUS = 0x80000000
 _ES_SYSTEM_REQUIRED = 0x00000001
 _ES_DISPLAY_REQUIRED = 0x00000002
 
+_UNSUPPORTED_LOG_MESSAGES = {
+    "container": "it has no effect inside a container; disable sleep on the host instead",
+    "missing_tool": (
+        "'systemd-inhibit' (Linux) or 'caffeinate' (macOS) was not found; "
+        "disable sleep in your OS power settings instead"
+    ),
+    "unsupported_platform": "this platform is not supported",
+}
+
+
+def unsupported_reason() -> str | None:
+    """Why keep-awake cannot work here, or None when it can.
+
+    One of ``container``, ``missing_tool`` or ``unsupported_platform``.
+    """
+    if is_windows():
+        return None
+    # A container cannot reach the host's power manager, and the host is what suspends.
+    if is_running_in_docker():
+        return "container"
+    if is_macos():
+        return None if shutil.which("caffeinate") else "missing_tool"
+    if is_linux():
+        return None if shutil.which("systemd-inhibit") else "missing_tool"
+    return "unsupported_platform"
+
 
 class KeepAwake:
-    """Keeps the host awake for the app's lifetime via a native OS mechanism.
+    """Holds a wake lock on the host via a native OS mechanism.
 
     Windows uses SetThreadExecutionState; macOS uses ``caffeinate``; Linux uses
     ``systemd-inhibit``. ``start()``/``stop()`` are safe to call on any platform
@@ -28,9 +59,19 @@ class KeepAwake:
 
     def __init__(self) -> None:
         self._process: subprocess.Popen | None = None
+        self.active = False
 
     def start(self) -> None:
         """Begin preventing system (and display) sleep."""
+        if self.active:
+            return
+
+        reason = unsupported_reason()
+        if reason is not None:
+            logging.warning(f"Keep-awake requested, but {_UNSUPPORTED_LOG_MESSAGES[reason]}.")
+            return
+
+        self.active = True
         if is_windows():
             self._start_windows()
         elif is_macos():
@@ -38,11 +79,10 @@ class KeepAwake:
             self._start_subprocess(["caffeinate", "-dis"], "caffeinate")
         elif is_linux():
             self._start_linux()
-        else:
-            logging.warning("Keep-awake is not supported on this platform; ignoring.")
 
     def stop(self) -> None:
         """Release the wake lock, allowing normal power management to resume."""
+        self.active = False
         if is_windows():
             self._stop_windows()
         elif self._process is not None:
@@ -54,8 +94,9 @@ class KeepAwake:
     # --- Windows ---
 
     def _start_windows(self) -> None:
-        # ES_CONTINUOUS keeps the requirement in effect for the life of this
-        # (main) thread, so a single call holds until stop() or process exit.
+        # ES_CONTINUOUS holds until stop() or process exit, on the calling
+        # thread. gevent keeps every greenlet on one OS thread, so a toggle
+        # from a web request lands on the thread that startup used.
         result = ctypes.windll.kernel32.SetThreadExecutionState(
             _ES_CONTINUOUS | _ES_SYSTEM_REQUIRED | _ES_DISPLAY_REQUIRED
         )
@@ -71,12 +112,6 @@ class KeepAwake:
     # --- Linux ---
 
     def _start_linux(self) -> None:
-        if shutil.which("systemd-inhibit") is None:
-            logging.warning(
-                "Keep-awake requested but 'systemd-inhibit' was not found. "
-                "Disable sleep manually in your OS power settings."
-            )
-            return
         self._start_subprocess(
             [
                 "systemd-inhibit",

--- a/pikaraoke/lib/preference_manager.py
+++ b/pikaraoke/lib/preference_manager.py
@@ -31,6 +31,7 @@ class PreferenceManager:
         "complete_transcode_before_play": False,
         "buffer_size": 150,
         "hide_overlay": False,
+        "keep_awake": False,
         "screensaver_timeout": 300,
         "disable_bg_music": False,
         "bg_music_volume": 0.3,

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -7,13 +7,14 @@ from flask_smorest import Blueprint
 
 from pikaraoke import VERSION
 from pikaraoke.constants import ITUNES_COUNTRIES, LANGUAGES, per_page_options
+from pikaraoke.lib import keep_awake
 from pikaraoke.lib.current_app import (
     get_admin_password,
     get_karaoke_instance,
     get_site_name,
     is_admin,
 )
-from pikaraoke.lib.get_platform import get_platform, is_linux
+from pikaraoke.lib.get_platform import get_platform, is_linux, is_running_in_docker
 
 _ = flask_babel.gettext
 
@@ -53,6 +54,7 @@ def info():
         disk=None,
         is_pi=k.is_raspberry_pi,
         is_linux=is_linux_platform,
+        is_container=is_running_in_docker(),
         volume=int(k.volume * 100),
         bg_music_volume=int(k.bg_music_volume * 100),
         disable_bg_music=k.disable_bg_music,
@@ -88,6 +90,8 @@ def info():
         },
         mic_available=k.sound_manager.available,
         mic_passthrough_enabled=k.enable_mic_passthrough,
+        keep_awake=k.keep_awake,
+        keep_awake_unsupported=keep_awake.unsupported_reason(),
     )
 
 

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -699,6 +699,24 @@
 						</label>
 					</div>
 
+					{% if keep_awake_unsupported %}
+					<p class="is-size-7 has-text-grey">
+						{% if keep_awake_unsupported == "container" %}
+						{# MSG: Shown instead of the keep-awake checkbox when running in a container. #} {% trans %}Keep the server awake: unavailable in a container. Disable sleep on the host.{% endtrans %}
+						{% elif keep_awake_unsupported == "missing_tool" %}
+						{# MSG: Shown instead of the keep-awake checkbox when the required tool is missing. #} {% trans %}Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS).{% endtrans %}
+						{% else %}
+						{# MSG: Shown instead of the keep-awake checkbox on platforms without a wake lock. #} {% trans %}Keep the server awake: not supported on this platform.{% endtrans %}
+						{% endif %}
+					</p>
+					{% else %}
+					<div class="user-preference-container">
+						<input id="pref-keep-awake" type="checkbox" class="user-preference-checkbox checkbox" data-pref="keep_awake" {% if keep_awake == True %}checked{% endif %}>
+						<label class="label" for="pref-keep-awake">{# MSG: Checkbox label which stops the server machine from sleeping #} {% trans %}Keep the server awake while PiKaraoke is running{% endtrans %}
+						</label>
+					</div>
+					{% endif %}
+
 					<div style="margin-top: 20px">
 						{# MSG: Text for the link where the user can clear all user preferences #}
 						<a id="clear-preferences-link" class="button is-danger is-outlined" href="{{ url_for('preferences.clear_preferences') }}">{% trans %}Clear preferences{% endtrans %}</a>
@@ -780,7 +798,8 @@
 			</div>
 		</div>
 
-		{% if is_pi %}
+		{# A Pi container still reports as a Pi, but has no raspi-config. #}
+		{% if is_pi and not is_container %}
 
 			{# MSG: Title of the updates section. #}
 			<h1>{% trans %}Other{% endtrans %}</h1>
@@ -839,7 +858,8 @@
 					<div class="buttons">
 						{# MSG: Text for button which turns off Pikaraoke for everyone using it at your house. #}
 						<a id="quit-link" class="button is-primary" href="{{ url_for('admin.quit') }}">{% trans %}Quit Pikaraoke{% endtrans %}</a>
-						{% if is_pi or is_linux %}
+						{# Host power control is meaningless in a container: only "Quit" applies. #}
+						{% if (is_pi or is_linux) and not is_container %}
 							{# MSG: Text for button which reboots the machine running Pikaraoke. #}
 							<a id="restart-link" class="button is-primary" href="{{ url_for('admin.reboot') }}">{% trans %}Reboot System{% endtrans %}</a>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,19 @@ class MockPlayHistory:
         return self.session["name"] if self.session else None
 
 
+class MockKeepAwake:
+    """Minimal mock of KeepAwake that records whether the lock is held."""
+
+    def __init__(self):
+        self.active = False
+
+    def start(self):
+        self.active = True
+
+    def stop(self):
+        self.active = False
+
+
 class MockKaraoke:
     """Minimal mock of the Karaoke class for testing queue operations.
 
@@ -168,6 +181,7 @@ class MockKaraoke:
     def __init__(self, tmp_path):
         self.song_manager = MockSongManager()
         self.sound_manager = MockSoundManager()
+        self._keep_awake = MockKeepAwake()
         self._socketio = None
         self.events = EventSystem()
         self.preferences = PreferenceManager(
@@ -214,6 +228,7 @@ class MockKaraoke:
     from pikaraoke.karaoke import Karaoke
 
     # Bind the real methods to our mock class
+    keep_awake = Karaoke.keep_awake
     get_now_playing = Karaoke.get_now_playing
     reset_now_playing = Karaoke.reset_now_playing
     transpose_current = Karaoke.transpose_current

--- a/tests/unit/test_karaoke_utils.py
+++ b/tests/unit/test_karaoke_utils.py
@@ -312,6 +312,40 @@ class TestStop:
 
         assert mock_karaoke.running is False
 
+    def test_stop_releases_the_wake_lock(self, mock_karaoke):
+        """Test that stop releases the keep-awake lock."""
+        mock_karaoke.preferences.set("keep_awake", "True")
+
+        mock_karaoke.stop()
+
+        assert mock_karaoke.keep_awake is False
+
+
+class TestKeepAwake:
+    """Tests for the keep_awake preference driving the wake lock."""
+
+    def test_enabling_preference_acquires_lock(self, mock_karaoke):
+        """Test that setting the preference starts the wake lock."""
+        mock_karaoke.preferences.set("keep_awake", "True")
+
+        assert mock_karaoke.keep_awake is True
+
+    def test_disabling_preference_releases_lock(self, mock_karaoke):
+        """Test that unsetting the preference stops the wake lock."""
+        mock_karaoke.preferences.set("keep_awake", "True")
+
+        mock_karaoke.preferences.set("keep_awake", "False")
+
+        assert mock_karaoke.keep_awake is False
+
+    def test_resetting_preferences_releases_lock(self, mock_karaoke):
+        """Test that clearing preferences returns the lock to its default off state."""
+        mock_karaoke.preferences.set("keep_awake", "True")
+
+        mock_karaoke.preferences.reset_all()
+
+        assert mock_karaoke.keep_awake is False
+
 
 class TestResetNowPlayingNotification:
     """Tests for the reset_now_playing_notification method."""

--- a/tests/unit/test_keep_awake.py
+++ b/tests/unit/test_keep_awake.py
@@ -8,25 +8,53 @@ from pikaraoke.lib.keep_awake import (
     _ES_DISPLAY_REQUIRED,
     _ES_SYSTEM_REQUIRED,
     KeepAwake,
+    unsupported_reason,
 )
+
+_POPEN = "pikaraoke.lib.keep_awake.subprocess.Popen"
 
 
 @contextmanager
-def _platform(target: str):
-    """Patch platform detectors so only `target` (win/mac/linux) is active."""
+def _platform(target: str, in_docker: bool = False, tool_installed: bool = True):
+    """Patch platform detection so only `target` (win/mac/linux) is active."""
     with ExitStack() as stack:
         for name in ("is_windows", "is_macos", "is_linux"):
             stack.enter_context(
                 mock.patch(f"pikaraoke.lib.keep_awake.{name}", return_value=(name == target))
             )
+        stack.enter_context(
+            mock.patch("pikaraoke.lib.keep_awake.is_running_in_docker", return_value=in_docker)
+        )
+        stack.enter_context(
+            mock.patch(
+                "pikaraoke.lib.keep_awake.shutil.which",
+                return_value="/usr/bin/inhibitor" if tool_installed else None,
+            )
+        )
         yield
+
+
+class TestUnsupportedReason:
+    def test_windows_is_supported(self):
+        with _platform("is_windows"):
+            assert unsupported_reason() is None
+
+    def test_container_is_unsupported_even_with_the_tool_installed(self):
+        with _platform("is_linux", in_docker=True):
+            assert unsupported_reason() == "container"
+
+    def test_missing_tool(self):
+        with _platform("is_linux", tool_installed=False):
+            assert unsupported_reason() == "missing_tool"
+
+    def test_unknown_platform(self):
+        with _platform("none_of_them"):
+            assert unsupported_reason() == "unsupported_platform"
 
 
 class TestMacOS:
     def test_start_launches_caffeinate(self):
-        with _platform("is_macos"), mock.patch(
-            "pikaraoke.lib.keep_awake.subprocess.Popen"
-        ) as popen:
+        with _platform("is_macos"), mock.patch(_POPEN) as popen:
             ka = KeepAwake()
             ka.start()
 
@@ -37,9 +65,7 @@ class TestMacOS:
 
 class TestLinux:
     def test_start_uses_systemd_inhibit_when_available(self):
-        with _platform("is_linux"), mock.patch(
-            "pikaraoke.lib.keep_awake.shutil.which", return_value="/usr/bin/systemd-inhibit"
-        ), mock.patch("pikaraoke.lib.keep_awake.subprocess.Popen") as popen:
+        with _platform("is_linux"), mock.patch(_POPEN) as popen:
             ka = KeepAwake()
             ka.start()
 
@@ -49,14 +75,28 @@ class TestLinux:
         assert cmd[-2:] == ["sleep", "infinity"]
 
     def test_start_warns_and_skips_without_systemd_inhibit(self):
-        with _platform("is_linux"), mock.patch(
-            "pikaraoke.lib.keep_awake.shutil.which", return_value=None
-        ), mock.patch("pikaraoke.lib.keep_awake.subprocess.Popen") as popen:
+        with _platform("is_linux", tool_installed=False), mock.patch(_POPEN) as popen:
             ka = KeepAwake()
             ka.start()
 
         popen.assert_not_called()
         assert ka._process is None
+
+    def test_start_skips_in_a_container(self):
+        with _platform("is_linux", in_docker=True), mock.patch(_POPEN) as popen:
+            ka = KeepAwake()
+            ka.start()
+
+        popen.assert_not_called()
+        assert ka._process is None
+
+    def test_starting_twice_holds_one_lock(self):
+        with _platform("is_linux"), mock.patch(_POPEN) as popen:
+            ka = KeepAwake()
+            ka.start()
+            ka.start()
+
+        popen.assert_called_once()
 
 
 class TestWindows:
@@ -82,9 +122,7 @@ class TestWindows:
 
 class TestStop:
     def test_stop_terminates_subprocess(self):
-        with _platform("is_macos"), mock.patch(
-            "pikaraoke.lib.keep_awake.subprocess.Popen"
-        ) as popen:
+        with _platform("is_macos"), mock.patch(_POPEN) as popen:
             ka = KeepAwake()
             ka.start()
             process = popen.return_value

--- a/tests/unit/test_preference_manager.py
+++ b/tests/unit/test_preference_manager.py
@@ -270,6 +270,7 @@ def test_preference_manager_defaults_exist():
         "complete_transcode_before_play",
         "buffer_size",
         "hide_overlay",
+        "keep_awake",
         "screensaver_timeout",
         "disable_bg_music",
         "bg_music_volume",


### PR DESCRIPTION
Upgrade `--keep-awake` to also be set via the Settings page.

It is only displayed on supported environments and if not, shows a message to change the sleep settings on the host.

For the same reason, the **Reboot/Shutdown System** buttons and the **Expand Raspberry Pi filesystem** card are also now hidden for containers.
