### PR TITLE
fix: verify preview stream URLs before handing them to the browser

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -208,17 +208,15 @@ PREVIEW_FORMAT = (
     "/worst[protocol=https][vcodec!=none][acodec!=none]"
 )
 
+# YouTube answers 403 to a freshly resolved itag 18 URL often enough that it has to be
+# proven here: downloads survive it by retrying, a <video> element gets one attempt.
+# Two consecutive refusals then a working URL is a routinely observed sequence.
+_PREVIEW_ATTEMPTS = 3
+_VERIFY_TIMEOUT_SECONDS = 5
 
-def get_stream_url(video_url: str) -> str | None:
-    """Get a direct stream URL for a YouTube video without downloading it.
 
-    Args:
-        video_url: YouTube video URL.
-
-    Returns:
-        Progressive stream URL playable in a browser, or None if yt-dlp failed or
-        offered nothing progressive.
-    """
+def _resolve_stream_url(video_url: str) -> str | None:
+    """Ask yt-dlp for a progressive stream URL. No guarantee it will serve bytes."""
     cmd = yt_dlp_cmd + ["-g", "-f", PREVIEW_FORMAT] + _js_runtime_args()
     cmd += [video_url]
     logging.debug(f"yt-dlp get stream URL command: {' '.join(cmd)}")
@@ -245,3 +243,44 @@ def get_stream_url(video_url: str) -> str | None:
     except (FileNotFoundError, PermissionError) as e:
         logging.error(f"Could not run yt-dlp: {e}")
         return None
+
+
+def _serves_bytes(stream_url: str) -> bool:
+    """Check the stream answers a browser, asking for one block so nothing downloads."""
+    # Lazy so importing this module never pulls requests in ahead of gevent's patching.
+    import requests
+
+    try:
+        response = requests.get(
+            stream_url,
+            headers={"Range": "bytes=0-1023"},
+            timeout=_VERIFY_TIMEOUT_SECONDS,
+            stream=True,
+        )
+        response.close()
+        return response.status_code in (200, 206)
+    except requests.RequestException as e:
+        logging.warning(f"Preview stream check failed: {e}")
+        return False
+
+
+def get_stream_url(video_url: str) -> str | None:
+    """Get a browser-playable stream URL for a YouTube video, without downloading it.
+
+    Args:
+        video_url: YouTube video URL.
+
+    Returns:
+        A stream URL confirmed to serve bytes, or None if every attempt was refused.
+    """
+    for attempt in range(_PREVIEW_ATTEMPTS):
+        stream_url = _resolve_stream_url(video_url)
+        if stream_url is None:
+            return None
+        if _serves_bytes(stream_url):
+            return stream_url
+        logging.info(
+            f"Preview stream refused for {video_url}, re-resolving "
+            f"(attempt {attempt + 1}/{_PREVIEW_ATTEMPTS})"
+        )
+    return None

--- a/pikaraoke/templates/search.html
+++ b/pikaraoke/templates/search.html
@@ -425,6 +425,38 @@
 		// Fetching a stream URL takes seconds, long enough to close the modal or click
 		// another thumbnail, so only the response for the preview on screen is applied.
 		let previewRequestId = 0;
+		let previewPageUrl = null;
+		let previewRetried = false;
+
+		// A refused stream is common enough that one silent re-request beats a failure,
+		// whether the server gave up or the browser could not play what it returned.
+		const retryOrFailPreview = function () {
+			if (!previewRetried) {
+				previewRetried = true;
+				previewContent.classList.add("is-loading");
+				requestPreview(previewPageUrl, previewRequestId);
+				return;
+			}
+			previewContent.classList.remove("is-loading");
+			previewError.style.display = "block";
+		};
+
+		const requestPreview = function (videoUrl, requestId) {
+			$.ajax({
+				url: "{{ url_for('search.preview') }}" + "?url=" + encodeURIComponent(videoUrl),
+				type: "get",
+				success: function (data) {
+					if (requestId !== previewRequestId) return;
+					previewVideo.src = data.stream_url;
+					previewVideo.load();
+					previewVideo.play().catch(function () {});
+				},
+				error: function () {
+					if (requestId !== previewRequestId) return;
+					retryOrFailPreview();
+				},
+			});
+		};
 
 		// Registered once; clearing the spinner is idempotent.
 		previewVideo.addEventListener("playing", function () {
@@ -432,8 +464,9 @@
 			previewError.style.display = "none";
 		});
 		previewVideo.addEventListener("error", function () {
-			previewContent.classList.remove("is-loading");
-			previewError.style.display = "block";
+			// Detaching the source during teardown also fires error; ignore that.
+			if (!previewModal.classList.contains("is-active")) return;
+			retryOrFailPreview();
 		});
 
 		const closePreview = function () {
@@ -454,30 +487,19 @@
 		$("#search-results").on("click", ".img-wrapper", function () {
 			const videoUrl = $(this).data("url");
 			const requestId = ++previewRequestId;
+			previewPageUrl = videoUrl;
+			previewRetried = false;
 
 			previewModal.classList.add("is-active");
 			previewContent.classList.add("is-loading");
+			previewError.style.display = "none";
 			previewCloseButton.focus();
 
 			// Unlock autoplay on iOS: Safari only ties play() to a gesture when it is
 			// called in the handler. load() aborts this promise, so nothing chains to it.
 			previewVideo.play().catch(function () {});
 
-			$.ajax({
-				url: "{{ url_for('search.preview') }}" + "?url=" + encodeURIComponent(videoUrl),
-				type: "get",
-				success: function (data) {
-					if (requestId !== previewRequestId) return;
-					previewVideo.src = data.stream_url;
-					previewVideo.load();
-					previewVideo.play().catch(function () {});
-				},
-				error: function () {
-					if (requestId !== previewRequestId) return;
-					previewContent.classList.remove("is-loading");
-					previewError.style.display = "block";
-				},
-			});
+			requestPreview(videoUrl, requestId);
 		});
 	});
 

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -5,8 +5,11 @@ import sys
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+import requests
 
 from pikaraoke.lib.youtube_dl import (
+    _PREVIEW_ATTEMPTS,
+    _serves_bytes,
     build_ytdl_download_command,
     get_stream_url,
     get_youtube_id_from_url,
@@ -200,11 +203,16 @@ class TestGetStreamUrl:
             return_value=MagicMock(returncode=returncode, stdout=stdout, stderr=b""),
         )
 
+    @staticmethod
+    def _serving(*results: bool):
+        return patch("pikaraoke.lib.youtube_dl._serves_bytes", side_effect=results)
+
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_requests_progressive_format_only(self, mock_js):
         """Test that the format selector excludes HLS and single-track formats."""
         with self._run_with_output(b"https://rr1.googlevideo.com/videoplayback?x=1\n") as mock_run:
-            get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            with self._serving(True):
+                get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
             cmd = mock_run.call_args[0][0]
             fmt = cmd[cmd.index("-f") + 1]
             assert "[protocol=https]" in fmt
@@ -212,9 +220,9 @@ class TestGetStreamUrl:
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_returns_progressive_url(self, mock_js):
-        """Test that a normal progressive URL is returned."""
+        """Test that a verified progressive URL is returned."""
         url = "https://rr1.googlevideo.com/videoplayback?itag=18"
-        with self._run_with_output(url.encode() + b"\n"):
+        with self._run_with_output(url.encode() + b"\n"), self._serving(True):
             assert get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == url
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
@@ -231,6 +239,49 @@ class TestGetStreamUrl:
         """Test that a non-zero yt-dlp exit returns None."""
         with self._run_with_output(b"", returncode=1):
             assert get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is None
+
+    @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
+    def test_re_resolves_when_stream_refused(self, mock_js):
+        """Test that a refused URL is discarded and a freshly resolved one returned."""
+        refused = b"https://rr1.googlevideo.com/videoplayback?itag=18&dead=1\n"
+        working = "https://rr2.googlevideo.com/videoplayback?itag=18&live=1"
+        runs = [
+            MagicMock(returncode=0, stdout=refused, stderr=b""),
+            MagicMock(returncode=0, stdout=working.encode() + b"\n", stderr=b""),
+        ]
+        with patch("subprocess.run", side_effect=runs), self._serving(False, True):
+            assert get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == working
+
+    @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
+    def test_returns_none_when_every_attempt_refused(self, mock_js):
+        """Test that a URL the browser could not play is never handed back."""
+        url = "https://rr1.googlevideo.com/videoplayback?itag=18"
+        with self._run_with_output(url.encode() + b"\n"):
+            with self._serving(*[False] * _PREVIEW_ATTEMPTS):
+                assert get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is None
+
+
+class TestServesBytes:
+    """Tests for the _serves_bytes stream check."""
+
+    @staticmethod
+    def _response(status_code: int):
+        return patch("requests.get", return_value=MagicMock(status_code=status_code))
+
+    def test_accepts_partial_content(self):
+        """Test that a ranged request answered with 206 counts as playable."""
+        with self._response(206):
+            assert _serves_bytes("https://rr1.googlevideo.com/videoplayback") is True
+
+    def test_rejects_forbidden(self):
+        """Test that YouTube refusing the stream counts as unplayable."""
+        with self._response(403):
+            assert _serves_bytes("https://rr1.googlevideo.com/videoplayback") is False
+
+    def test_rejects_unreachable_host(self):
+        """Test that a transport failure counts as unplayable rather than raising."""
+        with patch("requests.get", side_effect=requests.ConnectionError("boom")):
+            assert _serves_bytes("https://rr1.googlevideo.com/videoplayback") is False
 
 
 class TestGetYoutubedlVersion:


### PR DESCRIPTION
#860 tightened the format selector but did not fix the core problem: YouTube returns 403 on the preview URL about half the time.

Downloads never showed this because yt-dlp fetches the bytes itself and retries. So `get_stream_url` now does the same: resolve, check the URL actually returns data with a 1 KB ranged GET, and re-resolve if not, up to three attempts. The browser retries once silently instead of showing an error.

Another option previously canvassed was to remove the preview video completely, leaving the YouTube link which is 100% reliable - I am happy to do this and close this PR.
