### PR TITLE
feat: folder browsing

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -284,6 +284,7 @@ def main() -> None:
         avsync=float(args.avsync) if args.avsync is not None else None,
         config_file_path=args.config_file_path,
         cdg_pixel_scaling=args.cdg_pixel_scaling,
+        enable_folder_browsing=args.enable_folder_browsing,
         streaming_format=args.streaming_format,
         additional_ytdl_args=getattr(args, "ytdl_args", None),
         socketio=socketio,

--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -139,6 +139,7 @@ class Karaoke:
         splash_delay: int | None = None,
         volume: float | None = None,
         enable_title_tidy: bool | None = None,
+        enable_folder_browsing: bool | None = None,
     ) -> None:
         """Initialize the Karaoke instance.
 
@@ -179,6 +180,7 @@ class Karaoke:
             additional_ytdl_args: Additional yt-dlp command arguments.
             socketio: SocketIO instance for real-time event emission.
             preferred_language: Language code for UI (e.g., 'en', 'de_DE').
+            enable_folder_browsing: Offer a Folders view on the Songs page.
         """
         logging.basicConfig(
             format="[%(asctime)s] %(levelname)s: %(message)s",

--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -344,6 +344,12 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         required=False,
     )
     parser.add_argument(
+        "--enable-folder-browsing",
+        action="store_true",
+        help="Let users browse the song library by the folders it is stored in. Adds a Folders view to the Songs page when the library has subdirectories.",
+        required=False,
+    )
+    parser.add_argument(
         "--enable-mic-passthrough",
         action="store_true",
         help="Enable experimental server-side microphone passthrough so singers can hear themselves through the karaoke speakers.",

--- a/pikaraoke/lib/preference_manager.py
+++ b/pikaraoke/lib/preference_manager.py
@@ -50,6 +50,7 @@ class PreferenceManager:
         "hide_logo": False,
         "mic_settings": "{}",
         "enable_title_tidy": False,
+        "enable_folder_browsing": False,
         "metadata_provider": "itunes",
         "itunes_search_country": "US",
         "suggestion_name_order": "artist_title",

--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -52,6 +52,8 @@ class SongManager:
         self._get_title_tidy = get_title_tidy
         self._index: list[tuple[str, str]] = []  # (accent-folded raw filename key, path)
         self._index_version: int | None = None
+        self._folders: dict[str, list[str]] = {}  # folder key -> immediate subfolder names
+        self._folders_version: int | None = None
 
     @staticmethod
     def filename_from_path(
@@ -108,28 +110,91 @@ class SongManager:
             self._index_version = version
         return self._index
 
-    def search(self, query: str) -> list[str]:
+    def _scoped_index(self, folder: str | None) -> list[tuple[str, str]]:
+        """Match index entries, narrowed to one folder's direct children.
+
+        `None` means the whole library; `""` means the download path itself. The
+        two are not the same: the flat view lists every song wherever it sits,
+        while the root of the folder view lists only what is not in a subfolder.
+        """
+        index = self._match_index()
+        if folder is None:
+            return index
+        target = self.folder_path(folder)
+        return [
+            (name, path)
+            for name, path in index
+            if os.path.dirname(os.path.normpath(path)) == target
+        ]
+
+    def search(self, query: str, folder: str | None = None) -> list[str]:
         """Songs whose filename contains every whitespace-separated term, in list order."""
         terms = remove_accents(query).lower().split()
+        index = self._scoped_index(folder)
         if not terms:
-            return list(self.songs)
-        index = self._match_index()
+            return [path for _, path in index]
         if len(terms) == 1:
             term = terms[0]
             return [path for name, path in index if term in name]
         return [path for name, path in index if all(t in name for t in terms)]
 
-    def songs_by_letter(self, letter: str) -> list[str]:
+    def songs_by_letter(self, letter: str, folder: str | None = None) -> list[str]:
         """Songs whose filename starts with `letter`, or with a digit when 'numeric'.
 
         Grouping by the raw filename keeps the alpha bar in agreement with
         SongList's sort order, which also keys on the raw basename.
         """
-        index = self._match_index()
+        index = self._scoped_index(folder)
         if letter == "numeric":
             return [path for name, path in index if name[:1].isnumeric()]
         target = letter.lower()
         return [path for name, path in index if name[:1] == target]
+
+    # ------------------------------------------------------------------
+    # Folders
+    #
+    # Folder keys are relative to download_path and always "/"-separated, because
+    # they travel as a URL parameter and must not change shape between platforms.
+    # The empty string is the root.
+    # ------------------------------------------------------------------
+
+    def folder_path(self, folder: str) -> str:
+        """Absolute directory for a folder key."""
+        base = os.path.normpath(self.download_path)
+        return os.path.join(base, *folder.split("/")) if folder else base
+
+    def folder_tree(self) -> dict[str, list[str]]:
+        """Every folder holding songs, mapped to its immediate subfolder names.
+
+        Memoized against the song list like the match index: the browse page needs
+        the root entry on every request to decide whether to offer the folder view
+        at all, and rebuilding that per request is an O(songs) pass on a Pi.
+
+        Because keys are derived from real song paths, membership doubles as the
+        path-traversal guard -- "../../etc" is simply not a key.
+        """
+        version = self.songs.version
+        if self._folders_version != version:
+            children: dict[str, set[str]] = {"": set()}
+            prefix = os.path.normpath(self.download_path) + os.sep
+            for path in self.songs:
+                directory = os.path.dirname(os.path.normpath(path))
+                if not directory.startswith(prefix):
+                    continue  # sits directly in the download path
+                parent = ""
+                for name in directory[len(prefix) :].split(os.sep):
+                    children.setdefault(parent, set()).add(name)
+                    parent = f"{parent}/{name}" if parent else name
+                children.setdefault(parent, set())
+            self._folders = {
+                folder: sorted(names, key=str.lower) for folder, names in children.items()
+            }
+            self._folders_version = version
+        return self._folders
+
+    def songs_in_folder(self, folder: str) -> list[str]:
+        """Songs sitting directly in `folder`, excluding its subfolders, in list order."""
+        return [path for _, path in self._scoped_index(folder)]
 
     def _get_companion_files(self, song_path: str) -> list[str]:
         """Return paths to companion files (.cdg, .ass) that exist alongside a song."""

--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -54,6 +54,8 @@ class SongManager:
         self._index_version: int | None = None
         self._folders: dict[str, list[str]] = {}  # folder key -> immediate subfolder names
         self._folders_version: int | None = None
+        self._initials: dict[str | None, set[str]] = {}  # scope -> alpha-bar keys present
+        self._initials_version: int | None = None
 
     @staticmethod
     def filename_from_path(
@@ -191,6 +193,35 @@ class SongManager:
             }
             self._folders_version = version
         return self._folders
+
+    def letters_with_songs(self, folder: str | None = None) -> set[str]:
+        """Alpha-bar keys that `songs_by_letter` would answer for, in the same scope.
+
+        Memoized against the song list rather than derived per request: the browse
+        page greys out the dead letters on every render, and `_scoped_index` costs
+        an O(songs) pass of path splitting that a Pi should not repeat mid-playback.
+        Keyed like `_scoped_index` -- `None` is the whole library, `""` the root.
+        """
+        version = self.songs.version
+        if self._initials_version != version:
+            initials: dict[str | None, set[str]] = {None: set()}
+            prefix = os.path.normpath(self.download_path) + os.sep
+            for name, path in self._match_index():
+                first = name[:1]
+                if not first:
+                    continue
+                key = "numeric" if first.isnumeric() else first
+                directory = os.path.dirname(os.path.normpath(path))
+                scope = (
+                    directory[len(prefix) :].replace(os.sep, "/")
+                    if directory.startswith(prefix)
+                    else ""
+                )
+                initials[None].add(key)
+                initials.setdefault(scope, set()).add(key)
+            self._initials = initials
+            self._initials_version = version
+        return self._initials.get(folder, set())
 
     def songs_in_folder(self, folder: str) -> list[str]:
         """Songs sitting directly in `folder`, excluding its subfolders, in list order."""

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -91,8 +91,14 @@ def browse():
     # and q/letter are filters within it. An unknown folder -- including a "../"
     # traversal attempt -- is not a key in the tree, so it clamps to the root
     # rather than being validated against the filesystem.
-    folder_tree = k.song_manager.folder_tree()
-    in_folders = request.args.get("view") == "folders"
+    #
+    # Folder browsing is opt-in. The empty tree stands in when it is off, which
+    # drops the toggle and makes a bookmarked ?view=folders fall back to the flat
+    # list rather than 404 -- the preference can be turned off while a phone is
+    # sitting on a folder page.
+    folder_tree = k.song_manager.folder_tree() if k.enable_folder_browsing else {"": []}
+    has_subfolders = bool(folder_tree[""])
+    in_folders = has_subfolders and request.args.get("view") == "folders"
     folder = request.args.get("folder", "") if in_folders else ""
     if folder not in folder_tree:
         folder = ""
@@ -185,7 +191,7 @@ def browse():
         "breadcrumbs": _build_breadcrumbs(folder),
         # Drives whether the folder toggle is offered at all: a flat library never
         # sees it, so nothing about the page changes for those users.
-        "has_subfolders": bool(folder_tree[""]),
+        "has_subfolders": has_subfolders,
     }
     # Filter keystrokes ask for the result table alone. Rendering base.html per
     # keystroke is pure Python, so on a Pi it blocks the event loop as surely as

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -179,6 +179,9 @@ def browse():
         "sort_order": sort_order,
         "site_title": site_name,
         "letter": letter,
+        # Scoped, not filtered: the alpha bar sits outside the swapped fragment, so
+        # which letters it offers must not move as the user types.
+        "letters": k.song_manager.letters_with_songs(scope),
         "q": q,
         # MSG: Title of the page listing the songs already on this machine.
         "title": _("Songs"),

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -56,6 +56,14 @@ def _format_icon(song_path: str, db_format: str | None) -> str | None:
 files_bp = Blueprint("files", __name__)
 
 
+def _build_breadcrumbs(folder: str) -> list[dict[str, str]]:
+    """Trail of {name, folder} entries for each segment of a folder key."""
+    if not folder:
+        return []
+    parts = folder.split("/")
+    return [{"name": part, "folder": "/".join(parts[: i + 1])} for i, part in enumerate(parts)]
+
+
 class SongReferrerQuery(Schema):
     song = fields.String(required=True, metadata={"description": "Path to the song file"})
     referrer = fields.String(metadata={"description": "URL to redirect back to"})
@@ -79,11 +87,24 @@ def browse():
     q = (request.args.get("q") or "").strip()
     letter = request.args.get("letter")
 
+    # `view=folders` scopes the listing to one directory, so the folder is a scope
+    # and q/letter are filters within it. An unknown folder -- including a "../"
+    # traversal attempt -- is not a key in the tree, so it clamps to the root
+    # rather than being validated against the filesystem.
+    folder_tree = k.song_manager.folder_tree()
+    in_folders = request.args.get("view") == "folders"
+    folder = request.args.get("folder", "") if in_folders else ""
+    if folder not in folder_tree:
+        folder = ""
+    scope = folder if in_folders else None
+
     # A text query and a letter jump are two different intents, so q wins.
     if q:
-        available_songs = k.song_manager.search(q)
+        available_songs = k.song_manager.search(q, folder=scope)
     elif letter:
-        available_songs = k.song_manager.songs_by_letter(letter)
+        available_songs = k.song_manager.songs_by_letter(letter, folder=scope)
+    elif in_folders:
+        available_songs = k.song_manager.songs_in_folder(folder)
     else:
         available_songs = k.song_manager.songs
 
@@ -120,10 +141,16 @@ def browse():
     # no nav or stylesheet. The same leak poisons current_url, which becomes the
     # edit button's referrer.
     args.pop("partial", None)
-    # Rewritten rather than passed through, because the clamp above may have dropped
-    # a page the request asked for, and these args build the pagination links and
-    # the edit referrer -- an edit started from a clamped page comes back to a real
-    # one.
+    # Rewritten rather than passed through, because the clamps above may have
+    # dropped a folder or a page the request asked for. These args build the
+    # pagination links and the edit referrer, so they have to describe what was
+    # rendered -- an edit started from a clamped page comes back to a real one.
+    args.pop("view", None)
+    args.pop("folder", None)
+    if in_folders:
+        args["view"] = "folders"
+        if folder:
+            args["folder"] = folder
     args["page"] = page
 
     current_url = url_for("files.browse", **args.to_dict())
@@ -152,6 +179,13 @@ def browse():
         "songs": songs[start_index : start_index + results_per_page],
         "admin": admin,
         "current_url": current_url,
+        "view": "folders" if in_folders else "",
+        "folder": folder,
+        "subfolders": folder_tree[folder] if in_folders else [],
+        "breadcrumbs": _build_breadcrumbs(folder),
+        # Drives whether the folder toggle is offered at all: a flat library never
+        # sees it, so nothing about the page changes for those users.
+        "has_subfolders": bool(folder_tree[""]),
     }
     # Filter keystrokes ask for the result table alone. Rendering base.html per
     # keystroke is pure Python, so on a Pi it blocks the event loop as surely as

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -85,6 +85,7 @@ def info():
         browse_results_per_page=k.browse_results_per_page,
         per_page_options=per_page_options(k.browse_results_per_page),
         enable_title_tidy=k.enable_title_tidy,
+        enable_folder_browsing=k.enable_folder_browsing,
         score_phrases={
             "low": k.low_score_phrases,
             "mid": k.mid_score_phrases,

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -233,6 +233,14 @@
 		top: 3px;
 		z-index: 20;
 	}
+	/* Held in the layout rather than hidden, so the strip keeps the same 27 slots in
+	   every folder. Dim enough to read as unavailable, but still legible: it is the
+	   only thing telling you the folder has nothing under that letter. */
+	#alpha-bar .alpha-empty {
+		opacity: 0.35;
+		cursor: default;
+		user-select: none;
+	}
 	table {
 		width: 100%;
 		table-layout: auto; /* Allows columns to adjust based on content */
@@ -376,19 +384,31 @@
 	</div>
 </div>
 
-{# In folder view a short folder does not need 26 letters to narrow it, and the bar
-   would sit above a table it dwarfs. The flat view keeps it unconditionally. #}
-{% if not view or total > per_page %}
+{# A folder listing only subfolders has no songs for the bar to narrow, so every
+   letter would be a dead end. Everywhere else it renders, scoped to what is on
+   screen -- the letters that would return nothing are greyed rather than dropped,
+   so the strip does not change shape as the user moves between folders. #}
+{% if not view or letters %}
 <div id="alpha-bar" class="column is-full has-background-dark">
 	<a href="{{ url_for('files.browse', view=view or None, folder=folder or None) }}" title="Show all"
 		><i class="icon icon-list-bullet"></i
 	></a>
+	{% if 'numeric' in letters %}
 	<a href="{{ url_for('files.browse', letter='numeric', view=view or None, folder=folder or None) }}">#</a>
+	{% else %}
+	<span class="alpha-empty">#</span>
+	{% endif %}
 	{# Not named `letter`: the sort links below read the page's own `letter` variable,
 	   and shadowing it here would be one Jinja scoping rule away from a bug. #}
 	{% for alpha in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
 	'u', 'v', 'w', 'x', 'y', 'z'] %}
+	{% if alpha in letters %}
 	<a href="{{ url_for('files.browse', letter=alpha, view=view or None, folder=folder or None) }}">{{alpha.upper()}}</a>
+	{% else %}
+	{# A span, not a disabled link: an anchor with no href is still focusable, so a
+	   keyboard would tab through two dozen dead stops to reach the list. #}
+	<span class="alpha-empty">{{alpha.upper()}}</span>
+	{% endif %}
 	{% endfor %}
 </div>
 {% endif %}

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -51,8 +51,26 @@
 		}
 
 		const BROWSE_URL = "{{ url_for('files.browse') }}";
+		const VIEW = {{ view | tojson }};
+		const FOLDER = {{ folder | tojson }};
 		const input = document.getElementById("song-filter");
 		const resultsDiv = document.getElementById("browse-results");
+
+		// A folder holding only subfolders renders neither control. The alpha-bar
+		// handler above is already bound, so bail out here rather than earlier.
+		if (!input || !resultsDiv) return;
+
+		// Filtering and sorting act *within* the folder being browsed, so every URL
+		// built below has to carry the scope -- otherwise the first keystroke
+		// silently throws the user back out to the whole library.
+		function scopeParams() {
+			const params = new URLSearchParams();
+			if (VIEW) {
+				params.set("view", VIEW);
+				if (FOLDER) params.set("folder", FOLDER);
+			}
+			return params;
+		}
 		// What the server last rendered. A query that resolves to this needs no
 		// request, which is why typing one letter on an unfiltered page is free.
 		let renderedQuery = {{ q | tojson }};
@@ -66,7 +84,7 @@
 		}
 
 		function buildParams(q) {
-			const params = new URLSearchParams();
+			const params = scopeParams();
 			if (q) params.set("q", q);
 			// A user who chose ?sort=date and then typed has not asked to go back
 			// to alphabetical. page and letter are dropped: a new query is a new
@@ -81,7 +99,7 @@
 		// switching sort would then silently drop what the user had typed.
 		function syncSortLinks(q) {
 			document.querySelectorAll("a.sort-link").forEach(function (a) {
-				const params = new URLSearchParams();
+				const params = scopeParams();
 				if (q) params.set("q", q);
 				if (a.dataset.sort) params.set("sort", a.dataset.sort);
 				const query = params.toString();
@@ -244,14 +262,23 @@
 		white-space: nowrap;
 	}
 
-	#sort-bar {
+	/* The view toggle sits left, the sort toggle right. The left slot is rendered
+	   even when empty so that space-between keeps sort against the right edge on a
+	   library with no subfolders. */
+	#browse-controls {
 		display: flex;
-		justify-content: flex-end;
+		justify-content: space-between;
+		flex-wrap: wrap;
 	}
-	/* Bulma gives a non-last .buttons a full block of spacing; this control belongs
-	   close to the table it sorts. */
-	#sort-bar .buttons {
+	/* Bulma gives a non-last .buttons a full block of spacing; these controls belong
+	   close to the table they act on. */
+	#browse-controls .buttons {
 		margin-bottom: 0.5rem;
+	}
+
+	.folder-item {
+		/* Pushes the chevron to the right edge; panel-block is flex already. */
+		justify-content: space-between;
 	}
 
 	@media screen and (max-width: 500px) {
@@ -286,6 +313,34 @@
 </style>
 {% endblock %} {% block content %}
 
+{# A folder holding only subfolders is navigation, not a result set: no filter box,
+   no A-Z bar, no sort toggle and no empty table -- just the folders. An active
+   filter keeps them all, so a query matching nothing can still be cleared. #}
+{% set folder_landing = view and not songs and not q and not letter %}
+{# The route reports the sort as a display string; the view toggle needs the param
+   back so that switching between flat and folder view keeps the chosen order. #}
+{% set sort_param = 'date' if sort_order == 'Date' else None %}
+
+{% if breadcrumbs %}
+<nav class="breadcrumb is-small" aria-label="breadcrumbs">
+	<ul>
+		<li>
+			<a href="{{ url_for('files.browse', view='folders') }}">
+				<span class="icon is-small"><i class="icon icon-folder-open-empty"></i></span>
+				{# MSG: Breadcrumb link back to the top level of the folder view. #}
+				<span>{% trans %}All folders{% endtrans %}</span>
+			</a>
+		</li>
+		{% for crumb in breadcrumbs %}
+		<li {% if loop.last %}class="is-active"{% endif %}>
+			<a href="{{ url_for('files.browse', view='folders', folder=crumb.folder) }}">{{ crumb.name }}</a>
+		</li>
+		{% endfor %}
+	</ul>
+</nav>
+{% endif %}
+
+{% if not folder_landing %}
 {# Filtering is server-side: the page is paginated, so a client-side filter over
    the ~100 rows in the DOM would silently miss songs on every other page. #}
 <div class="field has-addons mb-3">
@@ -307,39 +362,78 @@
 	</div>
 </div>
 
+{# In folder view a short folder does not need 26 letters to narrow it, and the bar
+   would sit above a table it dwarfs. The flat view keeps it unconditionally. #}
+{% if not view or total > per_page %}
 <div id="alpha-bar" class="column is-full has-background-dark">
-	<a href="{{ url_for('files.browse') }}" title="Show all"><i class="icon icon-list-bullet"></i></a>
-	<a href="{{ url_for('files.browse') }}?letter=numeric">#</a>
+	<a href="{{ url_for('files.browse', view=view or None, folder=folder or None) }}" title="Show all"
+		><i class="icon icon-list-bullet"></i
+	></a>
+	<a href="{{ url_for('files.browse', letter='numeric', view=view or None, folder=folder or None) }}">#</a>
 	{# Not named `letter`: the sort links below read the page's own `letter` variable,
 	   and shadowing it here would be one Jinja scoping rule away from a bug. #}
 	{% for alpha in ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
 	'u', 'v', 'w', 'x', 'y', 'z'] %}
-	<a href="{{ url_for('files.browse') }}?letter={{alpha}}">{{alpha.upper()}}</a>
+	<a href="{{ url_for('files.browse', letter=alpha, view=view or None, folder=folder or None) }}">{{alpha.upper()}}</a>
 	{% endfor %}
 </div>
+{% endif %}
+{% endif %}
 
-{# Sits with the results it describes rather than above the search box, and shows
-   both orderings at once so the current one is visible without reading a sentence.
-   Sorting is orthogonal to filtering, so these carry the active filter through --
-   the alpha bar above is the one control that deliberately clears it. #}
-<div id="sort-bar">
+{% if subfolders %}
+{# Entering a folder deliberately drops q, letter and page: a folder is a new
+   listing, not a filtered continuation of the one being left. #}
+<div class="panel">
+	{% for name in subfolders %}
+	<a class="panel-block py-3 folder-item"
+		href="{{ url_for('files.browse', view='folders', folder=(folder ~ '/' ~ name) if folder else name) }}">
+		<span><span class="icon mr-2"><i class="icon-folder-open-empty"></i></span>{{ name }}</span>
+		<span class="icon"><i class="icon-right-big"></i></span>
+	</a>
+	{% endfor %}
+</div>
+{% endif %}
+
+{# Both toggles sit with the results they describe rather than above the search box,
+   and each shows its options at once so the active one is visible without reading a
+   sentence. Sorting and the view are orthogonal to filtering, so both carry the
+   active query through -- the alpha bar above is the one control that clears it. #}
+<div id="browse-controls">
 	<div class="buttons has-addons are-small">
+		{% if has_subfolders %}
+		<a class="button {% if not view %}is-info is-selected{% endif %}"
+			href="{{ url_for('files.browse', q=q or None, sort=sort_param) }}">
+			{# MSG: Button which lists every song at once, ignoring the folders they are stored in. #}
+			{% trans %}All songs{% endtrans %}
+		</a>
+		<a class="button {% if view %}is-info is-selected{% endif %}"
+			href="{{ url_for('files.browse', view='folders', q=q or None, sort=sort_param) }}">
+			{# MSG: Button which groups the songs by the folder they are stored in. #}
+			{% trans %}Folders{% endtrans %}
+		</a>
+		{% endif %}
+	</div>
+	<div class="buttons has-addons are-small">
+		{% if not folder_landing %}
 		{# Labels stay on one line: `trans` does not collapse whitespace, so a wrapped
 		   label bakes the newline and tabs into the msgid and any reindent breaks it. #}
 		<a class="button sort-link {% if sort_order == 'Alphabetical' %}is-info is-selected{% endif %}" data-sort=""
-			href="{{ url_for('files.browse', q=q or None, letter=letter or None) }}">
+			href="{{ url_for('files.browse', q=q or None, letter=letter or None, view=view or None, folder=folder or None) }}">
 			{# MSG: Button which changes how the songs are sorted so they become sorted by name. #}
 			{% trans %}Sort Alphabetically{% endtrans %}
 		</a>
 		<a class="button sort-link {% if sort_order == 'Date' %}is-info is-selected{% endif %}" data-sort="date"
-			href="{{ url_for('files.browse', sort='date', q=q or None, letter=letter or None) }}">
+			href="{{ url_for('files.browse', sort='date', q=q or None, letter=letter or None, view=view or None, folder=folder or None) }}">
 			{# MSG: Button which changes how the songs are sorted so they become sorted by date. #}
 			{% trans %}Sort by Date{% endtrans %}
 		</a>
+		{% endif %}
 	</div>
 </div>
 
+{% if not folder_landing %}
 {# The filter input sits outside this div, so a keystroke swap never takes the
    caret with it. #}
 <div id="browse-results">{% include 'partials/browse_results.html' %}</div>
+{% endif %}
 {% endblock %}

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -9,26 +9,35 @@
 		// media query -- an inline `top` would follow a resize onto the desktop
 		// layout and strand the bar wherever the phone had left it.
 		const alphaBar = document.getElementById("alpha-bar");
-		const restingTop = document.querySelector(".box").getBoundingClientRect().top + window.scrollY;
-		let queued = false;
-		function placeAlphaBar() {
-			queued = false;
-			const top = Math.max(3, restingTop - window.scrollY);
-			alphaBar.style.setProperty("--alpha-top", top + "px");
+		const box = document.querySelector(".box");
+		// The strip is dropped for a folder short enough to fit on one page.
+		if (alphaBar && box) {
+			const restingTop = box.getBoundingClientRect().top + window.scrollY;
+			let queued = false;
+			function placeAlphaBar() {
+				queued = false;
+				const top = Math.max(3, restingTop - window.scrollY);
+				alphaBar.style.setProperty("--alpha-top", top + "px");
+			}
+			// Not on load alone: a Back navigation restores the scroll position.
+			placeAlphaBar();
+			// Namespaced, and unbound first, because SPA navigation re-runs this
+			// script on every visit and a plain bind would stack a handler per page.
+			$(window)
+				.off("scroll.alphabar")
+				.on("scroll.alphabar", function () {
+					// A phone fires scroll faster than it paints and each write
+					// forces a layout, so collapse them onto the frame.
+					if (queued) return;
+					queued = true;
+					requestAnimationFrame(placeAlphaBar);
+				});
 		}
-		// Not on load alone: a Back navigation restores the scroll position.
-		placeAlphaBar();
-		// Namespaced, and unbound first, because SPA navigation re-runs this
-		// script on every visit and a plain bind would stack a handler per page.
-		$(window)
-			.off("scroll.alphabar")
-			.on("scroll.alphabar", function () {
-				// A phone fires scroll faster than it paints and each write
-				// forces a layout, so collapse them onto the frame.
-				if (queued) return;
-				queued = true;
-				requestAnimationFrame(placeAlphaBar);
-			});
+
+		const input = document.getElementById("song-filter");
+		const resultsDiv = document.getElementById("browse-results");
+		// A folder holding only subfolders renders neither control.
+		if (!input || !resultsDiv) return;
 
 		// --- Filter box -------------------------------------------------
 		// Hiragana/Katakana, CJK Ext A, CJK Unified, Hangul Syllables. Ranges mirror
@@ -53,12 +62,6 @@
 		const BROWSE_URL = "{{ url_for('files.browse') }}";
 		const VIEW = {{ view | tojson }};
 		const FOLDER = {{ folder | tojson }};
-		const input = document.getElementById("song-filter");
-		const resultsDiv = document.getElementById("browse-results");
-
-		// A folder holding only subfolders renders neither control. The alpha-bar
-		// handler above is already bound, so bail out here rather than earlier.
-		if (!input || !resultsDiv) return;
 
 		// Filtering and sorting act *within* the folder being browsed, so every URL
 		// built below has to carry the scope -- otherwise the first keystroke

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -10,7 +10,7 @@
 		// layout and strand the bar wherever the phone had left it.
 		const alphaBar = document.getElementById("alpha-bar");
 		const box = document.querySelector(".box");
-		// The strip is dropped for a folder short enough to fit on one page.
+		// The strip is dropped for a folder that holds only subfolders.
 		if (alphaBar && box) {
 			const restingTop = box.getBoundingClientRect().top + window.scrollY;
 			let queued = false;

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -281,6 +281,14 @@
 		justify-content: space-between;
 	}
 
+	/* Bulma ships the breadcrumb list as align-items: flex-start, which only shows
+	   when the items are unequal heights -- here the root crumb carries a folder
+	   icon and the rest are plain text, so they hang from the top instead of
+	   sharing a centre line. */
+	.breadcrumb ul {
+		align-items: center;
+	}
+
 	@media screen and (max-width: 500px) {
 		#alpha-bar {
 			font-size: 13px;
@@ -326,13 +334,16 @@
 	<ul>
 		<li>
 			<a href="{{ url_for('files.browse', view='folders') }}">
-				<span class="icon is-small"><i class="icon icon-folder-open-empty"></i></span>
+				{# The glyph class alone -- adding Bulma's `icon` to the inner element
+				   nests a default 1.5rem icon box inside this `is-small` one and
+				   knocks the folder glyph off centre. #}
+				<span class="icon is-small"><i class="icon-folder-open-empty"></i></span>
 				{# MSG: Breadcrumb link back to the top level of the folder view. #}
 				<span>{% trans %}All folders{% endtrans %}</span>
 			</a>
 		</li>
 		{% for crumb in breadcrumbs %}
-		<li {% if loop.last %}class="is-active"{% endif %}>
+		<li{% if loop.last %} class="is-active"{% endif %}>
 			<a href="{{ url_for('files.browse', view='folders', folder=crumb.folder) }}">{{ crumb.name }}</a>
 		</li>
 		{% endfor %}

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -682,6 +682,12 @@
 					</label>
 					</div>
 
+					<div class="user-preference-container">
+					<input id="pref-enable-folder-browsing" type="checkbox" class="user-preference-checkbox checkbox" data-pref="enable_folder_browsing" {% if enable_folder_browsing == True %}checked{% endif %}>
+					<label class="label" for="pref-enable-folder-browsing">{# MSG: Checkbox label which enables browsing the song library by folder #} {% trans %}Enable folder browsing (adds a Folders view to the Songs page when the library has subfolders){% endtrans %}
+					</label>
+					</div>
+
 					<div class="user-preference-container is-align-items-center">
 					<input id="pref-avsync" class="user-preference-input input" type="number" step="0.1" min="-10" max="10" data-pref="avsync" data-start-value="{{ avsync }}" value="{{ avsync }}" />
 					<label class="label" for="pref-avsync">

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -507,8 +507,10 @@ class TestFolderView:
         assert "Bon Jovi" not in body
 
     def test_breadcrumbs_appear_inside_a_folder(self, client, app):
+        """The attribute, not the bare word: a .breadcrumb CSS rule ships on every page."""
         body = _browse(client, app, NESTED, "?view=folders&folder=Rock/Metal").data.decode()
-        assert "breadcrumb" in body
+        assert 'class="breadcrumb' in body
+        assert ">Rock<" in body and ">Metal<" in body
 
     def test_view_toggle_is_absent_for_a_flat_library(self, client, app):
         body = _browse(client, app, ["/songs/A.mp4", "/songs/B.mp4"]).data.decode()
@@ -544,7 +546,7 @@ class TestFolderBrowsingIsOptIn:
             client, app, NESTED, "?view=folders&folder=Rock", folders=False
         ).data.decode()
         assert "Heavy Song" in body
-        assert "breadcrumb" not in body
+        assert 'class="breadcrumb' not in body
 
     def test_alpha_bar_returns_when_disabled(self, client, app):
         """The folder view's short-folder rule must not leak into the flat page."""
@@ -558,12 +560,12 @@ class TestTraversalGuard:
     def test_dot_dot_traversal_clamps_to_the_root(self, client, app):
         body = _browse(client, app, NESTED, "?view=folders&folder=../../etc").data.decode()
         assert "Loose Track" in body
-        assert "breadcrumb" not in body
+        assert 'class="breadcrumb' not in body
 
     def test_unknown_folder_clamps_to_the_root(self, client, app):
         body = _browse(client, app, NESTED, "?view=folders&folder=Nope").data.decode()
         assert "Loose Track" in body
-        assert "breadcrumb" not in body
+        assert 'class="breadcrumb' not in body
 
     def test_clamped_folder_is_dropped_from_generated_urls(self, client, app):
         """current_url becomes the edit referrer; it must describe what was rendered."""

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -517,11 +517,7 @@ class TestFolderView:
         assert "view=folders" not in body
 
     def test_alpha_bar_is_hidden_in_a_folder_that_fits_on_one_page(self, client, app):
-        """26 letters above four rows is noise; the flat view keeps the bar regardless.
-
-        Asserting on the id attribute, not the bare string: the scroll handler in
-        this template's script block names #alpha-bar whether or not it renders.
-        """
+        """26 letters above four rows is noise; the flat view keeps the bar regardless."""
         folders = _browse(client, app, NESTED, "?view=folders").data.decode()
         assert 'id="alpha-bar"' not in folders
         assert 'id="alpha-bar"' in _browse(client, app, NESTED).data.decode()

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -42,7 +42,7 @@ def _sort_links(body):
     return dict(re.findall(r'data-sort="([^"]*)"\s*href="([^"]+)"', body))
 
 
-def _karaoke(app, songs, per_page):
+def _karaoke(app, songs, per_page, folders=True):
     """A karaoke stand-in whose song_manager is the real thing."""
     sm = SongManager("/songs", db=MagicMock(), events=EventSystem(), get_title_tidy=lambda: False)
     sm.songs.update(songs)
@@ -50,12 +50,17 @@ def _karaoke(app, songs, per_page):
     k = MagicMock()
     k.song_manager = sm
     k.browse_results_per_page = per_page
+    # Set explicitly: a bare MagicMock attribute is truthy, so leaving it out would
+    # silently enable folder browsing in every test and never exercise the gate.
+    k.enable_folder_browsing = folders
     return k
 
 
-def _browse(client, app, songs=(), query="", per_page=100, admin=True, cookie=None, k=None):
+def _browse(
+    client, app, songs=(), query="", per_page=100, admin=True, cookie=None, k=None, folders=True
+):
     """GET /browse. `per_page` is the server-wide default, `cookie` one device's choice."""
-    k = k if k is not None else _karaoke(app, songs, per_page)
+    k = k if k is not None else _karaoke(app, songs, per_page, folders)
     if cookie is not None:
         client.set_cookie("browse_per_page", cookie)
     with (
@@ -518,6 +523,33 @@ class TestFolderView:
         folders = _browse(client, app, NESTED, "?view=folders").data.decode()
         assert 'id="alpha-bar"' not in folders
         assert 'id="alpha-bar"' in _browse(client, app, NESTED).data.decode()
+
+
+class TestFolderBrowsingIsOptIn:
+    """Off by default: the Songs page must look exactly as it did without the feature."""
+
+    def test_no_toggle_when_disabled(self, client, app):
+        body = _browse(client, app, NESTED, folders=False).data.decode()
+        assert "view=folders" not in body
+
+    def test_every_song_still_listed_when_disabled(self, client, app):
+        body = _browse(client, app, NESTED, folders=False).data.decode()
+        assert "Loose Track" in body
+        assert "Bon Jovi" in body
+        assert "Heavy Song" in body
+
+    def test_bookmarked_folder_url_falls_back_to_the_flat_list(self, client, app):
+        """The preference can be turned off while a phone is sitting on a folder page."""
+        body = _browse(
+            client, app, NESTED, "?view=folders&folder=Rock", folders=False
+        ).data.decode()
+        assert "Heavy Song" in body
+        assert "breadcrumb" not in body
+
+    def test_alpha_bar_returns_when_disabled(self, client, app):
+        """The folder view's short-folder rule must not leak into the flat page."""
+        body = _browse(client, app, NESTED, "?view=folders", folders=False).data.decode()
+        assert 'id="alpha-bar"' in body
 
 
 class TestTraversalGuard:

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -42,6 +42,21 @@ def _sort_links(body):
     return dict(re.findall(r'data-sort="([^"]*)"\s*href="([^"]+)"', body))
 
 
+def _alpha_bar(body):
+    """(linked, greyed) keys from the A-Z strip, or None when it is not rendered.
+
+    Read from the strip's own markup rather than the whole page: sort and pager
+    links carry `letter` too, so a page-wide search reports links that are not there.
+    """
+    match = re.search(r'<div id="alpha-bar".*?</div>', body, re.S)
+    if not match:
+        return None
+    bar = match.group(0)
+    linked = set(re.findall(r'letter=([a-z]+)[&"]', bar))
+    greyed = {t.lower() for t in re.findall(r'<span class="alpha-empty">([^<]+)</span>', bar)}
+    return linked, greyed
+
+
 def _karaoke(app, songs, per_page, folders=True):
     """A karaoke stand-in whose song_manager is the real thing."""
     sm = SongManager("/songs", db=MagicMock(), events=EventSystem(), get_title_tidy=lambda: False)
@@ -477,6 +492,9 @@ NESTED = [
     "/songs/Pop/Abba - Waterloo.mp4",
 ]
 
+# "Genres" holds a subfolder and no songs of its own.
+SUBFOLDERS_ONLY = ["/songs/Genres/Rock/Heavy Song.mp4"]
+
 
 class TestFolderView:
     def test_flat_view_lists_every_song_wherever_it_sits(self, client, app):
@@ -516,11 +534,55 @@ class TestFolderView:
         body = _browse(client, app, ["/songs/A.mp4", "/songs/B.mp4"]).data.decode()
         assert "view=folders" not in body
 
-    def test_alpha_bar_is_hidden_in_a_folder_that_fits_on_one_page(self, client, app):
-        """26 letters above four rows is noise; the flat view keeps the bar regardless."""
-        folders = _browse(client, app, NESTED, "?view=folders").data.decode()
-        assert 'id="alpha-bar"' not in folders
-        assert 'id="alpha-bar"' in _browse(client, app, NESTED).data.decode()
+    def test_alpha_bar_stays_inside_a_folder(self, client, app):
+        """It narrows the folder being browsed, so it belongs on the folder page."""
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock").data.decode()
+        assert _alpha_bar(body) is not None
+
+    def test_alpha_bar_is_dropped_for_a_folder_holding_only_subfolders(self, client, app):
+        """No songs on the page to narrow, so all 27 keys would be dead."""
+        body = _browse(client, app, SUBFOLDERS_ONLY, "?view=folders&folder=Genres").data.decode()
+        assert _alpha_bar(body) is None
+
+
+class TestAlphaBarFollowsTheScope:
+    """A key that would return nothing is greyed rather than dropped, so the strip
+    keeps the same shape in every folder."""
+
+    def test_only_letters_held_directly_by_the_folder_are_linked(self, client, app):
+        linked, greyed = _alpha_bar(
+            _browse(client, app, NESTED, "?view=folders&folder=Rock").data.decode()
+        )
+        assert linked == {"b"}, "Bon Jovi is the only song sitting directly in Rock"
+        assert "h" in greyed, "Heavy Song is in Rock/Metal, which Rock does not list"
+        assert "a" in greyed, "Abba is in Pop"
+
+    def test_the_flat_view_offers_every_letter_in_the_library(self, client, app):
+        linked, greyed = _alpha_bar(_browse(client, app, NESTED).data.decode())
+        assert {"a", "b", "h", "l"} <= linked
+        assert "z" in greyed
+
+    def test_the_strip_always_carries_all_27_keys(self, client, app):
+        """Dropping the dead ones would resize the strip on every folder change."""
+        linked, greyed = _alpha_bar(
+            _browse(client, app, NESTED, "?view=folders&folder=Rock").data.decode()
+        )
+        assert len(linked | greyed) == 27
+
+    def test_a_digit_lights_the_hash(self, client, app):
+        linked, _ = _alpha_bar(_browse(client, app, ["/songs/99 Luftballons.mp4"]).data.decode())
+        assert "numeric" in linked
+
+    def test_a_dead_letter_is_not_a_link(self, client, app):
+        """Greying it in CSS alone would still leave 25 tab stops before the list."""
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock").data.decode()
+        bar = re.search(r'<div id="alpha-bar".*?</div>', body, re.S).group(0)
+        assert "letter=z" not in bar
+
+    def test_an_active_letter_matching_nothing_keeps_the_strip(self, client, app):
+        """Otherwise the control that got you here vanishes and there is no way back."""
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock&letter=z").data.decode()
+        assert _alpha_bar(body) is not None
 
 
 class TestFolderBrowsingIsOptIn:
@@ -545,7 +607,7 @@ class TestFolderBrowsingIsOptIn:
         assert 'class="breadcrumb' not in body
 
     def test_alpha_bar_returns_when_disabled(self, client, app):
-        """The folder view's short-folder rule must not leak into the flat page."""
+        """The folder view's empty-scope rule must not leak into the flat page."""
         body = _browse(client, app, NESTED, "?view=folders", folders=False).data.decode()
         assert 'id="alpha-bar"' in body
 

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -461,3 +461,132 @@ class TestRenameFailuresKeepYourWork:
         body = response.data.decode()
         assert 'value="Half Typed Name"' in body
         assert 'value="/queue"' in body
+
+
+# Nested library shared by the folder tests below. "Loose" sits at the top level,
+# so it separates "every song" from "every song not in a subfolder".
+NESTED = [
+    "/songs/Loose Track.mp4",
+    "/songs/Rock/Bon Jovi - Livin.mp4",
+    "/songs/Rock/Metal/Heavy Song.mp4",
+    "/songs/Pop/Abba - Waterloo.mp4",
+]
+
+
+class TestFolderView:
+    def test_flat_view_lists_every_song_wherever_it_sits(self, client, app):
+        """The default view is what most libraries use; folders must not disturb it."""
+        body = _browse(client, app, NESTED).data.decode()
+        assert "Loose Track" in body
+        assert "Bon Jovi" in body
+        assert "Heavy Song" in body
+
+    def test_folder_root_lists_subfolders_and_only_loose_songs(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders").data.decode()
+        assert "Rock" in body
+        assert "Pop" in body
+        assert "Loose Track" in body
+        assert "Bon Jovi" not in body
+
+    def test_entering_a_folder_lists_its_direct_songs_only(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock").data.decode()
+        assert "Bon Jovi" in body
+        assert "Loose Track" not in body
+        # One level deeper: offered as a subfolder, not listed as a song.
+        assert "Heavy Song" not in body
+        assert "Metal" in body
+
+    def test_nested_folder_is_reached_by_its_full_key(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock/Metal").data.decode()
+        assert "Heavy Song" in body
+        assert "Bon Jovi" not in body
+
+    def test_breadcrumbs_appear_inside_a_folder(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock/Metal").data.decode()
+        assert "breadcrumb" in body
+
+    def test_view_toggle_is_absent_for_a_flat_library(self, client, app):
+        body = _browse(client, app, ["/songs/A.mp4", "/songs/B.mp4"]).data.decode()
+        assert "view=folders" not in body
+
+    def test_alpha_bar_is_hidden_in_a_folder_that_fits_on_one_page(self, client, app):
+        """26 letters above four rows is noise; the flat view keeps the bar regardless.
+
+        Asserting on the id attribute, not the bare string: the scroll handler in
+        this template's script block names #alpha-bar whether or not it renders.
+        """
+        folders = _browse(client, app, NESTED, "?view=folders").data.decode()
+        assert 'id="alpha-bar"' not in folders
+        assert 'id="alpha-bar"' in _browse(client, app, NESTED).data.decode()
+
+
+class TestTraversalGuard:
+    """Folder keys come from real song paths, so anything else clamps to the root."""
+
+    def test_dot_dot_traversal_clamps_to_the_root(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=../../etc").data.decode()
+        assert "Loose Track" in body
+        assert "breadcrumb" not in body
+
+    def test_unknown_folder_clamps_to_the_root(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Nope").data.decode()
+        assert "Loose Track" in body
+        assert "breadcrumb" not in body
+
+    def test_clamped_folder_is_dropped_from_generated_urls(self, client, app):
+        """current_url becomes the edit referrer; it must describe what was rendered."""
+        body = _browse(client, app, NESTED, "?view=folders&folder=Nope").data.decode()
+        assert "Nope" not in body
+
+
+class TestFolderScopeSurvivesTheControls:
+    """Every URL the page generates has to keep the folder, or a click silently leaves it."""
+
+    def test_sort_links_carry_the_folder(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock").data.decode()
+        links = _sort_links(body)
+        assert links, "expected sort links to assert against"
+        assert all("view=folders" in href and "folder=Rock" in href for href in links.values())
+
+    def test_alpha_bar_links_carry_the_folder(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Rock&letter=b").data.decode()
+        alpha = re.findall(r'href="([^"]*letter=[^"]*)"', body)
+        assert alpha, "expected alpha-bar links"
+        assert all("view=folders" in href and "folder=Rock" in href for href in alpha)
+
+    def test_pagination_links_carry_the_folder(self, client, app):
+        songs = [f"/songs/Rock/Song {i:03d}.mp4" for i in range(10)]
+        body = _browse(client, app, songs, "?view=folders&folder=Rock", per_page=2).data.decode()
+        links = re.findall(r'href="([^"]*page=\d+[^"]*)"', body)
+        assert links, "expected pagination links"
+        assert all("view=folders" in href and "folder=Rock" in href for href in links)
+
+    def test_filtering_stays_inside_the_folder(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Pop&q=a").data.decode()
+        assert "Abba - Waterloo" in body
+        assert "Bon Jovi" not in body
+
+    def test_partial_fragment_stays_inside_the_folder(self, client, app):
+        body = _browse(client, app, NESTED, "?view=folders&folder=Pop&partial=1").data.decode()
+        assert "Abba - Waterloo" in body
+        assert "Bon Jovi" not in body
+
+
+class TestFolderLanding:
+    """A folder holding only subfolders is navigation, not a result set."""
+
+    ONLY_FOLDERS = ["/songs/Rock/a.mp4", "/songs/Pop/b.mp4"]
+
+    def test_controls_and_table_are_hidden(self, client, app):
+        """Attributes, not bare ids: the script block names all three regardless."""
+        body = _browse(client, app, self.ONLY_FOLDERS, "?view=folders").data.decode()
+        assert "Rock" in body
+        assert 'id="song-filter"' not in body
+        assert 'id="browse-results"' not in body
+        assert 'class="button sort-link' not in body
+
+    def test_an_active_query_keeps_the_controls(self, client, app):
+        """A query matching nothing still has to be clearable."""
+        body = _browse(client, app, self.ONLY_FOLDERS, "?view=folders&q=zzz").data.decode()
+        assert 'id="song-filter"' in body
+        assert 'id="browse-results"' in body

--- a/tests/unit/test_preference_manager.py
+++ b/tests/unit/test_preference_manager.py
@@ -289,6 +289,7 @@ def test_preference_manager_defaults_exist():
         "hide_logo",
         "mic_settings",
         "enable_title_tidy",
+        "enable_folder_browsing",
         "metadata_provider",
         "itunes_search_country",
         "suggestion_name_order",

--- a/tests/unit/test_song_manager.py
+++ b/tests/unit/test_song_manager.py
@@ -441,3 +441,74 @@ class TestDisplayNameUnchanged:
     def test_tidy_off_returns_raw_name(self, tmp_path, mock_db):
         sm = _manager(tmp_path, mock_db, [self.SONG], tidy=False)
         assert sm.display_name_from_path(self.SONG) == "Queen - Bohemian Rhapsody (Karaoke Version)"
+
+
+def _under(tmp_path, *relative: str) -> list[str]:
+    """Native paths for songs genuinely inside the manager's download path."""
+    return [str(tmp_path.joinpath(*r.split("/"))) for r in relative]
+
+
+class TestFolderTree:
+    """The tree is what makes a folder key trustworthy: it is built from real songs."""
+
+    def test_root_lists_immediate_subfolders_only(self, tmp_path, mock_db):
+        songs = _under(tmp_path, "Top.mp4", "Rock/T.mp4", "Pop/T.mp4", "Rock/Metal/H.mp4")
+        sm = _manager(tmp_path, mock_db, songs)
+        assert sm.folder_tree()[""] == ["Pop", "Rock"]
+
+    def test_every_level_is_its_own_key(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "Rock/Metal/Heavy.mp4"))
+        tree = sm.folder_tree()
+        assert tree["Rock"] == ["Metal"]
+        # A leaf still has to be a key, or browsing into it clamps back to the root.
+        assert tree["Rock/Metal"] == []
+
+    def test_flat_library_has_only_the_root(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "A.mp4", "B.mp4"))
+        assert sm.folder_tree() == {"": []}
+
+    def test_subfolders_sort_case_insensitively(self, tmp_path, mock_db):
+        songs = _under(tmp_path, "zed/a.mp4", "Alpha/a.mp4", "beta/a.mp4")
+        sm = _manager(tmp_path, mock_db, songs)
+        assert sm.folder_tree()[""] == ["Alpha", "beta", "zed"]
+
+    def test_rebuilds_when_the_song_list_changes(self, tmp_path, mock_db):
+        """Memoized on SongList.version, so a stale tree would outlive a download."""
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "Rock/a.mp4"))
+        assert sm.folder_tree()[""] == ["Rock"]
+        sm.songs.update(_under(tmp_path, "Rock/a.mp4", "Jazz/b.mp4"))
+        assert sm.folder_tree()[""] == ["Jazz", "Rock"]
+
+
+class TestFolderScoping:
+    SONGS = ("Loose.mp4", "Rock/Bon Jovi.mp4", "Rock/Metal/Heavy.mp4", "Pop/Abba.mp4")
+
+    def test_songs_in_folder_excludes_deeper_levels(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert sm.songs_in_folder("Rock") == _under(tmp_path, "Rock/Bon Jovi.mp4")
+
+    def test_root_folder_excludes_everything_in_a_subfolder(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert sm.songs_in_folder("") == _under(tmp_path, "Loose.mp4")
+
+    def test_no_scope_is_not_the_same_as_the_root(self, tmp_path, mock_db):
+        """The flat view lists every song wherever it sits; the folder root does not."""
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert len(sm.search("", folder=None)) == 4
+        assert len(sm.search("", folder="")) == 1
+
+    def test_search_is_scoped_to_the_folder(self, tmp_path, mock_db):
+        songs = _under(tmp_path, "Rock/Abba - Waterloo.mp4", "Pop/Abba - Dancing.mp4")
+        sm = _manager(tmp_path, mock_db, songs)
+        assert sm.search("abba", folder="Rock") == _under(tmp_path, "Rock/Abba - Waterloo.mp4")
+        assert len(sm.search("abba")) == 2
+
+    def test_songs_by_letter_is_scoped_to_the_folder(self, tmp_path, mock_db):
+        songs = _under(tmp_path, "Rock/Abba.mp4", "Pop/Adele.mp4")
+        sm = _manager(tmp_path, mock_db, songs)
+        assert sm.songs_by_letter("a", folder="Rock") == _under(tmp_path, "Rock/Abba.mp4")
+        assert len(sm.songs_by_letter("a")) == 2
+
+    def test_unknown_folder_yields_nothing(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert sm.songs_in_folder("Nope") == []

--- a/tests/unit/test_song_manager.py
+++ b/tests/unit/test_song_manager.py
@@ -512,3 +512,49 @@ class TestFolderScoping:
     def test_unknown_folder_yields_nothing(self, tmp_path, mock_db):
         sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
         assert sm.songs_in_folder("Nope") == []
+
+
+class TestLettersWithSongs:
+    """The alpha bar greys the keys that would return nothing, so the two must agree."""
+
+    SONGS = ("Loose.mp4", "Rock/Bon Jovi.mp4", "Rock/Metal/Heavy.mp4", "Pop/Abba.mp4")
+
+    def test_a_folder_reports_only_its_direct_children(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert sm.letters_with_songs("Rock") == {"b"}
+
+    def test_no_scope_covers_the_whole_library(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert sm.letters_with_songs() == {"l", "b", "h", "a"}
+
+    def test_the_root_is_not_the_whole_library(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        assert sm.letters_with_songs("") == {"l"}
+
+    def test_a_folder_of_subfolders_reports_nothing(self, tmp_path, mock_db):
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "Genres/Rock/Heavy.mp4"))
+        assert sm.letters_with_songs("Genres") == set()
+
+    def test_a_digit_reports_as_numeric(self, tmp_path, mock_db):
+        """Matching songs_by_letter, which groups every digit under one key."""
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "99 Luftballons.mp4"))
+        assert sm.letters_with_songs() == {"numeric"}
+
+    def test_accents_fold_onto_the_plain_letter(self, tmp_path, mock_db):
+        """songs_by_letter matches the folded name, so 'b' must light up for Bjork."""
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "Bjork - Army Of Me.mp4"))
+        assert sm.letters_with_songs() == {"b"}
+
+    def test_every_reported_letter_actually_returns_songs(self, tmp_path, mock_db):
+        """The invariant behind the greying: a linked key is never a dead end."""
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, *self.SONGS))
+        for folder in ("", "Rock", "Rock/Metal", "Pop", None):
+            for key in sm.letters_with_songs(folder):
+                assert sm.songs_by_letter(key, folder=folder), f"{key!r} dead in {folder!r}"
+
+    def test_rebuilds_when_the_song_list_changes(self, tmp_path, mock_db):
+        """Memoized on SongList.version, so a download would otherwise stay greyed out."""
+        sm = _manager(tmp_path, mock_db, _under(tmp_path, "Rock/Bon Jovi.mp4"))
+        assert sm.letters_with_songs("Rock") == {"b"}
+        sm.songs.update(_under(tmp_path, "Rock/Bon Jovi.mp4", "Rock/Queen.mp4"))
+        assert sm.letters_with_songs("Rock") == {"b", "q"}


### PR DESCRIPTION
## Browse songs by folder

Adds an optional **Folders** view to the Songs page, for libraries organised into subdirectories — genre folders, per-artist folders, imported disc rips. The flat list stays the default and is unchanged.

The toggle only appears when two things are true: the preference is on, and the library actually has subfolders. A flat library sees nothing new.

### How it works

`view=folders` scopes the listing to one directory; `q`, `letter` and `sort` then act *within* that scope rather than resetting to the whole library. Breadcrumbs and a subfolder panel handle navigation, and entering a folder deliberately drops the active query and page — a folder is a new listing, not a filtered continuation of the one you left.

The A-Z strip is scoped to the folder on screen. Letters with no songs under them are greyed rather than dropped, so the strip keeps the same 27 slots as you move between folders, and they render as `<span>` rather than href-less anchors so a keyboard doesn't tab through two dozen dead stops. A folder holding only subfolders is treated as navigation: no filter box, no A-Z bar, no sort toggle, no empty table.

Folder keys are relative to the download path and always `/`-separated, since they travel as a URL parameter and must not change shape between platforms. Because the keys are derived from real song paths, an unknown folder — including a `../` traversal attempt — is simply not a key and clamps to the root.

### Enabling it

Off by default. Turn it on with the `Enable folder browsing` preference in Settings, or `--enable-folder-browsing` at startup. Turning it off while a phone is sitting on a folder page falls back to the flat list rather than 404ing.

### References

Refs #230 — the browsing half of that request; queueing a whole folder is not included, so it stays open.
Refs #854.

### Test plan

- [x] With the preference **off**, the Songs page looks exactly as before — no view toggle, no breadcrumbs.
- [x] Turn the preference on with a **flat** library (no subfolders): still no toggle.
- [x] Turn it on with a library containing subfolders: **All songs / Folders** toggle appears; `All songs` lists everything as before.
- [x] Switch to `Folders`: root lists subfolders, plus any songs sitting directly in the download path.
- [x] Enter a nested folder — breadcrumbs show `All folders / … / current`, and each crumb navigates correctly.
- [x] Type in the filter box inside a folder: results stay scoped to that folder, and the caret is not lost between keystrokes.
- [x] Click a letter in the A-Z bar inside a folder: results scoped to the folder; greyed letters are unclickable.
- [x] Switch sort order inside a folder and while filtering — the folder and the query both survive.
- [x] Open a folder holding only subfolders: no filter box, no A-Z bar, no sort toggle, no empty table.
- [x] Paginate inside a folder, then use a song's edit button — it returns to the same folder and page.
- [x] Visit `?view=folders&folder=../../etc` — clamps to the folder root.
- [x] Sit on a folder page, turn the preference off elsewhere, then reload — falls back to the flat list.
