### PR TITLE
fix: guarantee h264 for high quality downloads

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -139,8 +139,10 @@ def build_ytdl_download_command(
         List of command-line arguments for subprocess execution.
     """
     dl_path = os.path.join(download_path, "%(title)s---%(id)s.%(ext)s")
+    # AV1 ships in an mp4 container, so ext!=webm admits it and -S only sorts. Filtering
+    # on the codec is what keeps playback a stream copy instead of a libx264 transcode.
     file_quality = (
-        "bestvideo[ext!=webm][height<=1080]+bestaudio[ext!=webm]/best[ext!=webm]"
+        "bestvideo[vcodec^=avc1][height<=1080]+bestaudio[ext!=webm]/best[ext!=webm]"
         if high_quality
         else "mp4"
     )

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -94,7 +94,11 @@ class TestBuildYtdlDownloadCommand:
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_high_quality_format(self, mock_js):
-        """Test that high quality uses correct format string."""
+        """Test that high quality uses correct format string.
+
+        The codec filter is the guard: ext!=webm admits AV1, which would then be
+        transcoded on every playback rather than stream-copied.
+        """
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
             download_path="/songs",
@@ -102,6 +106,7 @@ class TestBuildYtdlDownloadCommand:
         )
         format_idx = cmd.index("-f") + 1
         assert "bestvideo" in cmd[format_idx]
+        assert "vcodec^=avc1" in cmd[format_idx]
         assert "1080" in cmd[format_idx]
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)


### PR DESCRIPTION
## What

One token in the high quality format selector — filter on the video codec instead of the container.

```
bestvideo[ext!=webm][height<=1080]  →  bestvideo[vcodec^=avc1][height<=1080]
```

## Why

`ext!=webm` was intended to exclude VP8/VP9, but AV1 ships in an mp4 container, so it passes the filter unchallenged. `-S vcodec:h264` only *sorts* candidates — it expresses a preference, not a constraint — so AV1 gets selected on any video that publishes no h264 at the requested height.

The consequence lands at playback, not download. `build_ffmpeg_command` decides to stream-copy on the file extension alone, on the assumption that mp4 implies h264:

```python
vcodec = "copy" if fr.file_extension == ".mp4" else default_vcodec
```

An AV1 file defeats that assumption. Where a webm is correctly transcoded to h264, an AV1 mp4 is copied straight through, so the browser receives an AV1 bitstream and playback depends on the client decoding it — which Pi-class hardware and older browsers do not. The file downloads fine and then silently fails to play.

Filtering on the codec makes AV1 unreachable by construction.

## Impact

A guarantee, not a behaviour change. The old and new selectors resolve identically on videos that publish h264, which is nearly all of them — checked on two videos, both giving `137+140 avc1 1080p` before and after.
