### PR TITLE
fix: retry failed downloads without blocking the queue

### DIFF
--- a/pikaraoke/lib/download_manager.py
+++ b/pikaraoke/lib/download_manager.py
@@ -8,9 +8,11 @@ import subprocess
 import uuid
 from queue import Queue
 
+import psutil
 from gevent import Greenlet, spawn
 
 from pikaraoke.lib.events import EventSystem
+from pikaraoke.lib.get_platform import is_windows
 from pikaraoke.lib.preference_manager import PreferenceManager
 from pikaraoke.lib.queue_manager import QueueManager
 from pikaraoke.lib.song_manager import SongManager
@@ -18,6 +20,29 @@ from pikaraoke.lib.youtube_dl import (
     build_ytdl_download_command,
     get_youtube_id_from_url,
 )
+
+# YouTube refuses a freshly resolved URL with a 403 on roughly half of all downloads,
+# regardless of the format selected, and re-extracting from scratch is the only known
+# remedy. At that rate three attempts would still leave one download in eight failing.
+MAX_DOWNLOAD_ATTEMPTS = 5
+
+
+def _use_spare_capacity(process: subprocess.Popen) -> None:
+    """Drop a download to background priority so it never competes with playback.
+
+    Priority is inherited, which is what covers the ffmpeg merge yt-dlp spawns.
+    """
+    try:
+        child = psutil.Process(process.pid)
+        if is_windows():
+            child.nice(psutil.BELOW_NORMAL_PRIORITY_CLASS)
+            child.ionice(psutil.IOPRIO_VERYLOW)
+        else:
+            child.nice(10)
+            # macOS has no ionice at all, hence AttributeError below.
+            child.ionice(psutil.IOPRIO_CLASS_IDLE)
+    except (psutil.Error, AttributeError, NotImplementedError, OSError) as e:
+        logging.debug(f"Could not lower download priority: {e}")
 
 
 class DownloadManager:
@@ -86,6 +111,7 @@ class DownloadManager:
             "active": self.active_download,
             "pending": self.pending_downloads,
             "errors": self.download_errors,
+            "max_attempts": MAX_DOWNLOAD_ATTEMPTS,
         }
 
     def remove_error(self, error_id: str) -> bool:
@@ -100,6 +126,28 @@ class DownloadManager:
         initial_len = len(self.download_errors)
         self.download_errors = [e for e in self.download_errors if e["id"] != error_id]
         return len(self.download_errors) < initial_len
+
+    def retry_error(self, error_id: str) -> bool:
+        """Re-queue a failed download and drop its error entry.
+
+        Args:
+            error_id: The ID of the error to retry.
+
+        Returns:
+            True if re-queued, False if the error was not found.
+        """
+        entry = next((e for e in self.download_errors if e["id"] == error_id), None)
+        if entry is None:
+            return False
+
+        self.remove_error(error_id)
+        self.queue_download(
+            entry["url"],
+            enqueue=entry["enqueue"],
+            user=entry["user"],
+            title=entry["title"],
+        )
+        return True
 
     def queue_download(
         self,
@@ -149,6 +197,7 @@ class DownloadManager:
             "user": user,
             "title": title,
             "display_title": displayed_title,
+            "attempts": 0,
         }
 
         # Add to the download queue and shadow list
@@ -174,23 +223,20 @@ class DownloadManager:
             self._is_downloading = True
 
             # Initialize active download state
+            attempts = download_request["attempts"]
             self.active_download = {
                 "title": download_request.get("display_title", download_request["video_url"]),
                 "url": download_request["video_url"],
                 "user": download_request["user"],
                 "progress": 0.0,
-                "status": "starting",
+                "status": "retrying" if attempts else "starting",
+                "attempts": attempts,
                 "eta": "--:--",
                 "speed": "---",
             }
 
             try:
-                self._execute_download(
-                    download_request["video_url"],
-                    download_request["enqueue"],
-                    download_request["user"],
-                    download_request["title"],
-                )
+                self._execute_download(download_request)
             except Exception as e:
                 logging.error(f"Error processing download: {e}")
             finally:
@@ -202,30 +248,100 @@ class DownloadManager:
                 if self.download_queue.empty():
                     self._events.emit("download_stopped")
 
-    def _execute_download(
-        self,
-        video_url: str,
-        enqueue: bool,
-        user: str,
-        title: str | None,
-    ) -> int:
-        """Execute a video download.
+    def _run_ytdl(self, cmd: list[str]) -> tuple[int, str]:
+        """Run yt-dlp to completion, streaming its progress into active_download.
+
+        Returns:
+            Tuple of (return code, captured output).
+        """
+        # Use Popen to capture output in real-time
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,  # Line buffered
+            universal_newlines=True,
+        )
+        _use_spare_capacity(process)
+
+        output_buffer = []
+
+        # Regex to parse progress from yt-dlp stdout
+        # Example: [download]   0.0% of    4.62MiB at  396.66KiB/s ETA 00:12
+        progress_regex = re.compile(
+            r"\[download\]\s+(\d+\.?\d*)%\s+of\s+.*?\s+at\s+([^\s]+)\s+ETA\s+([^\s]+)"
+        )
+
+        while True:
+            line = process.stdout.readline()
+            if not line and process.poll() is not None:
+                break
+            if line:
+                output_buffer.append(line)
+                match = progress_regex.search(line)
+                if match and self.active_download:
+                    self.active_download["progress"] = float(match.group(1))
+                    self.active_download["status"] = "downloading"
+                    self.active_download["speed"] = match.group(2)
+                    self.active_download["eta"] = match.group(3)
+
+        rc = process.poll()
+        output = "".join(output_buffer)
+        if rc == 0:
+            # A retry that succeeds is only diagnosable against the attempt that failed,
+            # so the winning attempt's output has to be kept as well.
+            logging.debug(f"yt-dlp output: {output}")
+        return rc, output
+
+    def _requeue(self, request: dict) -> bool:
+        """Put a failed download back at the end of the queue.
+
+        Back-of-queue placement is the backoff: any download waiting behind the failed
+        one overtakes it, so a dead link can never block the serialized worker.
+
+        Returns:
+            True if re-queued, False once the attempt cap is reached.
+        """
+        attempts = request["attempts"] + 1
+        if attempts >= MAX_DOWNLOAD_ATTEMPTS:
+            return False
+
+        request["attempts"] = attempts
+        if self.active_download:
+            self.active_download["progress"] = 0.0
+            self.active_download["status"] = "retrying"
+            self.active_download["attempts"] = attempts
+
+        self.download_queue.put(request)
+        self.pending_downloads.append(request)
+        logging.info(
+            f"Re-queueing failed download {request['video_url']} "
+            f"(attempt {attempts + 1} of {MAX_DOWNLOAD_ATTEMPTS})"
+        )
+        return True
+
+    def _execute_download(self, request: dict) -> int:
+        """Execute a video download, re-queueing it if it fails with attempts to spare.
 
         Args:
-            video_url: YouTube video URL.
-            enqueue: Whether to add to queue after download.
-            user: Username to attribute the download to.
-            title: Display title (defaults to URL if not provided).
+            request: Download request as built by queue_download.
 
         Returns:
             Return code from the download process (0 = success).
         """
         from flask_babel import _
 
-        displayed_title = title if title else video_url
+        video_url = request["video_url"]
+        enqueue = request["enqueue"]
+        user = request["user"]
+        displayed_title = request["title"] if request["title"] else video_url
 
-        # MSG: Message shown when download actually starts (after waiting in queue)
-        self._events.emit("notification", _("Downloading video: %s") % displayed_title)
+        # A retry is a quiet safety net, and the queue page already shows it. Repeating
+        # this toast on every attempt just reads as a glitch.
+        if not request["attempts"]:
+            # MSG: Message shown when download actually starts (after waiting in queue)
+            self._events.emit("notification", _("Downloading video: %s") % displayed_title)
 
         cmd = build_ytdl_download_command(
             video_url,
@@ -236,62 +352,30 @@ class DownloadManager:
         )
         logging.debug("yt-dlp command: " + " ".join(cmd))
 
-        # Use Popen to capture output in real-time
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,  # Line buffered
-            universal_newlines=True,
-        )
-
-        output_buffer = []
-
-        # Regex to parse progress from yt-dlp stdout
-        # Example: [download]   0.0% of    4.62MiB at  396.66KiB/s ETA 00:12
-        progress_regex = re.compile(
-            r"\[download\]\s+(\d+\.?\d*)%\s+of\s+.*?\s+at\s+([^\s]+)\s+ETA\s+([^\s]+)"
-        )
-        video_id = get_youtube_id_from_url(video_url)
-
-        while True:
-            line = process.stdout.readline()
-            if not line and process.poll() is not None:
-                break
-            if line:
-                output_buffer.append(line)
-                match = progress_regex.search(line)
-                if match and self.active_download:
-                    percent = float(match.group(1))
-                    speed = match.group(2)
-                    eta = match.group(3)
-
-                    self.active_download["progress"] = percent
-                    self.active_download["status"] = "downloading"
-                    self.active_download["speed"] = speed
-                    self.active_download["eta"] = eta
-                # Log only non-progress lines to avoid spamming logs, or log everything at debug
-                # logging.debug(line.strip())
-
-        rc = process.poll()
-        output = "".join(output_buffer)
+        try:
+            rc, output = self._run_ytdl(cmd)
+        except Exception as e:
+            # Deliberately broad: whatever goes wrong spawning or reading yt-dlp, the request
+            # has to reach the retry and error card below rather than vanish out of the worker.
+            logging.error(f"yt-dlp invocation failed for {video_url}: {e}")
+            rc, output = 1, f"{type(e).__name__}: {e}"
 
         if rc != 0:
-            # Logic removed: We no longer retry synchronously as it blocks the queue.
-            # Failed downloads are now failed fast and logged.
+            logging.error(f"yt-dlp stderr: {output}")
+            if self._requeue(request):
+                return rc
 
             # MSG: Message shown after the download process is completed but the song is not found
             self._events.emit(
                 "notification", _("Error downloading song: ") + displayed_title, "danger"
             )
-            logging.error(f"yt-dlp stderr: {output}")
             self.download_errors.append(
                 {
                     "id": str(uuid.uuid4()),
                     "title": displayed_title,
                     "url": video_url,
                     "user": user,
+                    "enqueue": enqueue,
                     "error": output or "Unknown error",
                 }
             )
@@ -311,6 +395,7 @@ class DownloadManager:
 
             # After download, find the file path by ID
             song_path = None
+            video_id = get_youtube_id_from_url(video_url)
             if video_id:
                 logging.debug(f"Searching for downloaded file by ID: {video_id}")
                 song_path = self._song_manager.songs.find_by_id(self._download_path, video_id)

--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -213,3 +213,12 @@ def delete_download_error(error_id):
     if k.download_manager.remove_error(error_id):
         return json.dumps({"success": True})
     return json.dumps({"success": False, "error": "Error not found"}), 404
+
+
+@queue_bp.route("/queue/downloads/errors/<error_id>/retry", methods=["POST"])
+def retry_download_error(error_id):
+    """Re-queue a failed download."""
+    k = get_karaoke_instance()
+    if k.download_manager.retry_error(error_id):
+        return json.dumps({"success": True})
+    return json.dumps({"success": False, "error": "Error not found"}), 404

--- a/pikaraoke/templates/queue.html
+++ b/pikaraoke/templates/queue.html
@@ -191,6 +191,7 @@
               var progressClass = "is-info";
               if (d.status === 'complete') progressClass = "is-success";
               if (d.status === 'error') progressClass = "is-danger";
+              var attempt = d.attempts > 0 ? ` (${d.attempts + 1}/${status.max_attempts})` : '';
 
               html += `
                   <div class="box mb-4 has-background-dark">
@@ -199,7 +200,7 @@
                       <progress class="progress ${progressClass}" value="${d.progress}" max="100" style="background-color: #dbdbdb;">${d.progress}%</progress>
                       <div class="level is-mobile is-size-7 mt-1">
                           <div class="level-left">
-                              <span class="level-item text-muted"><b>Status:</b>&nbsp;${d.status}</span>
+                              <span class="level-item text-muted"><b>Status:</b>&nbsp;${d.status}${attempt}</span>
                           </div>
                           <div class="level-right">
                               <span class="level-item"><b>Speed:</b>&nbsp;${d.speed}&nbsp;&nbsp;&nbsp;<b>ETA:</b>&nbsp;${d.eta}</span>
@@ -212,10 +213,14 @@
           if (status.pending && status.pending.length > 0) {
               html += `<div class="content"><h5 class="title is-6 mb-2">{{ _('Pending downloads') | forceescape }}</h5>`;
               status.pending.forEach(function(d) {
+                  // A re-queued download has to be distinguishable from a fresh one
+                  var tag = d.attempts > 0
+                      ? `<span class="tag is-info is-light is-rounded ml-auto">{{ _('Retrying') | forceescape }}&nbsp;${d.attempts + 1}/${status.max_attempts}</span>`
+                      : `<span class="tag is-light is-rounded ml-auto">{{ _('Queued') | forceescape }}</span>`;
                   html += `
                       <div class="box mb-2 p-3 has-background-dark is-flex is-align-items-center">
                           <span class="has-text-grey">${d.display_title || d.video_url}</span>
-                          <span class="tag is-light is-rounded ml-auto">{{ _('Queued') | forceescape }}</span>
+                          ${tag}
                       </div>
                   `;
               });
@@ -233,6 +238,7 @@
                               <p class="help is-danger mb-0 is-truncated" title="${d.error}">${d.error}</p>
                           </div>
                           <span class="tag is-danger is-light is-rounded ml-2">{{ _('Failed') | forceescape }}</span>
+                          <button class="button is-small is-info is-light ml-2" onclick="retryDownloadError('${d.id}')">{{ _('Retry') | forceescape }}</button>
                           <button class="delete ml-2" onclick="dismissDownloadError('${d.id}')" title="{{ _('Dismiss') | forceescape }}"></button>
                       </div>
                   `;
@@ -254,6 +260,13 @@
           if (shouldPoll && $('#downloads-section').length > 0) {
               window.downloadPollTimer = setTimeout(window.queuePage_getDownloads, 500);
           }
+      });
+  };
+
+  window.retryDownloadError = function(errorId) {
+      $.post('{{ url_for("queue.retry_download_error", error_id="ERROR_ID") }}'.replace("ERROR_ID", errorId), function() {
+          // Polling is stopped while only errors are on screen, so restart it here
+          window.queuePage_getDownloads();
       });
   };
 

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -4,9 +4,33 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pikaraoke.lib.download_manager import DownloadManager
+from pikaraoke.lib.download_manager import MAX_DOWNLOAD_ATTEMPTS, DownloadManager
 from pikaraoke.lib.events import EventSystem
 from pikaraoke.lib.preference_manager import PreferenceManager
+
+
+def make_request(
+    url: str = "https://youtube.com/watch?v=dQw4w9WgXcQ",
+    enqueue: bool = False,
+    user: str = "User",
+    title: str = "Title",
+) -> dict:
+    """Build a download request in the shape queue_download produces."""
+    return {
+        "video_url": url,
+        "enqueue": enqueue,
+        "user": user,
+        "title": title,
+        "display_title": title or url,
+        "attempts": 0,
+    }
+
+
+@pytest.fixture(autouse=True)
+def no_reprioritize():
+    """Keep psutil away from whatever pid a mocked Popen invents."""
+    with patch("pikaraoke.lib.download_manager._use_spare_capacity"):
+        yield
 
 
 @pytest.fixture
@@ -170,9 +194,7 @@ class TestDownloadManagerExecuteDownload:
         # Mock find_by_id to return a path
         song_manager.songs.find_by_id.return_value = "/songs/Artist - Song---dQw4w9WgXcQ.mp4"
 
-        rc = download_manager._execute_download(
-            "https://youtube.com/watch?v=dQw4w9WgXcQ", False, "User", "Title"
-        )
+        rc = download_manager._execute_download(make_request())
 
         assert rc == 0
         song_manager.songs.find_by_id.assert_called_once_with("/songs", "dQw4w9WgXcQ")
@@ -206,43 +228,11 @@ class TestDownloadManagerExecuteDownload:
         song_manager.songs.find_by_id.return_value = "/songs/Song---dQw4w9WgXcQ.mp4"
         song_manager.songs.add_if_valid.return_value = True
 
-        download_manager._execute_download(
-            "https://youtube.com/watch?v=dQw4w9WgXcQ", True, "TestUser", "Title"
-        )
+        download_manager._execute_download(make_request(enqueue=True, user="TestUser"))
 
         queue_manager.enqueue.assert_called_once_with(
             "/songs/Song---dQw4w9WgXcQ.mp4", "TestUser", log_action=False
         )
-
-    @patch("flask_babel._", side_effect=lambda x: x)
-    @patch("subprocess.run")
-    @patch("subprocess.Popen")
-    @patch("pikaraoke.lib.youtube_dl.build_ytdl_download_command")
-    def test_execute_download_failure(
-        self, mock_build_cmd, mock_popen, mock_run, mock_gettext, download_manager, events
-    ):
-        """Test download failure is handled without retry."""
-        notifications = []
-        events.on("notification", lambda msg, cat="info": notifications.append((msg, cat)))
-
-        mock_build_cmd.return_value = ["yt-dlp", "url"]
-
-        # First call (Popen) fails
-        mock_process = MagicMock()
-        mock_process.stdout.readline.return_value = ""
-        mock_process.poll.return_value = 1
-        mock_popen.return_value = mock_process
-
-        rc = download_manager._execute_download("url", False, "User", "Title")
-
-        assert rc == 1
-        # Should have "Error downloading" message with danger category
-        assert any("Error downloading" in msg and cat == "danger" for msg, cat in notifications)
-
-        # Should populate download_errors
-        assert len(download_manager.download_errors) == 1
-        assert download_manager.download_errors[0]["title"] == "Title"
-        assert "error" in download_manager.download_errors[0]
 
     @patch("flask_babel._", side_effect=lambda x: x)
     @patch("subprocess.Popen")
@@ -265,10 +255,170 @@ class TestDownloadManagerExecuteDownload:
         # Mock find_by_id to return None (file not found)
         song_manager.songs.find_by_id.return_value = None
 
-        download_manager._execute_download("https://youtube.com/watch?v=abc", True, "User", "Title")
+        download_manager._execute_download(
+            make_request(url="https://youtube.com/watch?v=abc", enqueue=True)
+        )
 
         # Should log error about queueing
         assert any("Error queueing" in msg and cat == "danger" for msg, cat in notifications)
+
+
+class TestDownloadManagerRetry:
+    """Tests for re-queueing failed downloads instead of failing them outright."""
+
+    @staticmethod
+    def _failing_popen(mock_popen):
+        process = MagicMock()
+        process.stdout.readline.return_value = ""
+        process.poll.return_value = 1
+        mock_popen.return_value = process
+        return process
+
+    @staticmethod
+    def _drain(manager) -> int:
+        """Run the queue to exhaustion the way the worker greenlet does."""
+        runs = 0
+        while not manager.download_queue.empty():
+            request = manager.download_queue.get()
+            manager.pending_downloads.pop(0)
+            manager._execute_download(request)
+            runs += 1
+        return runs
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen")
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_requeues_on_failure(self, mock_build_cmd, mock_popen, mock_gettext, download_manager):
+        """A first failure goes back on the queue rather than to an error card."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+        self._failing_popen(mock_popen)
+
+        rc = download_manager._execute_download(make_request())
+
+        assert rc == 1
+        assert download_manager.download_errors == []
+        assert download_manager.download_queue.get_nowait()["attempts"] == 1
+        assert len(download_manager.pending_downloads) == 1
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen")
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_stops_at_attempt_cap(self, mock_build_cmd, mock_popen, mock_gettext, download_manager):
+        """A download that never succeeds is bounded, and its error keeps enqueue."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+        self._failing_popen(mock_popen)
+
+        download_manager.queue_download(
+            "https://youtube.com/watch?v=dQw4w9WgXcQ", enqueue=True, title="Broken"
+        )
+
+        assert self._drain(download_manager) == MAX_DOWNLOAD_ATTEMPTS
+        assert mock_popen.call_count == MAX_DOWNLOAD_ATTEMPTS
+        assert download_manager.pending_downloads == []
+        assert len(download_manager.download_errors) == 1
+        # Without this the Retry button silently drops "add to the playback queue"
+        assert download_manager.download_errors[0]["enqueue"] is True
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen", side_effect=OSError("cannot spawn"))
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_invocation_crash_becomes_a_visible_failure(
+        self, mock_build_cmd, mock_popen, mock_gettext, download_manager
+    ):
+        """A crash launching yt-dlp must retry and surface, not vanish out of the worker."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+
+        download_manager.queue_download("https://youtube.com/watch?v=dQw4w9WgXcQ", title="Broken")
+
+        assert self._drain(download_manager) == MAX_DOWNLOAD_ATTEMPTS
+        assert len(download_manager.download_errors) == 1
+        assert "OSError" in download_manager.download_errors[0]["error"]
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen")
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_retry_is_silent(
+        self, mock_build_cmd, mock_popen, mock_gettext, download_manager, events
+    ):
+        """A retried attempt must not repeat the 'Downloading video' toast."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+        self._failing_popen(mock_popen)
+
+        notifications = []
+        events.on("notification", lambda msg, *args: notifications.append(msg))
+
+        download_manager.queue_download("https://youtube.com/watch?v=dQw4w9WgXcQ", title="Broken")
+        self._drain(download_manager)
+
+        assert sum("Downloading video" in n for n in notifications) == 1
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen")
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_no_retry_on_success(
+        self, mock_build_cmd, mock_popen, mock_gettext, download_manager, song_manager
+    ):
+        """Guards against doubling every download."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+        process = MagicMock()
+        process.stdout.readline.side_effect = ["Done", ""]
+        process.poll.return_value = 0
+        mock_popen.return_value = process
+        song_manager.songs.find_by_id.return_value = "/songs/Song---dQw4w9WgXcQ.mp4"
+
+        download_manager.queue_download("https://youtube.com/watch?v=dQw4w9WgXcQ", title="Fine")
+
+        assert self._drain(download_manager) == 1
+        assert mock_popen.call_count == 1
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen")
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_retry_goes_to_the_back_of_the_queue(
+        self, mock_build_cmd, mock_popen, mock_gettext, download_manager
+    ):
+        """Back-of-queue placement is the backoff: waiting downloads overtake the failure."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+        self._failing_popen(mock_popen)
+
+        download_manager.queue_download("https://youtube.com/watch?v=aaaaaaaaaaa", title="Broken")
+        download_manager.queue_download("https://youtube.com/watch?v=bbbbbbbbbbb", title="Waiting")
+
+        request = download_manager.download_queue.get()
+        download_manager.pending_downloads.pop(0)
+        download_manager._execute_download(request)
+
+        assert [r["title"] for r in download_manager.pending_downloads] == ["Waiting", "Broken"]
+        assert download_manager.download_queue.get_nowait()["title"] == "Waiting"
+        assert download_manager.download_queue.get_nowait()["title"] == "Broken"
+
+    @patch("flask_babel._", side_effect=lambda x: x)
+    def test_retry_error_requeues_and_clears(self, mock_gettext, download_manager):
+        """The Retry button restores the request, enqueue flag included."""
+        download_manager.download_errors = [
+            {
+                "id": "err-1",
+                "title": "Failed Song",
+                "url": "https://youtube.com/watch?v=dQw4w9WgXcQ",
+                "user": "TestUser",
+                "enqueue": True,
+                "error": "HTTP Error 403: Forbidden",
+            }
+        ]
+
+        assert download_manager.retry_error("err-1") is True
+        assert download_manager.download_errors == []
+
+        request = download_manager.download_queue.get_nowait()
+        assert request["video_url"] == "https://youtube.com/watch?v=dQw4w9WgXcQ"
+        assert request["enqueue"] is True
+        assert request["user"] == "TestUser"
+        assert request["attempts"] == 0
+
+    def test_retry_error_unknown_id(self, download_manager):
+        """An already-dismissed error cannot be retried."""
+        assert download_manager.retry_error("nope") is False
+        assert download_manager.download_queue.empty()
 
 
 class TestDownloadManagerStatus:
@@ -383,10 +533,12 @@ class TestDownloadManagerSpecialCharacters:
         song_manager.songs.add_if_valid.return_value = True
 
         download_manager._execute_download(
-            f"https://youtube.com/watch?v={video_id}",
-            enqueue=True,
-            user="TestUser",
-            title="Test",
+            make_request(
+                url=f"https://youtube.com/watch?v={video_id}",
+                enqueue=True,
+                user="TestUser",
+                title="Test",
+            )
         )
 
         queue_manager.enqueue.assert_called_once_with(file_path, "TestUser", log_action=False)


### PR DESCRIPTION
## What

Failed downloads are re-queued and retried instead of failing immediately.

## Why

YouTube answers `HTTP Error 403: Forbidden` to a freshly resolved video URL on a large fraction of downloads — 2 of 4 full downloads of one video in testing, consistent with reports of "about half the time". It is not tied to the format selected: the refusal hits DASH pairs and pre-merged streams alike, and arrives on the first data request after format selection has already succeeded.

Re-extracting from scratch is the only remedy that works, and it works reliably — every observed failure cleared on the following attempt, within about four seconds. Since yt-dlp does not retry a 403 itself (it re-raises anything below 500), the retry has to happen here.

## Design: re-queue rather than retry in place

A synchronous retry was removed from this file previously because it blocked the serialized download worker, and that concern still rules out a sleep-and-retry loop.

So a failed download goes back on the queue rather than looping in place. `_requeue` puts the request at the **back**, meaning anything already waiting overtakes it, and the worker returns to `queue.get()` immediately with no sleep anywhere in the path. A new download waits at most one attempt, never a full retry sequence, and a genuinely dead link can never hold the queue.

Back-of-queue placement is also the backoff — no timestamps, no rotation, no scheduling.

`MAX_DOWNLOAD_ATTEMPTS` is 5. At the observed refusal rate three attempts would still leave roughly one download in eight showing an error card; five brings that to about 3%. Failing attempts cost ~3s each and only on the failing path.

Every failure is retried rather than matching on error strings, which would encode yt-dlp's current wording and regress silently as it drifts.

## Also in this change

- **`enqueue` is recorded on error entries.** Without it, retrying a song that was added with "add to queue" silently dropped it from the playback queue — the way most downloads are requested.
- **Retry button on the error card**, beside the existing dismiss, plus a `retrying` status and attempt counts on the active and pending rows. Retries are otherwise silent, so the queue page is where they become visible.
- **yt-dlp runs at background CPU and I/O priority** (`BELOW_NORMAL`/`IOPRIO_VERYLOW` on Windows, `nice(10)` plus idle `ionice` elsewhere), so a download uses only spare capacity while a song plays. Priority is inherited, so any ffmpeg it spawns is covered.
- **A crash launching yt-dlp becomes an ordinary failure** instead of escaping the worker, where it previously vanished with no retry and no error card.
- **yt-dlp output is logged on success too**, so a retry that succeeds can be compared against the attempt that failed.