### PR TITLE
refactor: give YouTube search results a dataclass

### DIFF
--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -37,11 +37,7 @@ from pikaraoke.lib.queue_manager import QueueManager
 from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.lib.sound_manager import SoundManager
 from pikaraoke.lib.url_prefix import append_base_path_to_url
-from pikaraoke.lib.youtube_dl import (
-    get_search_results,
-    get_youtubedl_version,
-    upgrade_youtubedl,
-)
+from pikaraoke.lib.youtube_dl import get_youtubedl_version, upgrade_youtubedl
 from pikaraoke.version import __version__ as VERSION
 
 

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import subprocess
 import sys
+from dataclasses import dataclass
 from urllib.parse import parse_qs, urlparse
 
 from pikaraoke.lib.get_platform import get_installed_js_runtime
@@ -15,6 +16,17 @@ yt_dlp_cmd = [sys.executable, "-m", "yt_dlp"]
 
 # YouTube video IDs are always exactly 11 characters
 YOUTUBE_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{11}")
+
+
+@dataclass
+class SearchResult:
+    """One YouTube search hit. Channel and duration may be empty."""
+
+    title: str
+    url: str
+    video_id: str
+    channel: str
+    duration: str  # formatted M:SS, not seconds
 
 
 def _js_runtime_args() -> list[str]:
@@ -165,15 +177,14 @@ def build_ytdl_download_command(
     return cmd
 
 
-def get_search_results(query: str) -> list[list[str]]:
+def get_search_results(query: str) -> list[SearchResult]:
     """Search YouTube for videos matching the query.
 
     Args:
         query: Search query string.
 
     Returns:
-        List of [title, url, video_id, channel, duration] for each result.
-        Duration is formatted as M:SS; channel and duration may be empty strings.
+        One SearchResult per hit, in the order yt-dlp reported them.
     """
     logging.info(f"Searching YouTube for: {query}")
     num_results = 10
@@ -196,7 +207,7 @@ def get_search_results(query: str) -> list[list[str]]:
             if isinstance(duration_raw, (int, float)):
                 seconds = int(duration_raw)
                 duration_str = f"{seconds // 60}:{seconds % 60:02d}"
-            results.append([j["title"], j["url"], j["id"], channel, duration_str])
+            results.append(SearchResult(j["title"], j["url"], j["id"], channel, duration_str))
         return results
     except subprocess.CalledProcessError as e:
         logging.debug(f"Error while executing search: {e}")

--- a/pikaraoke/routes/search.py
+++ b/pikaraoke/routes/search.py
@@ -50,7 +50,9 @@ def search():
     # A result already on this machine gets a queue action instead of a pointless
     # second download. One indexed query for the page, not one per result.
     library_matches = (
-        k.db.get_paths_by_youtube_ids([r[2] for r in search_results]) if search_results else {}
+        k.db.get_paths_by_youtube_ids([r.video_id for r in search_results])
+        if search_results
+        else {}
     )
     return render_template(
         "search.html",

--- a/pikaraoke/templates/search.html
+++ b/pikaraoke/templates/search.html
@@ -611,26 +611,26 @@
 			{%- endtrans %}
 		</label>
 		<ul id="search-results" class="search_result_items">
-			{% for title,url,id,channel,duration in search_results %}
-			{% set local_path = library_matches.get(id) %}
-			<li data-ytID="{{id}}" data-ytTitle="{{title}}" value="{{url}}" data-index="{{loop.index0}}">
-				<div class="img-wrapper" data-url="{{url}}">
+			{% for result in search_results %}
+			{% set local_path = library_matches.get(result.video_id) %}
+			<li data-ytID="{{result.video_id}}" data-ytTitle="{{result.title}}" value="{{result.url}}" data-index="{{loop.index0}}">
+				<div class="img-wrapper" data-url="{{result.url}}">
 					<div class="img-frame">
-						<img src="https://img.youtube.com/vi/{{id}}/mqdefault.jpg" />
+						<img src="https://img.youtube.com/vi/{{result.video_id}}/mqdefault.jpg" />
 						{# On the thumbnail rather than after the title: titles wrap, so a tag
 						   trailing the text lands wherever the last line happens to end. #}
 						{% if local_path %}
 						{# MSG: Badge on a YouTube search result marking a song that is already downloaded. #}
 						<span class="library-badge">{% trans %}In library{% endtrans %}</span>
 						{% endif %}
-						{% if duration %}<span class="duration-badge">{{ duration }}</span>{% endif %}
+						{% if result.duration %}<span class="duration-badge">{{ result.duration }}</span>{% endif %}
 					</div>
 				</div>
 				<div class="search_result_items_meta">
 					<div>
-						{{title}}
-						{% if channel %}<div class="is-size-7 has-text-grey">{{ channel }}</div>{% endif %}
-						<a href="{{url}}" target="_blank" rel="noopener noreferrer" class="is-size-7 has-text-info">YouTube ↗</a>
+						{{result.title}}
+						{% if result.channel %}<div class="is-size-7 has-text-grey">{{ result.channel }}</div>{% endif %}
+						<a href="{{result.url}}" target="_blank" rel="noopener noreferrer" class="is-size-7 has-text-info">YouTube ↗</a>
 					</div>
 					<div class="search_result_items_actions">
 						{% if local_path %}

--- a/tests/unit/test_search_routes.py
+++ b/tests/unit/test_search_routes.py
@@ -8,12 +8,14 @@ import werkzeug
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "3.0.0"
 
+from pikaraoke.lib.youtube_dl import SearchResult
 from pikaraoke.routes.search import search_bp
 from tests.conftest import make_route_app
 
-# (title, url, id, channel, duration) -- the shape get_search_results returns
-HELD = ("Held Song", "https://youtu.be/aaaaaaaaaaa", "aaaaaaaaaaa", "Chan", "3:21")
-MISSING = ("Missing Song", "https://youtu.be/zzzzzzzzzzz", "zzzzzzzzzzz", "Chan", "4:05")
+HELD = SearchResult("Held Song", "https://youtu.be/aaaaaaaaaaa", "aaaaaaaaaaa", "Chan", "3:21")
+MISSING = SearchResult(
+    "Missing Song", "https://youtu.be/zzzzzzzzzzz", "zzzzzzzzzzz", "Chan", "4:05"
+)
 
 # The rendered elements, not the bare class name -- that also appears in the page's CSS.
 # The row carries the queue-or-not intent, so there is no global toggle to read.
@@ -112,3 +114,14 @@ class TestLibraryMatches:
         assert "add-song-link" in rows
         assert QUEUE_BUTTON in rows
         assert SAVE_BUTTON in rows
+
+    def test_every_result_field_reaches_the_row(self, client):
+        """The download script reads value= and data-ytTitle, so a dropped field
+        breaks downloading at click time on a page that still looks correct."""
+        response, _ = _search(client, [MISSING], {})
+        rows = _rows(response)
+        assert 'data-ytTitle="Missing Song"' in rows
+        assert 'value="https://youtu.be/zzzzzzzzzzz"' in rows
+        assert "vi/zzzzzzzzzzz/mqdefault.jpg" in rows
+        assert "4:05" in rows
+        assert "Chan" in rows


### PR DESCRIPTION
## What

YouTube search results were passed around as a plain 5-item list — title, url, id, channel, duration — in that order and nothing more. Every place that used them had to know the order by heart. The search page pulled the video id out with `r[2]`, and the only written note of what the five items were was a comment sitting in a test file.

They're now a small `SearchResult` object with named fields, so `r[2]` becomes `r.video_id` and the template reads `result.title` instead of `title`.

Nothing changes on screen. Same data, better labelled.

## Files

- `youtube_dl.py` — defines `SearchResult` and returns them
- `routes/search.py` — one line
- `search.html` — the results loop uses field names
- `karaoke.py` — removes an unused import that expected the old format
- `test_search_routes.py` — test data updated, plus one new test

## Why the new test

If the template asks for a field that doesn't exist, the page doesn't error — it just renders nothing and carries on looking fine. The download buttons read the title and url straight off each row, so a mistake here would break downloading while the page still looked perfect and the tests still passed.

The old tests checked which buttons appeared on a row, but never that the title, url, thumbnail, channel and duration actually made it onto the page. The new test does, and I confirmed it fails when a field is missing.
