### PR TITLE
feat: make iTunes scores out of 100

### DIFF
--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -238,6 +238,7 @@ TRAILING_NOISE_PATTERNS = [
 DISCARDABLE_QUALIFIER_WORDS = [
     r"official\s+(?:music\s+)?video",
     r"no\s+lead\s+vocals?",
+    r"original\s+key",
     r"with\s+lyrics?",
     r"sing[\s-]*along",
     r"backing\s+track",
@@ -246,6 +247,7 @@ DISCARDABLE_QUALIFIER_WORDS = [
     r"version",
     r"official",
     r"music",
+    r"songs?",
     r"video",
     r"audio",
     r"lyrics?",

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -71,8 +71,14 @@ NOISE_WORDS = [
 ]
 NOISE_PATTERN = re.compile("|".join(NOISE_WORDS), flags=re.IGNORECASE)
 
+# A featuring credit is part of the track's name, not a qualifier over it. Only
+# the unambiguous words: "with" opens credits ("with Kiki Dee") and qualifiers
+# ("with Live Band") alike, and a qualifier admitted here is one renamed away.
+_FEAT_CREDIT_ALT = r"feat(?:uring)?|ft"
+_FEAT_CREDIT_RE = re.compile(rf"^\s*(?:{_FEAT_CREDIT_ALT})\.?\s", re.IGNORECASE)
+
 # Matches parenthesised content EXCEPT featuring credits like "(feat. X)" / "(ft. X)"
-_FEAT_LOOKAHEAD = r"(?!\s*(?:feat(?:uring)?|ft)\.?\s)"
+_FEAT_LOOKAHEAD = rf"(?!\s*(?:{_FEAT_CREDIT_ALT})\.?\s)"
 _PAREN_NOT_FEAT = re.compile(rf"\s*\({_FEAT_LOOKAHEAD}[^)]*\)", flags=re.IGNORECASE)
 _PAREN_NOT_FEAT_TRAILING = re.compile(rf"\s*\({_FEAT_LOOKAHEAD}[^)]*\)\s*$", flags=re.IGNORECASE)
 
@@ -98,20 +104,6 @@ SPECIAL_VERSION_KEYWORDS = [
 ]
 _SPECIAL_VERSION_RE = re.compile(
     r"\b(?:" + "|".join(re.escape(kw) for kw in SPECIAL_VERSION_KEYWORDS if kw != " - ") + r")\b",
-    re.IGNORECASE,
-)
-
-# Qualifiers marking a different recording of the same song, as opposed to noise
-# a rename may safely discard. Derived from SPECIAL_VERSION_KEYWORDS minus
-# "version" and "karaoke", which in a karaoke library are the two most common
-# noise tokens there are -- keeping them would push most of a library out of
-# reach of any suggestion that strips them.
-_RECORDING_VARIANT_RE = re.compile(
-    r"\b(?:"
-    + "|".join(
-        re.escape(kw) for kw in SPECIAL_VERSION_KEYWORDS if kw not in (" - ", "version", "karaoke")
-    )
-    + r")\b",
     re.IGNORECASE,
 )
 
@@ -209,6 +201,9 @@ ATTRIBUTION_PATTERNS = [
         re.IGNORECASE,
     ),
 ]
+# An attribution phrase and everything after it, for reading bracketed text that
+# has already been separated from its title.
+_QUALIFIER_ATTRIBUTION_RE = re.compile(rf"\b(?:{_ATTRIBUTION_ALT})\b.*$", re.IGNORECASE)
 
 TRAILING_NOISE_PATTERNS = [
     # Any karaoke keyword = nuke everything from that word to end of string.
@@ -227,6 +222,53 @@ TRAILING_NOISE_PATTERNS = [
         re.IGNORECASE,
     ),
 ]
+
+# Everything a bracketed qualifier may be made of and still be safe to drop.
+# A whitelist, not a blacklist: the qualifiers that must survive a rename --
+# "(2011 Remaster)", "(Unplugged)", "(Single Edit)", "(BBC Session)" -- are an
+# open set, so listing them would always be one release form behind. "karaoke"
+# and "version" belong here despite naming a variant elsewhere: in this library
+# they are the two commonest noise tokens there are.
+DISCARDABLE_QUALIFIER_WORDS = [
+    r"official\s+(?:music\s+)?video",
+    r"no\s+lead\s+vocals?",
+    r"with\s+lyrics?",
+    r"sing[\s-]*along",
+    r"backing\s+track",
+    r"minus\s+one",
+    rf"(?:{_KARAOKE_KEYWORDS_ALT})",
+    r"version",
+    r"official",
+    r"music",
+    r"video",
+    r"audio",
+    r"lyrics?",
+    r"karafun",
+    r"coversph",
+    r"singkaraoke",
+    r"complete|completo",
+    r"full",
+    r"hd|hq|4k|mv|cc",
+]
+_DISCARDABLE_QUALIFIER_RE = re.compile(
+    r"\b(?:" + "|".join(DISCARDABLE_QUALIFIER_WORDS) + r")\b", re.IGNORECASE
+)
+# Digits, punctuation and separators carry no version meaning on their own, so a
+# qualifier of "(2011)" or "(HD)" is spent once its words are accounted for.
+_QUALIFIER_FILLER_RE = re.compile(r"[\W\d_]+")
+
+
+def is_discardable_qualifier(text: str) -> bool:
+    """Whether bracketed text is noise a rename may drop rather than a recording variant.
+
+    Dropping "(Karaoke Version)" tidies a filename; dropping "(Live)" renames one
+    recording into another, which can collide with the studio cut already filed
+    beside it. Anything this cannot account for is treated as the latter.
+    """
+    remainder = _QUALIFIER_ATTRIBUTION_RE.sub("", text)
+    remainder = _DISCARDABLE_QUALIFIER_RE.sub(" ", remainder)
+    return not _QUALIFIER_FILLER_RE.sub("", remainder)
+
 
 # A dash adjacent to a CJK/Kana/Hangul character is always a separator (never a hyphen
 # within a word). Uses lookaround so the replacement is just the dash, not surrounding chars.

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -12,8 +12,11 @@ import unicodedata
 
 from pikaraoke.lib.get_platform import is_windows
 
-# Characters illegal in Windows filenames
+# Characters illegal in Windows filenames, and what to write in their place.
+# A quote has a readable stand-in; the rest have none, so they collapse to a
+# dash. Without this, Bobby "Boris" Pickett is filed as Bobby -Boris- Pickett.
 _WINDOWS_ILLEGAL_CHARS = re.compile(r'[<>:"/\\|?*]')
+_ILLEGAL_CHAR_SUBSTITUTES = {'"': "'"}
 _PATH_SEPARATORS = re.compile(r"[/\\]")
 
 EMOJI_PATTERN = re.compile(
@@ -821,7 +824,9 @@ def sanitize_filename(name: str) -> str:
     separator can only be an attempt to write outside the song directory.
     """
     if is_windows():
-        name = _WINDOWS_ILLEGAL_CHARS.sub("-", name)
+        name = _WINDOWS_ILLEGAL_CHARS.sub(
+            lambda m: _ILLEGAL_CHAR_SUBSTITUTES.get(m.group(), "-"), name
+        )
     else:
         name = _PATH_SEPARATORS.sub("-", name)
     return name.strip()

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -823,8 +823,9 @@ def regex_tidy(filename: str) -> str:
 def sanitize_filename(name: str) -> str:
     """Remove characters that are illegal in a filename on the current platform.
 
-    Path separators go on every platform: callers pass a bare filename, so a
-    separator can only be an attempt to write outside the song directory.
+    Path separators go on every platform: the result is a bare filename, so a
+    separator in it is either punctuation the filesystem cannot keep or an
+    attempt to leave the song directory. Both want the same substitution.
     """
     original = name.strip()
     if is_windows():

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -10,6 +10,12 @@ import re
 import time
 import unicodedata
 
+from pikaraoke.lib.get_platform import is_windows
+
+# Characters illegal in Windows filenames
+_WINDOWS_ILLEGAL_CHARS = re.compile(r'[<>:"/\\|?*]')
+_PATH_SEPARATORS = re.compile(r"[/\\]")
+
 EMOJI_PATTERN = re.compile(
     "["
     "\U0001F1E0-\U0001F1FF"
@@ -92,6 +98,20 @@ SPECIAL_VERSION_KEYWORDS = [
 ]
 _SPECIAL_VERSION_RE = re.compile(
     r"\b(?:" + "|".join(re.escape(kw) for kw in SPECIAL_VERSION_KEYWORDS if kw != " - ") + r")\b",
+    re.IGNORECASE,
+)
+
+# Qualifiers marking a different recording of the same song, as opposed to noise
+# a rename may safely discard. Derived from SPECIAL_VERSION_KEYWORDS minus
+# "version" and "karaoke", which in a karaoke library are the two most common
+# noise tokens there are -- keeping them would push most of a library out of
+# reach of any suggestion that strips them.
+_RECORDING_VARIANT_RE = re.compile(
+    r"\b(?:"
+    + "|".join(
+        re.escape(kw) for kw in SPECIAL_VERSION_KEYWORDS if kw not in (" - ", "version", "karaoke")
+    )
+    + r")\b",
     re.IGNORECASE,
 )
 
@@ -719,6 +739,19 @@ def regex_tidy(filename: str) -> str:
     name = _step_normalize_cjk_dashes(name)
     name = _step_extract_attribution_or_strip_noise(name)
     return _step_normalize_separators_and_whitespace(name)
+
+
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are illegal in a filename on the current platform.
+
+    Path separators go on every platform: callers pass a bare filename, so a
+    separator can only be an attempt to write outside the song directory.
+    """
+    if is_windows():
+        name = _WINDOWS_ILLEGAL_CHARS.sub("-", name)
+    else:
+        name = _PATH_SEPARATORS.sub("-", name)
+    return name.strip()
 
 
 def youtube_id_suffix(file_path: str) -> str:

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -13,10 +13,13 @@ import unicodedata
 from pikaraoke.lib.get_platform import is_windows
 
 # Characters illegal in Windows filenames, and what to write in their place.
-# A quote has a readable stand-in; the rest have none, so they collapse to a
-# dash. Without this, Bobby "Boris" Pickett is filed as Bobby -Boris- Pickett.
+# A quote reads as an apostrophe, and a question mark reads as nothing -- a
+# title survives losing its punctuation. The rest stand in for structure a
+# dash keeps: AC/DC is AC-DC, and a censored word is F--k rather than Fk.
 _WINDOWS_ILLEGAL_CHARS = re.compile(r'[<>:"/\\|?*]')
-_ILLEGAL_CHAR_SUBSTITUTES = {'"': "'"}
+_ILLEGAL_CHAR_SUBSTITUTES = {'"': "'", "?": "", "<": "", ">": ""}
+_WHITESPACE_RUN_RE = re.compile(r"\s{2,}")
+_DANGLING_SEPARATOR_RE = re.compile(r"[\s-]+$")
 _PATH_SEPARATORS = re.compile(r"[/\\]")
 
 EMOJI_PATTERN = re.compile(
@@ -823,13 +826,21 @@ def sanitize_filename(name: str) -> str:
     Path separators go on every platform: callers pass a bare filename, so a
     separator can only be an attempt to write outside the song directory.
     """
+    original = name.strip()
     if is_windows():
         name = _WINDOWS_ILLEGAL_CHARS.sub(
             lambda m: _ILLEGAL_CHAR_SUBSTITUTES.get(m.group(), "-"), name
         )
     else:
         name = _PATH_SEPARATORS.sub("-", name)
-    return name.strip()
+    # Dropping a character at the end leaves a dangling separator, which reads
+    # as a truncated name rather than as punctuation the filesystem refused.
+    collapsed = _WHITESPACE_RUN_RE.sub(" ", name).strip()
+    sanitized = _DANGLING_SEPARATOR_RE.sub("", collapsed)
+    # A name of nothing but refused characters would sanitize away to nothing,
+    # and the caller builds a path from this: bare extension is a hidden file,
+    # not a song. Keep whatever survived, or a dash, so the rename stays visible.
+    return sanitized or collapsed or ("-" if original else "")
 
 
 def youtube_id_suffix(file_path: str) -> str:

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -167,17 +167,45 @@ _LEADING_BRACKET_NOISE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Phrases naming the original artist of a karaoke track: "Title (Made Famous by
+# Artist)". Longest first -- the alternation is first-match-wins, so a bare "by"
+# listed ahead of "made famous by" would capture "famous by Artist".
+ATTRIBUTION_CONNECTORS = [
+    "originally performed by",
+    "as popularized by",
+    "popularized by",
+    "made famous by",
+    "in the style of",
+    "by",
+]
+
+
+def _connector_alternation(connectors: list[str]) -> str:
+    return "|".join(c.replace(" ", r"\s+") for c in connectors)
+
+
+_ATTRIBUTION_ALT = _connector_alternation(ATTRIBUTION_CONNECTORS)
+# Bare "by" only where brackets mark it as attribution. Inline it is unreadable:
+# "Stand by Me" and "Blinded by the Light" are titles, not attributions.
+_ATTRIBUTION_ALT_INLINE = _connector_alternation([c for c in ATTRIBUTION_CONNECTORS if c != "by"])
+
 ATTRIBUTION_PATTERNS = [
-    # Parenthetical: "(Made Famous by Artist)", "(In the Style of Artist)", etc.
-    re.compile(
-        r"\((?:as\s+)?(?:made\s+famous\s+by|in\s+the\s+style\s+of"
-        r"|originally\s+performed\s+by|as\s+popularized\s+by)[:\s]+([^)]+)\)",
-        re.IGNORECASE,
-    ),
+    # Parenthetical: "(Made Famous by Artist)", "(In the Style of Artist)", "(by Artist)"
+    re.compile(rf"\((?:as\s+)?(?:{_ATTRIBUTION_ALT})[:\s]+([^)]+)\)", re.IGNORECASE),
+    # The same in square brackets, the form most karaoke vendors ship
+    re.compile(rf"\[(?:as\s+)?(?:{_ATTRIBUTION_ALT})[:\s]+([^\]]+)\]", re.IGNORECASE),
     # Trailing inline: "Title made famous by Artist [noise]"
     re.compile(
-        r"\b(?:made\s+famous\s+by|in\s+the\s+style\s+of"
-        r"|originally\s+performed\s+by|as\s+popularized\s+by)[:\s]+(.+?)(?:\s*[\(\[]|$)",
+        rf"\b(?:{_ATTRIBUTION_ALT_INLINE})[:\s]+(.+?)(?:\s*[\(\[]|$)",
+        re.IGNORECASE,
+    ),
+    # Bare "by" after a *closed* karaoke bracket: "Song [Karaoke Version] by
+    # Artist". The bracket is what distinguishes it from "Karaoke by Stingray",
+    # where the same word names the vendor who cut the track, not the artist.
+    # Unbracketed and unmarked, a bare "by" is unreadable -- hence neither the
+    # pattern above nor this one will touch "Stand by Me".
+    re.compile(
+        rf"[\(\[][^)\]]*?(?:{_KARAOKE_KEYWORDS_ALT})[^)\]]*[\)\]]\s*by[:\s]+(.+?)(?:\s*[\(\[]|$)",
         re.IGNORECASE,
     ),
 ]
@@ -708,7 +736,10 @@ def _step_extract_attribution_or_strip_noise(name: str) -> str:
     artist = _extract_attribution_artist(name)
     if artist:
         title = _strip_attribution_and_noise(name)
-        return f"{title} - {artist}"
+        # An empty title means the phrase matched across the whole name and what
+        # it called the artist was really the title ("Karaoke - Stand by Me").
+        if title:
+            return f"{title} - {artist}"
     # No attribution — strip trailing parenthesised/bracketed content + noise
     name = _PAREN_NOT_FEAT_TRAILING.sub("", name)
     name = re.sub(r"\s*\[[^\]]*\]\s*$", "", name, flags=re.IGNORECASE)

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -510,78 +510,86 @@ def _proposal(result: dict, artist_first: bool) -> str:
     return sanitize_filename(f"{artist} - {title}" if artist_first else f"{title} - {artist}")
 
 
-def _correction_count(
+def _corrections(
     name: str, proposal: str, query_artist_first: bool, artist_first: bool
-) -> int:
-    """Count the kinds of correction a rename to `proposal` would apply.
+) -> list[str]:
+    """Which kinds of correction a rename to `proposal` would apply.
 
     Three sequential transformations -- order, then noise, then characters --
     each asking "did this step change anything". Sequential rather than parallel
     so that one defect cannot be counted under two kinds.
     """
-    corrections = 0
+    kinds = []
     reordered = name
     if query_artist_first != artist_first:
-        corrections += 1
+        kinds.append("order")
         head, _, tail = name.partition(" - ")
         if tail:
             reordered = f"{tail} - {head}"
     tidied = regex_tidy(reordered)
     if tidied != reordered:
-        corrections += 1
+        kinds.append("noise")
     # Deliberately raw: no case folding, no accent folding. This is what keeps
     # "Beyonce" off 100.
     if tidied != proposal:
-        corrections += 1
-    return corrections
+        kinds.append("characters")
+    return kinds
 
 
 def _anchor_score(
     score: int, result: dict, query_parts_norm: list[tuple[str, str]], name: str, artist_first: bool
-) -> int:
+) -> tuple[int, str]:
     """Pin a confirmed match to its anchor; cap everything else below the band.
 
     `name` is the name the caller asked about, which on the edit page is what
     the box currently holds rather than what is on disk -- 100 answers "would
     saving this change anything", not "is the library tidy".
+
+    Returns the score with the reason for it. A score below the band is only
+    interpretable alongside which of the three ways of missing it applied.
     """
     query_artist_first = _exact_match_artist_first(result, query_parts_norm)
     if query_artist_first is None:
-        return min(score, _UNCONFIRMED_CEILING)
+        # "iTunes offered a variant, not the track" and "the two fields were
+        # never both matched" are the same 94 and want opposite responses.
+        qualified = _has_disqualifying_qualifier(result.get("title", "").lower())
+        return min(score, _UNCONFIRMED_CEILING), (
+            "result qualified" if qualified else "unconfirmed"
+        )
     proposal = _proposal(result, artist_first)
     # regex_tidy strips "(Live)" and "(2011 Remaster)" as readily as it strips
     # "(Official Video)", so a confirmed match can still be the wrong recording.
     if _has_disqualifying_qualifier(name) and not _has_disqualifying_qualifier(proposal):
-        return min(score, _UNCONFIRMED_CEILING)
-    return (_ALREADY_CORRECT, _ONE_CORRECTION, _MANY_CORRECTIONS, _MANY_CORRECTIONS)[
-        _correction_count(name, proposal, query_artist_first, artist_first)
-    ]
+        return min(score, _UNCONFIRMED_CEILING), "variant kept"
+    kinds = _corrections(name, proposal, query_artist_first, artist_first)
+    anchor = (_ALREADY_CORRECT, _ONE_CORRECTION, _MANY_CORRECTIONS, _MANY_CORRECTIONS)[len(kinds)]
+    return anchor, ", ".join(kinds) or "already correct"
 
 
 def _deduplicate_suggestions(
     results: list[dict], query: str, name: str, artist_first: bool, featuring: str = ""
-) -> list[tuple[int, dict]]:
+) -> list[tuple[int, str, dict]]:
     """Keep the highest-scored result per unique (artist, title) pair.
 
     Anchoring happens here rather than at display time: the badge sits beside a
     ranked list, so a demotion applied after the sort could show a 95 above a 98.
 
-    Returns (score, result) tuples sorted by score descending.
+    Returns (score, reason, result) tuples sorted by score descending.
     """
     query_parts_norm = _normalize_query_parts(query)
     featuring_norm = _normalize_for_matching(featuring) if featuring else ""
-    best: dict[tuple[str, str], tuple[int, int, dict]] = {}
+    best: dict[tuple[str, str], tuple[int, int, str, dict]] = {}
     for r in results:
         key = (r.get("artist", "").lower(), r.get("title", "").lower())
         tally = _suggestion_score(r, query_parts_norm, featuring_norm)
-        s = _anchor_score(tally, r, query_parts_norm, name, artist_first)
-        if key not in best or (s, tally) > best[key][:2]:
-            best[key] = (s, tally, r)
+        score, reason = _anchor_score(tally, r, query_parts_norm, name, artist_first)
+        if key not in best or (score, tally) > best[key][:2]:
+            best[key] = (score, tally, reason, r)
     # The raw tally breaks ties: the ceiling flattens every unconfirmed result
     # above it to one value, and without this the best of them would rank by
     # nothing more than the order iTunes happened to return it in.
     ranked = sorted(best.values(), key=lambda x: (x[0], x[1]), reverse=True)
-    return [(score, result) for score, _, result in ranked]
+    return [(score, reason, result) for score, _, reason, result in ranked]
 
 
 # Over-fetch factor to compensate for deduplication
@@ -630,8 +638,8 @@ def suggest_metadata(
     if not truncated:
         return []
 
-    # Build output dicts with display and score fields (don't mutate originals)
+    # Build output dicts with display, score and reason (don't mutate originals)
     return [
-        {**r, "display": _proposal(r, artist_first), "score": max(0, score)}
-        for score, r in truncated
+        {**r, "display": _proposal(r, artist_first), "score": max(0, score), "reason": reason}
+        for score, reason, r in truncated
     ]

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -453,14 +453,15 @@ def _decomposes_into(whole: str, first: str, second: str) -> bool:
     return any(whole == f"{first} {c} {second}" for c in _ATTRIBUTION_CONNECTORS_NORM)
 
 
-def _part_names_field(part_norm: str, field_norm: str) -> bool:
-    """Whether a query part is this field, with or without an opening connector.
+def _part_names_field(part_norm: str, *field_norms: str) -> bool:
+    """Whether a query part is any of these forms of a field.
 
-    Both forms, not just the stripped one: "By the Way - Red Hot Chili Peppers"
-    puts a connector at the front of a real title, and stripping it there would
-    lose the match the separator already made plain.
+    With or without an opening connector: "By the Way - Red Hot Chili Peppers"
+    puts one at the front of a real title, and stripping it there would lose the
+    match the separator already made plain.
     """
-    return field_norm in (part_norm, _LEADING_ATTRIBUTION_RE.sub("", part_norm))
+    forms = (part_norm, _LEADING_ATTRIBUTION_RE.sub("", part_norm))
+    return any(f in forms for f in field_norms if f)
 
 
 def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, str]]) -> bool | None:
@@ -478,23 +479,29 @@ def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, st
     title_norm = _normalize_for_matching(_PAREN_CONTENT_RE.sub("", title_lower).strip())
     if not artist_norm or not title_norm:
         return None
+    # Both forms of the title. A filename already carrying the credit iTunes
+    # writes -- "Everything Has Changed (feat. Ed Sheeran)" -- has to match the
+    # whole title, not only what is left once the brackets come off. Comparing a
+    # bracketed query part against a stripped title is what stopped this feature
+    # recognising the very names it renames songs to.
+    titles = (title_norm, _normalize_for_matching(title_lower))
     if len(query_parts_norm) == 1:
         # A query with no separator confirms both fields only when it is exactly
         # the two of them, nothing left over: "CAKE I Will Survive" and "Cry Me a
         # River by Julie London" qualify, "Cry Me a River, a Julie London song"
         # does not. Whichever arrangement matches is the order it is written in.
         whole = query_parts_norm[0][1]
-        if _decomposes_into(whole, artist_norm, title_norm):
+        if any(_decomposes_into(whole, artist_norm, t) for t in titles):
             return True
-        if _decomposes_into(whole, title_norm, artist_norm):
+        if any(_decomposes_into(whole, t, artist_norm) for t in titles):
             return False
         return None
     # "Cry Me a River - by Julie London": the separator is there, but the artist
     # side still opens with the connector the vendor wrote it with.
     first, second = query_parts_norm[0][1], query_parts_norm[1][1]
-    if _part_names_field(first, artist_norm) and _part_names_field(second, title_norm):
+    if _part_names_field(first, artist_norm) and _part_names_field(second, *titles):
         return True
-    if _part_names_field(first, title_norm) and _part_names_field(second, artist_norm):
+    if _part_names_field(first, *titles) and _part_names_field(second, artist_norm):
         return False
     return None
 

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -14,10 +14,10 @@ import urllib3.connection
 import urllib3.util.ssl_
 
 from pikaraoke.lib.metadata_parser import (
-    _PAREN_NOT_FEAT,
-    _RECORDING_VARIANT_RE,
+    _FEAT_CREDIT_RE,
     _SPECIAL_VERSION_RE,
     ATTRIBUTION_CONNECTORS,
+    is_discardable_qualifier,
     normalize_for_comparison,
     regex_tidy,
     remove_accents,
@@ -422,19 +422,22 @@ def _suggestion_score(
 # candidates against each other no longer apply. 100 is also what the rebased
 # weights produce for a clean confirmed match (38 + 38 + 24), so the assignment
 # agrees with the arithmetic instead of overriding it.
-_ALREADY_CORRECT = 100  # the name on disk is what we would rename it to
+_ALREADY_CORRECT = 100  # the name as submitted is what we would rename it to
 _ONE_CORRECTION = 98  # fields confirmed; one of order / noise / characters is wrong
 _MANY_CORRECTIONS = 95  # fields confirmed; two or three of them are
 _UNCONFIRMED_CEILING = 94  # nothing unconfirmed may enter the confirmed band
 
 
 def _has_disqualifying_qualifier(title: str) -> bool:
-    """Whether the title carries a qualifier other than a featuring credit."""
-    # "(Live)", "(Taylor's Version)", "(Commentary)" -- anything parenthesised that is not a credit
-    if _PAREN_NOT_FEAT.search(title):
-        return True
-    # _PAREN_NOT_FEAT only sees round brackets, so "(feat. X) [Live]" reaches here
-    return bool(_RECORDING_VARIANT_RE.search(_extract_qualifier_text(title)))
+    """Whether the title carries a qualifier that is neither a credit nor droppable noise.
+
+    Round and square brackets alike: "[2011 Remaster]" renames to a different
+    recording just as surely as "(2011 Remaster)" does.
+    """
+    return any(
+        not _FEAT_CREDIT_RE.match(text) and not is_discardable_qualifier(text)
+        for text in _extract_qualifier_texts(title)
+    )
 
 
 # The attribution phrases as they survive normalization, for reading a filename
@@ -496,6 +499,17 @@ def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, st
     return None
 
 
+def _proposal(result: dict, artist_first: bool) -> str:
+    """The filename a rename to this result would write.
+
+    Sanitized, because that is what lands on disk: a score of "already correct"
+    has to be measured against the name the save can actually produce, and the
+    suggestion the user clicks has to be the same string it was scored as.
+    """
+    artist, title = result.get("artist", ""), result.get("title", "")
+    return sanitize_filename(f"{artist} - {title}" if artist_first else f"{title} - {artist}")
+
+
 def _correction_count(
     name: str, proposal: str, query_artist_first: bool, artist_first: bool
 ) -> int:
@@ -527,17 +541,17 @@ def _anchor_score(
 ) -> int:
     """Pin a confirmed match to its anchor; cap everything else below the band.
 
-    `name` is the filename as it stands, compared against the sanitised proposal
-    so a title containing a character Windows forbids can still be already-correct.
+    `name` is the name the caller asked about, which on the edit page is what
+    the box currently holds rather than what is on disk -- 100 answers "would
+    saving this change anything", not "is the library tidy".
     """
     query_artist_first = _exact_match_artist_first(result, query_parts_norm)
     if query_artist_first is None:
         return min(score, _UNCONFIRMED_CEILING)
-    artist, title = result.get("artist", ""), result.get("title", "")
-    proposal = sanitize_filename(f"{artist} - {title}" if artist_first else f"{title} - {artist}")
-    # regex_tidy strips "(Live)" and "(Remastered 2010)" as readily as
+    proposal = _proposal(result, artist_first)
+    # regex_tidy strips "(Live)" and "(2011 Remaster)" as readily as it strips
     # "(Official Video)", so a confirmed match can still be the wrong recording.
-    if _RECORDING_VARIANT_RE.search(name) and not _RECORDING_VARIANT_RE.search(proposal):
+    if _has_disqualifying_qualifier(name) and not _has_disqualifying_qualifier(proposal):
         return min(score, _UNCONFIRMED_CEILING)
     return (_ALREADY_CORRECT, _ONE_CORRECTION, _MANY_CORRECTIONS, _MANY_CORRECTIONS)[
         _correction_count(name, proposal, query_artist_first, artist_first)
@@ -556,29 +570,32 @@ def _deduplicate_suggestions(
     """
     query_parts_norm = _normalize_query_parts(query)
     featuring_norm = _normalize_for_matching(featuring) if featuring else ""
-    best: dict[tuple[str, str], tuple[int, dict]] = {}
+    best: dict[tuple[str, str], tuple[int, int, dict]] = {}
     for r in results:
         key = (r.get("artist", "").lower(), r.get("title", "").lower())
-        s = _anchor_score(
-            _suggestion_score(r, query_parts_norm, featuring_norm),
-            r,
-            query_parts_norm,
-            name,
-            artist_first,
-        )
-        if key not in best or s > best[key][0]:
-            best[key] = (s, r)
-    scored = sorted(best.values(), key=lambda x: x[0], reverse=True)
-    return scored
+        tally = _suggestion_score(r, query_parts_norm, featuring_norm)
+        s = _anchor_score(tally, r, query_parts_norm, name, artist_first)
+        if key not in best or (s, tally) > best[key][:2]:
+            best[key] = (s, tally, r)
+    # The raw tally breaks ties: the ceiling flattens every unconfirmed result
+    # above it to one value, and without this the best of them would rank by
+    # nothing more than the order iTunes happened to return it in.
+    ranked = sorted(best.values(), key=lambda x: (x[0], x[1]), reverse=True)
+    return [(score, result) for score, _, result in ranked]
 
 
 # Over-fetch factor to compensate for deduplication
 _OVERFETCH_FACTOR = 3
 
 
+def _extract_qualifier_texts(text: str) -> list[str]:
+    """Each parenthetical and bracketed group's content, brackets removed."""
+    return [g for groups in _PAREN_EXTRACT_RE.findall(text) for g in groups if g]
+
+
 def _extract_qualifier_text(text: str) -> str:
     """Extract all parenthetical and bracketed content as a single string."""
-    return " ".join(g for groups in _PAREN_EXTRACT_RE.findall(text) for g in groups if g)
+    return " ".join(_extract_qualifier_texts(text))
 
 
 def suggest_metadata(
@@ -614,10 +631,7 @@ def suggest_metadata(
         return []
 
     # Build output dicts with display and score fields (don't mutate originals)
-    out = []
-    for score, r in truncated:
-        display = (
-            f"{r['artist']} - {r['title']}" if artist_first else f"{r['title']} - {r['artist']}"
-        )
-        out.append({**r, "display": display, "score": max(0, score)})
-    return out
+    return [
+        {**r, "display": _proposal(r, artist_first), "score": max(0, score)}
+        for score, r in truncated
+    ]

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -525,24 +525,25 @@ def _corrections(
 ) -> list[str]:
     """Which kinds of correction a rename to `proposal` would apply.
 
-    Three sequential transformations -- order, then noise, then characters --
-    each asking "did this step change anything". Sequential rather than parallel
-    so that one defect cannot be counted under two kinds.
+    Three sequential transformations -- noise, then order, then characters --
+    each asking "did this step change anything", so that one defect cannot be
+    counted under two kinds. Noise goes first because reordering a name that
+    still carries its brackets can split on a separator inside one.
     """
     kinds = []
-    reordered = name
+    tidied = regex_tidy(name)
+    if tidied != name:
+        kinds.append("noise")
+    reordered = tidied
     if query_artist_first != artist_first:
-        head, _, tail = name.partition(" - ")
+        head, _, tail = tidied.partition(" - ")
         if tail:
             reordered = f"{tail} - {head}"
-    if reordered != name:
+    if reordered != tidied:
         kinds.append("order")
-    tidied = regex_tidy(reordered)
-    if tidied != reordered:
-        kinds.append("noise")
     # Deliberately raw: no case folding, no accent folding. This is what keeps
     # "Beyonce" off 100.
-    if tidied != proposal:
+    if reordered != proposal:
         kinds.append("characters")
     return kinds
 

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -434,10 +434,13 @@ def _has_disqualifying_qualifier(title: str) -> bool:
     Round and square brackets alike: "[2011 Remaster]" renames to a different
     recording just as surely as "(2011 Remaster)" does.
     """
-    return any(
-        not _FEAT_CREDIT_RE.match(text) and not is_discardable_qualifier(text)
-        for text in _extract_qualifier_texts(title)
-    )
+    for text in _extract_qualifier_texts(title):
+        # A credit excuses only the bracket it is alone in: "(feat. Sia, Live)"
+        # is still a live recording.
+        credit_only = _FEAT_CREDIT_RE.match(text) and not _SPECIAL_VERSION_RE.search(text)
+        if not credit_only and not is_discardable_qualifier(text):
+            return True
+    return False
 
 
 # The attribution phrases as they survive normalization, for reading a filename
@@ -529,10 +532,11 @@ def _corrections(
     kinds = []
     reordered = name
     if query_artist_first != artist_first:
-        kinds.append("order")
         head, _, tail = name.partition(" - ")
         if tail:
             reordered = f"{tail} - {head}"
+    if reordered != name:
+        kinds.append("order")
     tidied = regex_tidy(reordered)
     if tidied != reordered:
         kinds.append("noise")

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -14,10 +14,13 @@ import urllib3.connection
 import urllib3.util.ssl_
 
 from pikaraoke.lib.metadata_parser import (
+    _PAREN_NOT_FEAT,
+    _RECORDING_VARIANT_RE,
     _SPECIAL_VERSION_RE,
     normalize_for_comparison,
     regex_tidy,
     remove_accents,
+    sanitize_filename,
 )
 
 # iTunes nominally allows ~20 requests/minute.  A 2s floor between requests
@@ -343,19 +346,21 @@ def _suggestion_score(
         fuzzy = _fuzzy_match(part_norm, artist_norm) or _fuzzy_match(part_norm, title_norm)
         substring = part_norm in artist_norm or part_norm in title_norm
         if exact_match:
-            score += 50
+            score += 38
         elif fuzzy:
-            score += 40
+            score += 31
         elif substring:
-            score += 25
+            score += 19
 
     # Cross-field bonus: when one query part matched the artist and another
     # matched the title, the result aligns with the query's structure.
     # Without this, a result where both parts coincidentally appear in the
     # title (e.g. a track titled "Dolly Parton + Beer Cereal Divorce" by
     # David Liebe Hart) could outscore a result with the correct artist.
+    # 24 rather than the proportional 23 so that two exact parts plus this
+    # bonus sum to exactly _ALREADY_CORRECT.
     if len(query_parts_norm) >= 2 and artist_matched and title_matched:
-        score += 30
+        score += 24
 
     # Single-part decomposition: when the query has no separator but can be
     # split into artist + title, score each confirmed field independently.
@@ -364,18 +369,18 @@ def _suggestion_score(
         # Strip artist -> does remainder match title?
         artist_remainder = part_norm.replace(artist_norm, "", 1).strip()
         if artist_remainder and _matches_field(artist_remainder, title_norm):
-            score += 40
+            score += 31
         # Strip title -> does remainder match artist?
         title_remainder = part_norm.replace(title_norm, "", 1).strip()
         if title_remainder and _matches_field(title_remainder, artist_norm):
-            score += 40
+            score += 31
 
     # Bonus if the featuring artist appears in the result title
     # Normalize both sides so "and" matches "&" and accents are ignored
     if featuring_norm:
         title_full_norm = _normalize_for_matching(title_lower)
         if featuring_norm in title_full_norm:
-            score += 15
+            score += 12
 
     # Bonus when query artist part has extra names that appear in the result's
     # parenthetical (e.g. query "Taylor Swift and Ed Sheeran" matches
@@ -392,29 +397,121 @@ def _suggestion_score(
             extra = query_artist_norm.replace(artist_norm, "").strip()
             extra = _LEADING_CONJUNCTION_RE.sub("", extra).strip()
             if extra and len(extra) > 2 and extra in parens_text:
-                score += 15
+                score += 12
 
     # Penalize titles with parenthetical qualifiers (sessions, performances, etc.)
     if title_base != title_lower:
-        score -= 10
+        score -= 8
 
     # Penalize special versions (live, remix, etc.)
     if _SPECIAL_VERSION_RE.search(title_lower):
-        score -= 30
+        score -= 23
     if len(title_lower) > 60:
-        score -= 20
+        score -= 15
 
     # Prefer simple genres ("Rock") over compound ones ("Singer/Songwriter")
     genre = result.get("genre", "")
     if "/" in genre or "&" in genre:
-        score -= 5
+        score -= 4
     return score
 
 
+# A confirmed match is assigned its anchor rather than tallied: exactness is a
+# definitive determination, so the version and length penalties that rank
+# candidates against each other no longer apply. 100 is also what the rebased
+# weights produce for a clean confirmed match (38 + 38 + 24), so the assignment
+# agrees with the arithmetic instead of overriding it.
+_ALREADY_CORRECT = 100  # the name on disk is what we would rename it to
+_ONE_CORRECTION = 98  # fields confirmed; one of order / noise / characters is wrong
+_MANY_CORRECTIONS = 95  # fields confirmed; two or three of them are
+_UNCONFIRMED_CEILING = 94  # nothing unconfirmed may enter the confirmed band
+
+
+def _has_disqualifying_qualifier(title: str) -> bool:
+    """Whether the title carries a qualifier other than a featuring credit."""
+    # "(Live)", "(Taylor's Version)", "(Commentary)" -- anything parenthesised that is not a credit
+    if _PAREN_NOT_FEAT.search(title):
+        return True
+    # _PAREN_NOT_FEAT only sees round brackets, so "(feat. X) [Live]" reaches here
+    return bool(_RECORDING_VARIANT_RE.search(_extract_qualifier_text(title)))
+
+
+def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, str]]) -> bool | None:
+    """Whether an exactly matching query is written artist-first.
+
+    None when the result is not an exact match on both fields, including when
+    the title carries a qualifier other than a featuring credit.
+    """
+    if len(query_parts_norm) != 2:
+        return None
+    title_lower = result.get("title", "").lower()
+    if _has_disqualifying_qualifier(title_lower):
+        return None
+    artist_norm = _normalize_for_matching(result.get("artist", "").lower())
+    title_norm = _normalize_for_matching(_PAREN_CONTENT_RE.sub("", title_lower).strip())
+    first, second = query_parts_norm[0][1], query_parts_norm[1][1]
+    if first == artist_norm and second == title_norm:
+        return True
+    if first == title_norm and second == artist_norm:
+        return False
+    return None
+
+
+def _correction_count(
+    name: str, proposal: str, query_artist_first: bool, artist_first: bool
+) -> int:
+    """Count the kinds of correction a rename to `proposal` would apply.
+
+    Three sequential transformations -- order, then noise, then characters --
+    each asking "did this step change anything". Sequential rather than parallel
+    so that one defect cannot be counted under two kinds.
+    """
+    corrections = 0
+    reordered = name
+    if query_artist_first != artist_first:
+        corrections += 1
+        head, _, tail = name.partition(" - ")
+        if tail:
+            reordered = f"{tail} - {head}"
+    tidied = regex_tidy(reordered)
+    if tidied != reordered:
+        corrections += 1
+    # Deliberately raw: no case folding, no accent folding. This is what keeps
+    # "Beyonce" off 100.
+    if tidied != proposal:
+        corrections += 1
+    return corrections
+
+
+def _anchor_score(
+    score: int, result: dict, query_parts_norm: list[tuple[str, str]], name: str, artist_first: bool
+) -> int:
+    """Pin a confirmed match to its anchor; cap everything else below the band.
+
+    `name` is the filename as it stands, compared against the sanitised proposal
+    so a title containing a character Windows forbids can still be already-correct.
+    """
+    query_artist_first = _exact_match_artist_first(result, query_parts_norm)
+    if query_artist_first is None:
+        return min(score, _UNCONFIRMED_CEILING)
+    artist, title = result.get("artist", ""), result.get("title", "")
+    proposal = sanitize_filename(f"{artist} - {title}" if artist_first else f"{title} - {artist}")
+    # regex_tidy strips "(Live)" and "(Remastered 2010)" as readily as
+    # "(Official Video)", so a confirmed match can still be the wrong recording.
+    if _RECORDING_VARIANT_RE.search(name) and not _RECORDING_VARIANT_RE.search(proposal):
+        return min(score, _UNCONFIRMED_CEILING)
+    return (_ALREADY_CORRECT, _ONE_CORRECTION, _MANY_CORRECTIONS, _MANY_CORRECTIONS)[
+        _correction_count(name, proposal, query_artist_first, artist_first)
+    ]
+
+
 def _deduplicate_suggestions(
-    results: list[dict], query: str, featuring: str = ""
+    results: list[dict], query: str, name: str, artist_first: bool, featuring: str = ""
 ) -> list[tuple[int, dict]]:
     """Keep the highest-scored result per unique (artist, title) pair.
+
+    Anchoring happens here rather than at display time: the badge sits beside a
+    ranked list, so a demotion applied after the sort could show a 95 above a 98.
 
     Returns (score, result) tuples sorted by score descending.
     """
@@ -423,7 +520,13 @@ def _deduplicate_suggestions(
     best: dict[tuple[str, str], tuple[int, dict]] = {}
     for r in results:
         key = (r.get("artist", "").lower(), r.get("title", "").lower())
-        s = _suggestion_score(r, query_parts_norm, featuring_norm)
+        s = _anchor_score(
+            _suggestion_score(r, query_parts_norm, featuring_norm),
+            r,
+            query_parts_norm,
+            name,
+            artist_first,
+        )
         if key not in best or s > best[key][0]:
             best[key] = (s, r)
     scored = sorted(best.values(), key=lambda x: x[0], reverse=True)
@@ -443,14 +546,16 @@ def suggest_metadata(
     display_name: str,
     provider: MetadataProvider | None = None,
     limit: int = 5,
-    artist_first: bool = False,
+    artist_first: bool = True,
 ) -> list[dict]:
     """Tidy a display name and search for metadata suggestions.
 
     Args:
         artist_first: Render each suggestion as "Artist - Title" rather than
             "Title - Artist". The library's naming convention, not the current
-            filename's, so suggestions pull a mangled library into line.
+            filename's, so suggestions pull an untidy library into line. It also
+            decides which order scores 100, so the default mirrors the
+            "artist_title" default of the suggestion_name_order preference.
     """
     if provider is None:
         provider = ITunesProvider()
@@ -461,7 +566,9 @@ def suggest_metadata(
     featuring = feat_match.group("name").strip() if feat_match else ""
     search_query = _FEATURING_PATTERN.sub("", tidied).strip()
     results = provider.search(search_query, limit=limit * _OVERFETCH_FACTOR)
-    scored = _deduplicate_suggestions(results, search_query, featuring)
+    # The untidied name, not the query: the question the anchors answer is what
+    # is on disk, not what the tidy makes of it.
+    scored = _deduplicate_suggestions(results, search_query, display_name, artist_first, featuring)
     truncated = scored[:limit]
 
     if not truncated:
@@ -473,5 +580,5 @@ def suggest_metadata(
         display = (
             f"{r['artist']} - {r['title']}" if artist_first else f"{r['title']} - {r['artist']}"
         )
-        out.append({**r, "display": display, "score": score})
+        out.append({**r, "display": display, "score": max(0, score)})
     return out

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -17,6 +17,7 @@ from pikaraoke.lib.metadata_parser import (
     _PAREN_NOT_FEAT,
     _RECORDING_VARIANT_RE,
     _SPECIAL_VERSION_RE,
+    ATTRIBUTION_CONNECTORS,
     normalize_for_comparison,
     regex_tidy,
     remove_accents,
@@ -436,6 +437,29 @@ def _has_disqualifying_qualifier(title: str) -> bool:
     return bool(_RECORDING_VARIANT_RE.search(_extract_qualifier_text(title)))
 
 
+# The attribution phrases as they survive normalization, for reading a filename
+# that names its artist in prose: "Cry Me a River made famous by Julie London".
+_ATTRIBUTION_CONNECTORS_NORM = [_normalize_for_matching(c) for c in ATTRIBUTION_CONNECTORS]
+_LEADING_ATTRIBUTION_RE = re.compile(r"^(?:" + "|".join(_ATTRIBUTION_CONNECTORS_NORM) + r")\s+")
+
+
+def _decomposes_into(whole: str, first: str, second: str) -> bool:
+    """Whether `whole` is exactly `first` then `second`, bar an attribution phrase."""
+    if whole == f"{first} {second}":
+        return True
+    return any(whole == f"{first} {c} {second}" for c in _ATTRIBUTION_CONNECTORS_NORM)
+
+
+def _part_names_field(part_norm: str, field_norm: str) -> bool:
+    """Whether a query part is this field, with or without an opening connector.
+
+    Both forms, not just the stripped one: "By the Way - Red Hot Chili Peppers"
+    puts a connector at the front of a real title, and stripping it there would
+    lose the match the separator already made plain.
+    """
+    return field_norm in (part_norm, _LEADING_ATTRIBUTION_RE.sub("", part_norm))
+
+
 def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, str]]) -> bool | None:
     """Whether an exactly matching query is written artist-first.
 
@@ -453,19 +477,21 @@ def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, st
         return None
     if len(query_parts_norm) == 1:
         # A query with no separator confirms both fields only when it is exactly
-        # the two of them concatenated, nothing left over: "CAKE I Will Survive"
-        # qualifies, "Cry Me a River by Julie London" does not. Whichever
-        # concatenation matches is the order the filename is written in.
+        # the two of them, nothing left over: "CAKE I Will Survive" and "Cry Me a
+        # River by Julie London" qualify, "Cry Me a River, a Julie London song"
+        # does not. Whichever arrangement matches is the order it is written in.
         whole = query_parts_norm[0][1]
-        if whole == f"{artist_norm} {title_norm}":
+        if _decomposes_into(whole, artist_norm, title_norm):
             return True
-        if whole == f"{title_norm} {artist_norm}":
+        if _decomposes_into(whole, title_norm, artist_norm):
             return False
         return None
+    # "Cry Me a River - by Julie London": the separator is there, but the artist
+    # side still opens with the connector the vendor wrote it with.
     first, second = query_parts_norm[0][1], query_parts_norm[1][1]
-    if first == artist_norm and second == title_norm:
+    if _part_names_field(first, artist_norm) and _part_names_field(second, title_norm):
         return True
-    if first == title_norm and second == artist_norm:
+    if _part_names_field(first, title_norm) and _part_names_field(second, artist_norm):
         return False
     return None
 

--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -442,13 +442,26 @@ def _exact_match_artist_first(result: dict, query_parts_norm: list[tuple[str, st
     None when the result is not an exact match on both fields, including when
     the title carries a qualifier other than a featuring credit.
     """
-    if len(query_parts_norm) != 2:
+    if len(query_parts_norm) not in (1, 2):
         return None
     title_lower = result.get("title", "").lower()
     if _has_disqualifying_qualifier(title_lower):
         return None
     artist_norm = _normalize_for_matching(result.get("artist", "").lower())
     title_norm = _normalize_for_matching(_PAREN_CONTENT_RE.sub("", title_lower).strip())
+    if not artist_norm or not title_norm:
+        return None
+    if len(query_parts_norm) == 1:
+        # A query with no separator confirms both fields only when it is exactly
+        # the two of them concatenated, nothing left over: "CAKE I Will Survive"
+        # qualifies, "Cry Me a River by Julie London" does not. Whichever
+        # concatenation matches is the order the filename is written in.
+        whole = query_parts_norm[0][1]
+        if whole == f"{artist_norm} {title_norm}":
+            return True
+        if whole == f"{title_norm} {artist_norm}":
+            return False
+        return None
     first, second = query_parts_norm[0][1], query_parts_norm[1][1]
     if first == artist_norm and second == title_norm:
         return True

--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -3,32 +3,18 @@
 import contextlib
 import logging
 import os
-import re
 from collections.abc import Callable
 
 from pikaraoke.lib.events import EventSystem
-from pikaraoke.lib.get_platform import is_windows
 from pikaraoke.lib.karaoke_database import KaraokeDatabase
 from pikaraoke.lib.library_scanner import build_song_record
-from pikaraoke.lib.metadata_parser import regex_tidy, remove_accents, youtube_id_suffix
+from pikaraoke.lib.metadata_parser import (
+    regex_tidy,
+    remove_accents,
+    sanitize_filename,
+    youtube_id_suffix,
+)
 from pikaraoke.lib.song_list import SongList
-
-# Characters illegal in Windows filenames
-_WINDOWS_ILLEGAL_CHARS = re.compile(r'[<>:"/\\|?*]')
-_PATH_SEPARATORS = re.compile(r"[/\\]")
-
-
-def sanitize_filename(name: str) -> str:
-    """Remove characters that are illegal in a filename on the current platform.
-
-    Path separators go on every platform: callers pass a bare filename, so a
-    separator can only be an attempt to write outside the song directory.
-    """
-    if is_windows():
-        name = _WINDOWS_ILLEGAL_CHARS.sub("-", name)
-    else:
-        name = _PATH_SEPARATORS.sub("-", name)
-    return name.strip()
 
 
 class SongManager:

--- a/pikaraoke/templates/edit.html
+++ b/pikaraoke/templates/edit.html
@@ -32,8 +32,14 @@
               if (item.genre) parts.push(item.genre);
               $text.append($('<span class="suggest-meta">').text(" (" + parts.join(", ") + ")"));
             }
-            var score = item.score != null ? item.score : "";
-            var $score = $('<span class="suggest-score">').text(score);
+            // Percent, because the score is anchored rather than ranked: 100 means
+            // "already correct", not "best of these five". The reason explains a
+            // number below that, which the number alone can only assert.
+            var $score = $('<span class="suggest-score">');
+            if (item.score != null) {
+              $score.text(item.score + '%');
+              if (item.reason) $score.attr('title', item.reason);
+            }
             $('<a class="suggested_item has-background-grey-dark">').data('name', display).append($text).append($score).appendTo($container);
           });
           // {# MSG: Help text explaining that clicking a suggestion copies it to the filename input. #}

--- a/scripts/itunes_bulk_report.py
+++ b/scripts/itunes_bulk_report.py
@@ -42,6 +42,34 @@ def collect_unique_songs(songs_dir: str) -> list[str]:
     return filenames
 
 
+def _print_distribution(label: str, rows: list[dict], queried: int) -> None:
+    """Score distribution and reasons for one provenance group."""
+    scores = [r["score"] for r in rows if r.get("score") is not None]
+    if not scores:
+        return
+    n = len(scores)
+    print(f"\n  {label}: {n} songs, {n / queried * 100:.0f}% of those queried")
+    # The three anchors, so the counts size the groups directly: >= 100 is
+    # already correct, 95..98 is what a bulk run would touch.
+    for thresh in (100, 98, 95):
+        count = sum(1 for s in scores if s >= thresh)
+        print(f"      score >= {thresh:>3}: {count:>4} / {n}  ({count / n * 100:5.1f}%)")
+    # A count below the band means nothing on its own. "iTunes had nothing to
+    # offer" wants a better query; "we held it back" is the threshold's own
+    # doing, and only that second group argues for moving it.
+    for sub, keep in (("inside the band", True), ("below it", False)):
+        members = [r for r in rows if r.get("score") is not None and (r["score"] >= 95) == keep]
+        if not members:
+            continue
+        tally: dict[str, int] = {}
+        for r in members:
+            reason = r.get("reason") or "unknown"
+            tally[reason] = tally.get(reason, 0) + 1
+        print(f"      why {sub}:")
+        for reason, count in sorted(tally.items(), key=lambda kv: -kv[1]):
+            print(f"        {reason:<26} {count:>4} / {n}  ({count / n * 100:5.1f}%)")
+
+
 def run_report(songs_dir: str, country: str = "US") -> None:
     filenames = collect_unique_songs(songs_dir)
     total = len(filenames)
@@ -60,6 +88,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
         writer.writerow(
             [
                 "original_stem",
+                "youtube",
                 "tidied",
                 "top_score",
                 "reason",
@@ -77,6 +106,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
             stem = os.path.splitext(filename)[0]
             suffix = youtube_id_suffix(filename)
             clean_stem = stem[: -len(suffix)] if suffix else stem
+            yt = bool(suffix)
             tidied = regex_tidy(clean_stem)
             eta_min = (total - i) * 3 / 60  # ~3s effective per song
 
@@ -84,8 +114,10 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 suggestions = suggest_metadata(clean_stem, provider=provider, limit=5)
             except (requests.exceptions.RequestException, ValueError, KeyError) as e:
                 print(f"  [{i}/{total}] ERROR: {stem} -> {e}")
-                writer.writerow([stem, tidied, "ERROR", type(e).__name__, "", "", "", "", ""])
-                results.append({"stem": stem, "score": None, "reason": type(e).__name__})
+                writer.writerow([stem, yt, tidied, "ERROR", type(e).__name__, "", "", "", "", ""])
+                results.append(
+                    {"stem": stem, "youtube": yt, "score": None, "reason": type(e).__name__}
+                )
                 continue
 
             if suggestions:
@@ -93,6 +125,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 score = top.get("score", 0)
                 row = {
                     "stem": stem,
+                    "youtube": yt,
                     "tidied": tidied,
                     "score": score,
                     "reason": top.get("reason", ""),
@@ -111,6 +144,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 writer.writerow(
                     [
                         stem,
+                        yt,
                         tidied,
                         score,
                         row["reason"],
@@ -123,8 +157,8 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 )
             else:
                 print(f"  [{i}/{total}] NONE {stem[:50]:<50}  (ETA: {eta_min:.0f}m)")
-                row = {"stem": stem, "score": 0, "reason": "no results"}
-                writer.writerow([stem, tidied, 0, "no results", "", "", "", "", ""])
+                row = {"stem": stem, "youtube": yt, "score": 0, "reason": "no results"}
+                writer.writerow([stem, yt, tidied, 0, "no results", "", "", "", "", ""])
 
             results.append(row)
 
@@ -142,28 +176,15 @@ def run_report(songs_dir: str, country: str = "US") -> None:
     print(f"Time elapsed:               {elapsed_total / 60:.1f} minutes")
     print()
 
-    # The four anchors, so the counts size the three groups directly: >= 100 is
-    # already correct, 95..98 is what a bulk run would touch, the rest is review.
-    for thresh in (100, 98, 95, 80, 0):
-        count = sum(1 for s in scores if s >= thresh)
-        pct = count / queried * 100 if queried else 0
-        print(f"  Score >= {thresh:>3}: {count:>4} / {queried}  ({pct:5.1f}%)")
-
-    # A count of songs below the band means nothing on its own. "iTunes had
-    # nothing to offer" wants a better query; "we held it back" is the
-    # threshold's own doing, and only that second group argues for moving it.
-    for label, keep in (("below the band", False), ("inside it", True)):
-        group = [r for r in results if r.get("score") is not None and ((r["score"] >= 95) == keep)]
-        if not group:
-            continue
-        tally: dict[str, int] = {}
-        for r in group:
-            reason = r.get("reason") or "unknown"
-            tally[reason] = tally.get(reason, 0) + 1
-        print(f"\n  Why, for everything {label}:")
-        for reason, count in sorted(tally.items(), key=lambda kv: -kv[1]):
-            pct = count / queried * 100 if queried else 0
-            print(f"    {reason:<26} {count:>4} / {queried}  ({pct:5.1f}%)")
+    # Auto-renaming YouTube downloads is what this feature exists for. A
+    # library's other files arrive with their own naming conventions and are a
+    # secondary concern, so one blended number hides how well the primary case
+    # works -- and hides which group a disappointing number belongs to.
+    for label, group in (
+        ("YouTube-sourced", [r for r in results if r.get("youtube")]),
+        ("Other provenance", [r for r in results if r.get("youtube") is False]),
+    ):
+        _print_distribution(label, group, queried)
 
     print(f"\nFull results saved to: {csv_path}")
 

--- a/scripts/itunes_bulk_report.py
+++ b/scripts/itunes_bulk_report.py
@@ -100,7 +100,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                     "year": top.get("year", ""),
                     "genre": top.get("genre", ""),
                 }
-                status = "OK" if score >= 100 else "LOW"
+                status = "OK" if score >= 95 else "LOW"
                 print(
                     f"  [{i}/{total}] {status} ({score:>4}) "
                     f"{stem[:50]:<50} -> {row['display'][:50]}"
@@ -139,15 +139,12 @@ def run_report(songs_dir: str, country: str = "US") -> None:
     print(f"Time elapsed:               {elapsed_total / 60:.1f} minutes")
     print()
 
-    thresholds = [120, 100, 80, 50, 0]
-    for thresh in thresholds:
+    # The four anchors, so the counts size the three groups directly: >= 100 is
+    # already correct, 95..98 is what a bulk run would touch, the rest is review.
+    for thresh in (100, 98, 95, 80, 0):
         count = sum(1 for s in scores if s >= thresh)
         pct = count / queried * 100 if queried else 0
         print(f"  Score >= {thresh:>3}: {count:>4} / {queried}  ({pct:5.1f}%)")
-
-    neg = sum(1 for s in scores if s < 0)
-    neg_pct = neg / queried * 100 if queried else 0
-    print(f"  Score <   0: {neg:>4} / {queried}  ({neg_pct:5.1f}%)")
 
     print(f"\nFull results saved to: {csv_path}")
 

--- a/scripts/itunes_bulk_report.py
+++ b/scripts/itunes_bulk_report.py
@@ -62,6 +62,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 "original_stem",
                 "tidied",
                 "top_score",
+                "reason",
                 "suggested_display",
                 "suggested_artist",
                 "suggested_title",
@@ -83,8 +84,8 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 suggestions = suggest_metadata(clean_stem, provider=provider, limit=5)
             except (requests.exceptions.RequestException, ValueError, KeyError) as e:
                 print(f"  [{i}/{total}] ERROR: {stem} -> {e}")
-                writer.writerow([stem, tidied, "ERROR", "", "", "", "", ""])
-                results.append({"stem": stem, "score": None})
+                writer.writerow([stem, tidied, "ERROR", type(e).__name__, "", "", "", "", ""])
+                results.append({"stem": stem, "score": None, "reason": type(e).__name__})
                 continue
 
             if suggestions:
@@ -94,6 +95,7 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                     "stem": stem,
                     "tidied": tidied,
                     "score": score,
+                    "reason": top.get("reason", ""),
                     "display": top.get("display", ""),
                     "artist": top.get("artist", ""),
                     "title": top.get("title", ""),
@@ -103,14 +105,15 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 status = "OK" if score >= 95 else "LOW"
                 print(
                     f"  [{i}/{total}] {status} ({score:>4}) "
-                    f"{stem[:50]:<50} -> {row['display'][:50]}"
-                    f"  (ETA: {eta_min:.0f}m)"
+                    f"{stem[:44]:<44} -> {row['display'][:44]:<44}"
+                    f" [{row['reason'][:24]:<24}] (ETA: {eta_min:.0f}m)"
                 )
                 writer.writerow(
                     [
                         stem,
                         tidied,
                         score,
+                        row["reason"],
                         row["display"],
                         row["artist"],
                         row["title"],
@@ -120,8 +123,8 @@ def run_report(songs_dir: str, country: str = "US") -> None:
                 )
             else:
                 print(f"  [{i}/{total}] NONE {stem[:50]:<50}  (ETA: {eta_min:.0f}m)")
-                row = {"stem": stem, "score": 0}
-                writer.writerow([stem, tidied, 0, "", "", "", "", ""])
+                row = {"stem": stem, "score": 0, "reason": "no results"}
+                writer.writerow([stem, tidied, 0, "no results", "", "", "", "", ""])
 
             results.append(row)
 
@@ -145,6 +148,22 @@ def run_report(songs_dir: str, country: str = "US") -> None:
         count = sum(1 for s in scores if s >= thresh)
         pct = count / queried * 100 if queried else 0
         print(f"  Score >= {thresh:>3}: {count:>4} / {queried}  ({pct:5.1f}%)")
+
+    # A count of songs below the band means nothing on its own. "iTunes had
+    # nothing to offer" wants a better query; "we held it back" is the
+    # threshold's own doing, and only that second group argues for moving it.
+    for label, keep in (("below the band", False), ("inside it", True)):
+        group = [r for r in results if r.get("score") is not None and ((r["score"] >= 95) == keep)]
+        if not group:
+            continue
+        tally: dict[str, int] = {}
+        for r in group:
+            reason = r.get("reason") or "unknown"
+            tally[reason] = tally.get(reason, 0) + 1
+        print(f"\n  Why, for everything {label}:")
+        for reason, count in sorted(tally.items(), key=lambda kv: -kv[1]):
+            pct = count / queried * 100 if queried else 0
+            print(f"    {reason:<26} {count:>4} / {queried}  ({pct:5.1f}%)")
 
     print(f"\nFull results saved to: {csv_path}")
 

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -14,7 +14,8 @@ if not hasattr(werkzeug, "__version__"):
 
 from pikaraoke.karaoke import SongInUseError
 from pikaraoke.lib.events import EventSystem
-from pikaraoke.lib.song_manager import SongManager, sanitize_filename
+from pikaraoke.lib.metadata_parser import sanitize_filename
+from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.routes.files import files_bp
 from tests.conftest import make_route_app
 

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -29,13 +29,32 @@ class TestSanitizeFilename:
         assert sanitize_filename("../../home/pi/x") == "..-..-home-pi-x"
         assert sanitize_filename("a\\b") == "a-b"
 
-    def test_a_quote_becomes_an_apostrophe_not_a_dash(self, monkeypatch):
-        """Windows forbids the quote, but a dash makes a nickname read as
-        corruption: Bobby "Boris" Pickett filed as Bobby -Boris- Pickett."""
+    def test_illegal_characters_get_the_stand_in_they_deserve(self, monkeypatch):
+        """A dash for everything reads as corruption: Bobby -Boris- Pickett for a
+        nickname, What Does the Fox Say- for a question."""
         monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: True)
         assert sanitize_filename('Bobby "Boris" Pickett') == "Bobby 'Boris' Pickett"
-        # Everything else still has no stand-in worth using
+        assert sanitize_filename("Ylvis - What Does the Fox Say?") == (
+            "Ylvis - What Does the Fox Say"
+        )
+        # A dash where it stands in for structure, not for punctuation
         assert sanitize_filename("AC/DC - T.N.T.") == "AC-DC - T.N.T."
+        assert sanitize_filename("Cee Lo Green - F**k You") == "Cee Lo Green - F--k You"
+
+    def test_a_dropped_character_leaves_no_dangling_separator(self, monkeypatch):
+        """The substitution runs at the end as readily as the middle, and a name
+        ending in a stray dash looks truncated rather than sanitized."""
+        monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: True)
+        assert sanitize_filename("Blondie - Rip Her to Shreds*") == "Blondie - Rip Her to Shreds"
+        assert sanitize_filename("Prince - 1999?") == "Prince - 1999"
+
+    def test_a_name_is_never_sanitized_away_to_nothing(self, monkeypatch):
+        """The rename route checks for an empty name before sanitizing, so a name
+        emptied here would build a path of bare extension -- a hidden file."""
+        monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: True)
+        assert sanitize_filename("---") == "---"
+        assert sanitize_filename("?") == "-"
+        assert sanitize_filename("") == ""
 
     def test_posix_legal_characters_survive(self, monkeypatch):
         """Colons and question marks are legal on POSIX and appear in real titles."""

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -29,6 +29,14 @@ class TestSanitizeFilename:
         assert sanitize_filename("../../home/pi/x") == "..-..-home-pi-x"
         assert sanitize_filename("a\\b") == "a-b"
 
+    def test_a_quote_becomes_an_apostrophe_not_a_dash(self, monkeypatch):
+        """Windows forbids the quote, but a dash makes a nickname read as
+        corruption: Bobby "Boris" Pickett filed as Bobby -Boris- Pickett."""
+        monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: True)
+        assert sanitize_filename('Bobby "Boris" Pickett') == "Bobby 'Boris' Pickett"
+        # Everything else still has no stand-in worth using
+        assert sanitize_filename("AC/DC - T.N.T.") == "AC-DC - T.N.T."
+
     def test_posix_legal_characters_survive(self, monkeypatch):
         """Colons and question marks are legal on POSIX and appear in real titles."""
         monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: False)

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -572,6 +572,13 @@ class TestRegexTidy:
     def test_strips_karaoke_by_source(self):
         assert regex_tidy("Artist - Song - Karaoke by Stingray") == "Artist - Song"
 
+    def test_a_closed_karaoke_bracket_makes_by_an_attribution(self):
+        """The bracket is the whole difference: "Karaoke by Stingray" names the
+        vendor who cut the track, "[Karaoke] by Stingray" names the artist."""
+        assert regex_tidy("Song [Karaoke Version] by Julie London") == "Song - Julie London"
+        assert regex_tidy("Song (Karaoke) by Julie London") == "Song - Julie London"
+        assert regex_tidy("Song [Karaoke by Stingray]") == "Song"
+
     def test_no_dangling_separator_after_noise_and_attribution_removal(self):
         result = regex_tidy("Fernando - KARAOKE VERSION - as popularized by ABBA")
         assert result == "Fernando - ABBA"

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -74,6 +74,7 @@ class TestIsDiscardableQualifier:
             "HD",
             "Lyrics",
             "With Lyrics",
+            "Original Key",
             "カラオケ",
             "2011",
         ):
@@ -85,6 +86,8 @@ class TestIsDiscardableQualifier:
         for text in (
             "Live",
             "Acoustic",
+            "Lower Key",
+            "Higher Key",
             "Remastered 2010",
             "2011 Remaster",
             "Unplugged",

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pikaraoke.lib.metadata_parser import (
-    _RECORDING_VARIANT_RE,
     _detect_artist_first,
     clean_search_query,
     clear_song_name_cache,
@@ -13,6 +12,7 @@ from pikaraoke.lib.metadata_parser import (
     get_song_correct_name,
     has_artist_title_separator,
     has_youtube_id,
+    is_discardable_qualifier,
     lookup_lastfm,
     regex_tidy,
     sanitize_filename,
@@ -35,18 +35,50 @@ class TestSanitizeFilename:
         assert sanitize_filename("Who's Next: Part 2?") == "Who's Next: Part 2?"
 
 
-class TestRecordingVariantPattern:
-    """A qualifier a rename must not silently discard, unlike YouTube noise."""
+class TestIsDiscardableQualifier:
+    """Which bracketed text a rename may drop, and which names another recording."""
 
-    def test_variants_are_matched(self):
-        for qualifier in ("Live", "Remastered 2010", "Acoustic", "Radio Edit", "Demo"):
-            assert _RECORDING_VARIANT_RE.search(qualifier), qualifier
+    def test_production_noise_is_discardable(self):
+        for text in (
+            "Official Video",
+            "Official Music Video",
+            "Karaoke",
+            "Karaoke Version",
+            "HD",
+            "Lyrics",
+            "With Lyrics",
+            "カラオケ",
+            "2011",
+        ):
+            assert is_discardable_qualifier(text), text
 
-    def test_karaoke_and_version_are_not_variants(self):
-        """Excluded deliberately: '(Karaoke Version)' is this app's commonest
-        noise token, and treating it as a variant would gut the feature."""
-        assert not _RECORDING_VARIANT_RE.search("Karaoke Version")
-        assert not _RECORDING_VARIANT_RE.search("Karaoke")
+    def test_recording_variants_are_not_discardable(self):
+        """Dropping one of these renames a recording into a different one, which
+        can collide with the studio cut already filed beside it."""
+        for text in (
+            "Live",
+            "Acoustic",
+            "Remastered 2010",
+            "2011 Remaster",
+            "Unplugged",
+            "Single Edit",
+            "Club Mix",
+            "Mono Version",
+            "BBC Session",
+            "Alternate Take",
+            "Taylor's Version",
+        ):
+            assert not is_discardable_qualifier(text), text
+
+    def test_an_attribution_is_discardable(self):
+        """regex_tidy moves the artist out to the other side of the separator,
+        so the bracket it came from is spent, not lost."""
+        for text in ("Made Famous by Julie London", "In the Style of ABBA", "by Adele"):
+            assert is_discardable_qualifier(text), text
+
+    def test_an_unknown_qualifier_fails_closed(self):
+        """The point of the whitelist: a release form nobody listed is kept."""
+        assert not is_discardable_qualifier("Rarities Box Set")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pikaraoke.lib.metadata_parser import (
+    _RECORDING_VARIANT_RE,
     _detect_artist_first,
     clean_search_query,
     clear_song_name_cache,
@@ -14,10 +15,38 @@ from pikaraoke.lib.metadata_parser import (
     has_youtube_id,
     lookup_lastfm,
     regex_tidy,
+    sanitize_filename,
     score_result,
     search_lastfm_tracks,
     youtube_id_suffix,
 )
+
+
+class TestSanitizeFilename:
+    def test_path_separators_go_on_posix_too(self, monkeypatch):
+        """A name of '../../x' on a Pi used to move the song out of the library."""
+        monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: False)
+        assert sanitize_filename("../../home/pi/x") == "..-..-home-pi-x"
+        assert sanitize_filename("a\\b") == "a-b"
+
+    def test_posix_legal_characters_survive(self, monkeypatch):
+        """Colons and question marks are legal on POSIX and appear in real titles."""
+        monkeypatch.setattr("pikaraoke.lib.metadata_parser.is_windows", lambda: False)
+        assert sanitize_filename("Who's Next: Part 2?") == "Who's Next: Part 2?"
+
+
+class TestRecordingVariantPattern:
+    """A qualifier a rename must not silently discard, unlike YouTube noise."""
+
+    def test_variants_are_matched(self):
+        for qualifier in ("Live", "Remastered 2010", "Acoustic", "Radio Edit", "Demo"):
+            assert _RECORDING_VARIANT_RE.search(qualifier), qualifier
+
+    def test_karaoke_and_version_are_not_variants(self):
+        """Excluded deliberately: '(Karaoke Version)' is this app's commonest
+        noise token, and treating it as a variant would gut the feature."""
+        assert not _RECORDING_VARIANT_RE.search("Karaoke Version")
+        assert not _RECORDING_VARIANT_RE.search("Karaoke")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -651,6 +651,21 @@ class TestScoreAnchoring:
         assert _anchored("Beyoncé - Halo (Live)", "Beyoncé", "Halo") <= 94
         assert _anchored("ABBA - Fernando (Remastered 2010)", "ABBA", "Fernando") <= 94
 
+    def test_a_variant_nobody_listed_leaves_the_band(self):
+        """The qualifier vocabulary is a whitelist of what may be dropped, so a
+        release form outside it is kept rather than silently renamed away."""
+        for qualifier in ("2011 Remaster", "Unplugged", "Single Edit", "BBC Session", "Club Mix"):
+            assert (
+                _anchored(f"Queen - Bohemian Rhapsody ({qualifier})", "Queen", "Bohemian Rhapsody")
+                <= 94
+            ), qualifier
+
+    def test_a_suggestion_may_not_add_a_qualifier_to_a_clean_name(self):
+        """Square brackets used to slip past the paren-only check, so a correctly
+        named file was offered a 98 that would have made it worse."""
+        for title in ("Bohemian Rhapsody [2011 Remaster]", "Bohemian Rhapsody (2011 Remaster)"):
+            assert _anchored("Queen - Bohemian Rhapsody", "Queen", title) <= 94, title
+
     def test_a_title_whose_body_reads_as_a_variant_is_untouched(self):
         """The variant guard reads bracketed text only, never the title body."""
         assert _anchored("Wings - Live and Let Die", "Wings", "Live and Let Die") == 100

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -637,6 +637,12 @@ class TestScoreReasons:
         assert no_sep == "characters"
         assert with_sep == "order"
 
+    def test_a_separator_inside_a_bracket_is_not_a_character_correction(self):
+        """Reordering before the tidy split on the bracket's own " - ", leaving a
+        name the tidy then collapsed to the artist alone."""
+        vendor = "Halo - Beyoncé (Karaoke Songs With Lyrics - Original Key)"
+        assert _reason(vendor, "Beyoncé", "Halo") == "noise, order"
+
     def test_a_credit_does_not_excuse_a_variant_sharing_its_bracket(self):
         """A bracket that opens on a credit can still close on a variant, and
         "(feat. Sia, Live)" is as much a live recording as "(Live)" is."""

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -42,6 +42,12 @@ def _anchored(name: str, artist: str, title: str, artist_first: bool = True) -> 
     return suggest_metadata(name, provider=provider, artist_first=artist_first)[0]["score"]
 
 
+def _reason(name: str, artist: str, title: str, artist_first: bool = True) -> str:
+    """The top suggestion's explanation of its score."""
+    provider = _mock_provider((artist, title))
+    return suggest_metadata(name, provider=provider, artist_first=artist_first)[0]["reason"]
+
+
 ITUNES_RESPONSE = {
     "resultCount": 2,
     "results": [
@@ -604,6 +610,24 @@ class TestSuggestionScoring:
         """
         result = {"artist": "Queen", "title": "Bohemian Rhapsody", "genre": "Rock"}
         assert _score(result, "Queen - Bohemian Rhapsody") == _ALREADY_CORRECT
+
+
+class TestScoreReasons:
+    """A score below the band is only interpretable with the reason beside it."""
+
+    def test_each_anchor_names_its_corrections(self):
+        assert _reason("Beyoncé - Halo", "Beyoncé", "Halo") == "already correct"
+        assert _reason("Beyonce - Halo", "Beyoncé", "Halo") == "characters"
+        assert _reason("Halo - Beyoncé", "Beyoncé", "Halo") == "order"
+        assert _reason("Beyoncé - Halo (Official Video)", "Beyoncé", "Halo") == "noise"
+        assert _reason("halo - beyonce", "Beyoncé", "Halo") == "order, characters"
+
+    def test_the_two_ways_of_missing_the_band_are_distinguished(self):
+        """Both score 94 and they want opposite responses: one is our caution,
+        the other is iTunes having nothing to offer."""
+        assert _reason("Beyoncé - Halo (Live)", "Beyoncé", "Halo") == "variant kept"
+        assert _reason("Beyoncé - Halo", "Beyoncé", "Halo (Live)") == "result qualified"
+        assert _reason("Beyoncé - Halo", "Nickelback", "Photograph") == "unconfirmed"
 
 
 class TestScoreAnchoring:

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -702,6 +702,16 @@ class TestScoreAnchoring:
         assert top["score"] >= 95
         assert top["display"] == "David Guetta - Bang My Head (feat. Sia)"
 
+    def test_a_name_we_already_wrote_is_already_correct(self):
+        """The rename restores iTunes' canonical credit, so the name on disk
+        afterwards carries it. Scoring that 94 means the feature does not
+        recognise its own output, and every renamed song leaves the band."""
+        for artist, title in (
+            ("Taylor Swift", "Everything Has Changed (feat. Ed Sheeran)"),
+            ("David Guetta", "Bang My Head (feat. Sia)"),
+        ):
+            assert _anchored(f"{artist} - {title}", artist, title) == 100, title
+
     def test_a_qualifier_that_is_not_a_credit_disqualifies(self):
         artist, title = "Taylor Swift", "Everything Has Changed"
         assert _anchored(f"{artist} - {title}", artist, f"{title} (Taylor's Version)") <= 94

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pikaraoke.lib.metadata_parser import sanitize_filename
 from pikaraoke.lib.metadata_providers import (
+    _ALREADY_CORRECT,
+    _UNCONFIRMED_CEILING,
     ITUNES_MAX_RETRIES,
     ITunesProvider,
     _normalize_for_matching,
@@ -21,6 +24,22 @@ def _score(result: dict, query: str, featuring: str = "") -> int:
     parts = _normalize_query_parts(query)
     feat_norm = _normalize_for_matching(featuring) if featuring else ""
     return _suggestion_score(result, parts, feat_norm)
+
+
+def _mock_provider(*results: tuple[str, str]) -> MagicMock:
+    """A provider returning (artist, title) pairs as full result dicts."""
+    provider = MagicMock()
+    provider.search.return_value = [
+        {"artist": artist, "title": title, "year": "2008", "genre": "Pop", "source": "itunes"}
+        for artist, title in results
+    ]
+    return provider
+
+
+def _anchored(name: str, artist: str, title: str, artist_first: bool = True) -> int:
+    """The top suggestion's 0-100 score for a filename against one mocked result."""
+    provider = _mock_provider((artist, title))
+    return suggest_metadata(name, provider=provider, artist_first=artist_first)[0]["score"]
 
 
 ITUNES_RESPONSE = {
@@ -576,3 +595,126 @@ class TestSuggestionScoring:
         no_apos = _score(result, "Elvis Costello & The Attractions - Olivers Army")
         with_apos = _score(result, "Elvis Costello & The Attractions - Oliver's Army")
         assert no_apos == with_apos
+
+    def test_a_clean_confirmed_match_tallies_to_the_anchor(self):
+        """Two exact parts plus the cross-field bonus must sum to exactly 100.
+
+        The anchor is assigned rather than computed, so nothing else would catch
+        a weight tweak silently detaching the tally from the value it anchors to.
+        """
+        result = {"artist": "Queen", "title": "Bohemian Rhapsody", "genre": "Rock"}
+        assert _score(result, "Queen - Bohemian Rhapsody") == _ALREADY_CORRECT
+
+
+class TestScoreAnchoring:
+    """Tests for the 0-100 scale: 100 already correct, 98/95 confirmed, <= 94 not."""
+
+    def test_a_byte_identical_name_scores_100(self):
+        assert _anchored("Beyoncé - Halo", "Beyoncé", "Halo") == 100
+
+    def test_a_missing_accent_is_one_correction(self):
+        """100 is byte-equality, not a fuzzy match: the file still needs renaming."""
+        assert _anchored("Beyonce - Halo", "Beyoncé", "Halo") == 98
+
+    def test_wrong_case_alone_is_one_correction(self):
+        assert _anchored("abba - waterloo", "ABBA", "Waterloo") == 98
+
+    def test_order_is_measured_against_the_preference(self):
+        """The same file is already correct or one correction away, depending
+        only on which way round the library writes its names."""
+        assert _anchored("Halo - Beyoncé", "Beyoncé", "Halo", artist_first=True) == 98
+        assert _anchored("Halo - Beyoncé", "Beyoncé", "Halo", artist_first=False) == 100
+
+    def test_corrections_compound(self):
+        """Two or three kinds of correction share one score, below a single kind."""
+        assert _anchored("halo - beyonce", "Beyoncé", "Halo") == 95
+        assert _anchored("Halo - Beyonce (Official Video)", "Beyoncé", "Halo") == 95
+
+    def test_noise_the_tidy_cannot_reach_never_confirms(self):
+        """regex_tidy only strips *trailing* qualifiers, so noise attached to a
+        leading title survives into the query and the fields never match."""
+        assert _anchored("Halo (Official Video) - Beyonce", "Beyoncé", "Halo") <= 94
+
+    def test_a_tidied_name_still_needs_renaming(self):
+        """The tidy decides confidence; the raw stem decides whether there is
+        anything to apply. Confirmed fields alone must not reach 100."""
+        assert _anchored("Beyoncé - Halo (Official Video)", "Beyoncé", "Halo") == 98
+
+    def test_the_variant_guard_ignores_karaoke(self):
+        """'(Karaoke Version)' is this app's commonest noise token. Treating it
+        as a recording variant would push most of a library out of the band."""
+        assert _anchored("Beyoncé - Halo (Karaoke Version)", "Beyoncé", "Halo") == 98
+
+    def test_a_stripped_recording_variant_leaves_the_band(self):
+        """Renaming these would lose the distinction, and possibly collide with
+        the studio recording already in the library."""
+        assert _anchored("Beyoncé - Halo (Live)", "Beyoncé", "Halo") <= 94
+        assert _anchored("ABBA - Fernando (Remastered 2010)", "ABBA", "Fernando") <= 94
+
+    def test_a_title_whose_body_reads_as_a_variant_is_untouched(self):
+        """The variant guard reads bracketed text only, never the title body."""
+        assert _anchored("Wings - Live and Let Die", "Wings", "Live and Let Die") == 100
+
+    def test_a_featuring_credit_reaches_the_band_and_is_restored(self):
+        """The credit is stripped from the query so the fields can agree; the
+        rename then writes iTunes' canonical form back."""
+        provider = _mock_provider(("David Guetta", "Bang My Head (feat. Sia)"))
+        top = suggest_metadata("David Guetta - Bang My Head ft Sia", provider=provider)[0]
+        assert top["score"] >= 95
+        assert top["display"] == "David Guetta - Bang My Head (feat. Sia)"
+
+    def test_a_qualifier_that_is_not_a_credit_disqualifies(self):
+        artist, title = "Taylor Swift", "Everything Has Changed"
+        assert _anchored(f"{artist} - {title}", artist, f"{title} (Taylor's Version)") <= 94
+        assert _anchored(f"{artist} - {title}", artist, f"{title} (Commentary)") <= 94
+
+    def test_a_bracketed_variant_beside_a_credit_disqualifies(self):
+        """_PAREN_NOT_FEAT sees round brackets only, so this reaches the
+        variant regex running over the extracted qualifier text."""
+        assert (
+            _anchored("Mark Ronson - Uptown Funk", "Mark Ronson", "Uptown Funk (feat. B) [Live]")
+            <= 94
+        )
+
+    def test_a_windows_illegal_character_still_reaches_100(self):
+        """The comparison is against the sanitised proposal, so a file named as
+        correctly as the filesystem permits is not demoted for the platform's sake."""
+        on_disk = sanitize_filename("Rush - Song: The Sequel")
+        assert _anchored(on_disk, "Rush", "Song: The Sequel") == 100
+
+    def test_an_unconfirmed_tally_cannot_enter_the_band(self):
+        """Bonuses stack past 100 without confirming anything, which is what the
+        ceiling exists to catch."""
+        query = "David Guetta and Fetty Wap - Bang My Head"
+        result = {"artist": "David Guetta", "title": "Bang My Head (feat. Sia & Fetty Wap)"}
+        assert _score(result, query, "Sia") > _UNCONFIRMED_CEILING
+        assert (
+            _anchored(
+                "David Guetta and Fetty Wap - Bang My Head ft Sia",
+                result["artist"],
+                result["title"],
+            )
+            <= 94
+        )
+
+    def test_a_heavily_penalised_result_floors_at_zero(self):
+        provider = _mock_provider(("Nobody At All", f"{'x' * 70} (Live Remix)"))
+        provider.search.return_value[0]["genre"] = "Rock/Pop"
+        assert suggest_metadata("Beyoncé - Halo", provider=provider)[0]["score"] == 0
+
+    def test_scores_never_rise_down_the_list(self):
+        """The badge sits beside a ranked list, so a demotion applied after the
+        sort could show a 95 above a 98."""
+        provider = _mock_provider(
+            ("Beyoncé", "Halo"),
+            ("Beyoncé", "Halo (Live)"),
+            ("Unrelated Band", "Some Other Song"),
+        )
+        scores = [r["score"] for r in suggest_metadata("Beyoncé - Halo", provider=provider)]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_two_different_cjk_titles_are_not_confirmed(self):
+        """The renamer's old normaliser folded every pure-CJK title to '', so
+        two unrelated ones compared equal. This normaliser keeps them apart."""
+        assert _anchored("夜に駆ける - YOASOBI", "YOASOBI", "君の名は") <= 94
+        assert _anchored("YOASOBI - 夜に駆ける", "YOASOBI", "夜に駆ける") == 100

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pikaraoke.lib.metadata_parser import sanitize_filename
+from pikaraoke.lib.metadata_parser import regex_tidy, sanitize_filename
 from pikaraoke.lib.metadata_providers import (
     _ALREADY_CORRECT,
     _UNCONFIRMED_CEILING,
@@ -720,10 +720,44 @@ class TestScoreAnchoring:
         assert _anchored("CAKE I Will Survive", "CAKE", "I Will Survive") == 98
         assert _anchored("【カラオケ】うっせぇわ _ Ado", "Ado", "うっせぇわ") == 95
 
+    def test_an_attribution_phrase_confirms(self):
+        """The karaoke vendors' house style. Each of these names both fields as
+        plainly as a separator does, so each belongs in the band."""
+        for name in (
+            "Cry Me a River by Julie London",
+            "Cry Me a River made famous by Julie London",
+            "Cry Me a River (Made Famous by Julie London)",
+            "Cry Me a River [In the Style of Julie London]",
+            "Cry Me a River (As Popularized by Julie London)",
+            "Cry Me a River (by Julie London)",
+            "Cry Me a River - by Julie London",
+            "Cry Me a River [Karaoke Version] made famous by Julie London",
+            "Cry Me a River [Karaoke Version] by Julie London",
+            "Cry Me a River (Karaoke) by Julie London",
+        ):
+            assert _anchored(name, "Julie London", "Cry Me a River") >= 95, name
+
+    def test_a_bare_by_needs_a_bracket_to_read_as_attribution(self):
+        """Unbracketed it cannot be told from a title: renaming 'Stand by Me' to
+        'Stand - Me' is the failure this asymmetry exists to prevent."""
+        assert regex_tidy("Stand by Me") == "Stand by Me"
+        assert regex_tidy("Blinded by the Light") == "Blinded by the Light"
+        assert regex_tidy("Cry Me a River (by Julie London)") == "Cry Me a River - Julie London"
+
+    def test_a_leading_connector_does_not_swallow_a_real_title(self):
+        """'By the Way' opens with one. The separator already named both fields,
+        so the connector has to be optional rather than stripped."""
+        assert (
+            _anchored("By the Way - Red Hot Chili Peppers", "Red Hot Chili Peppers", "By the Way")
+            == 98
+        )
+
     def test_a_separator_less_query_must_decompose_exactly(self):
-        """Anything left over after the two fields means the query carries more
-        than a name, and the file needs a human."""
-        assert _anchored("Cry Me a River by Julie London", "Julie London", "Cry Me a River") <= 94
+        """Anything left over after the two fields and an attribution phrase
+        means the query carries more than a name, and the file needs a human."""
+        assert (
+            _anchored("Cry Me a River, a Julie London song", "Julie London", "Cry Me a River") <= 94
+        )
         assert _anchored("王菲 Faye Wong Eyes On Me", "Faye Wong", "Eyes On Me") <= 94
 
     def test_a_romanised_result_never_confirms_a_native_script_name(self):

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -713,6 +713,24 @@ class TestScoreAnchoring:
         scores = [r["score"] for r in suggest_metadata("Beyoncé - Halo", provider=provider)]
         assert scores == sorted(scores, reverse=True)
 
+    def test_a_query_with_no_separator_can_confirm(self):
+        """_suggestion_score already confirms both fields by decomposition, so
+        the anchoring has to honour it: an underscore-separated YouTube name
+        tidies to a single part, and used to be locked out of the band."""
+        assert _anchored("CAKE I Will Survive", "CAKE", "I Will Survive") == 98
+        assert _anchored("【カラオケ】うっせぇわ _ Ado", "Ado", "うっせぇわ") == 95
+
+    def test_a_separator_less_query_must_decompose_exactly(self):
+        """Anything left over after the two fields means the query carries more
+        than a name, and the file needs a human."""
+        assert _anchored("Cry Me a River by Julie London", "Julie London", "Cry Me a River") <= 94
+        assert _anchored("王菲 Faye Wong Eyes On Me", "Faye Wong", "Eyes On Me") <= 94
+
+    def test_a_romanised_result_never_confirms_a_native_script_name(self):
+        """Accepting 'Usseewa' for a file named うっせぇわ rewrites the library's
+        convention, which is a decision for an admin and not for a bulk run."""
+        assert _anchored("【カラオケ】うっせぇわ _ Ado", "Ado", "Usseewa") <= 94
+
     def test_two_different_cjk_titles_are_not_confirmed(self):
         """The renamer's old normaliser folded every pure-CJK title to '', so
         two unrelated ones compared equal. This normaliser keeps them apart."""

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -629,6 +629,20 @@ class TestScoreReasons:
         assert _reason("Beyoncé - Halo", "Beyoncé", "Halo (Live)") == "result qualified"
         assert _reason("Beyoncé - Halo", "Nickelback", "Photograph") == "unconfirmed"
 
+    def test_a_reorder_that_cannot_happen_is_not_a_correction(self):
+        """With no separator there is nothing to swap, so the rewrite the rename
+        applies is counted once, under "characters"."""
+        no_sep = _reason("CAKE I Will Survive", "CAKE", "I Will Survive", artist_first=False)
+        with_sep = _reason("CAKE - I Will Survive", "CAKE", "I Will Survive", artist_first=False)
+        assert no_sep == "characters"
+        assert with_sep == "order"
+
+    def test_a_credit_does_not_excuse_a_variant_sharing_its_bracket(self):
+        """A bracket that opens on a credit can still close on a variant, and
+        "(feat. Sia, Live)" is as much a live recording as "(Live)" is."""
+        assert _reason("Beyoncé - Halo", "Beyoncé", "Halo (feat. Sia, Live)") == "result qualified"
+        assert _reason("Beyoncé - Halo", "Beyoncé", "Halo (feat. Sia)") == "characters"
+
 
 class TestScoreAnchoring:
     """Tests for the 0-100 scale: 100 already correct, 98/95 confirmed, <= 94 not."""

--- a/tests/unit/test_song_manager.py
+++ b/tests/unit/test_song_manager.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pikaraoke.lib.events import EventSystem
-from pikaraoke.lib.song_manager import SongManager, sanitize_filename
+from pikaraoke.lib.song_manager import SongManager
 
 
 def _native(path: Path) -> str:
@@ -235,19 +235,6 @@ class TestRenameTarget:
         sm = SongManager(str(tmp_path), db=mock_db, events=EventSystem())
 
         assert sm.rename_target(_native(song), "New---abc") == _native(subfolder / "New---abc.mp4")
-
-
-class TestSanitizeFilename:
-    def test_path_separators_go_on_posix_too(self, monkeypatch):
-        """A name of '../../x' on a Pi used to move the song out of the library."""
-        monkeypatch.setattr("pikaraoke.lib.song_manager.is_windows", lambda: False)
-        assert sanitize_filename("../../home/pi/x") == "..-..-home-pi-x"
-        assert sanitize_filename("a\\b") == "a-b"
-
-    def test_posix_legal_characters_survive(self, monkeypatch):
-        """Colons and question marks are legal on POSIX and appear in real titles."""
-        monkeypatch.setattr("pikaraoke.lib.song_manager.is_windows", lambda: False)
-        assert sanitize_filename("Who's Next: Part 2?") == "Who's Next: Part 2?"
 
 
 class TestDBCoordination:


### PR DESCRIPTION
The score was an open-ended tally: a 120 meant "better than the other four", not "this is right". Fine beside a list an admin reads, useless as a threshold — and these scores are headed for the batch renamer's triage.

It now answers an absolute question. **100** — the name is already what a rename would write. **98 / 95** — both fields confirmed, one or a few corrections left. **94 and below** — unconfirmed, wants a human. Everything from 95 up is safe to apply.

The edit page shows the score as a percentage, with the reason as a tooltip.

Making the band mean that took two kinds of fix. Qualifiers are now a whitelist of what is safe to drop rather than a list of what is bad, so an open set of release forms — `(2011 Remaster)`, `(Unplugged)`, a live take sharing a bracket with a featuring credit — no longer reaches 98. And the corrections behind a score are counted once each, so the anchor and the reason beside it agree.

Karaoke vendors' house styles are read properly along the way: square brackets like parentheses, the attribution phrases they ship, and their boilerplate suffixes. The feature also recognises its own output, which it used to score 92.

Measured on 602 songs: 24 of 25 Latin-script YouTube files reach the band, and the one exclusion is correct — a lower-key backing track that must not be renamed onto the studio title.
