### PR TITLE
fix: rank the fair queue by turns taken this session

### DIFF
--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -295,6 +295,8 @@ class Karaoke:
             get_now_playing_user=lambda: self.playback_controller.now_playing_user,
             filename_from_path=self.song_manager.display_name_from_path,
             get_available_songs=lambda: self.song_manager.songs,
+            # Bound late: play history is built below.
+            get_turns_taken=lambda: self.play_history.get_turns_taken(),
         )
 
         # Play history recording and reporting (subscribes to song_ended itself)

--- a/pikaraoke/lib/play_history_manager.py
+++ b/pikaraoke/lib/play_history_manager.py
@@ -624,6 +624,27 @@ class PlayHistoryManager:
         )
         return [dict(row) for row in rows]
 
+    def get_turns_taken(self) -> dict[str, int]:
+        """Return how many songs each singer has sung through tonight, keyed lower-case.
+
+        What the fair queue shares turns out against, so it is scoped to the
+        active session and counts neither skipped songs nor the one on screen,
+        whose row does not settle until it ends.
+        """
+        session = self.get_current_session()
+        if session is None:
+            return {}
+        rows = self.db.query(
+            f"SELECT p.performer, COUNT(*) AS turns FROM plays p "
+            f"WHERE p.session_id = ? AND {_SUNG} GROUP BY p.performer COLLATE NOCASE",
+            (session["id"],),
+        )
+        # Folding again in Python can merge two of SQLite's ASCII-only groups.
+        turns: dict[str, int] = {}
+        for row in rows:
+            turns[row["performer"].lower()] = turns.get(row["performer"].lower(), 0) + row["turns"]
+        return turns
+
     def get_top_songs(self, limit: int = 20, session_uuid: str | None = None) -> list[dict]:
         """Return the most-played songs, counting each one across its renames.
 

--- a/pikaraoke/lib/queue_manager.py
+++ b/pikaraoke/lib/queue_manager.py
@@ -47,12 +47,13 @@ class QueueManager:
     def is_user_limited(self, user: str) -> bool:
         """Check if a user has reached their queue limit."""
         limit = self._preferences.get_or_default("limit_user_songs_by")
-        if limit == 0 or user.lower() in _PLACEHOLDER_SINGERS:
+        singer = user.lower()
+        if limit == 0 or singer in _PLACEHOLDER_SINGERS:
             return False
 
         now_playing_user = self._get_now_playing_user() if self._get_now_playing_user else None
-        count = sum(1 for item in self.queue if item["user"] == user) + (
-            1 if now_playing_user == user else 0
+        count = sum(1 for item in self.queue if item["user"].lower() == singer) + (
+            1 if now_playing_user and now_playing_user.lower() == singer else 0
         )
         return count >= int(limit)
 

--- a/pikaraoke/lib/queue_manager.py
+++ b/pikaraoke/lib/queue_manager.py
@@ -26,6 +26,7 @@ class QueueManager:
         get_now_playing_user: Callable[[], str | None] | None = None,
         filename_from_path: Callable[[str, bool], str] | None = None,
         get_available_songs: Callable[[], Any] | None = None,
+        get_turns_taken: Callable[[], dict[str, int]] | None = None,
     ) -> None:
         self.queue: list[dict[str, Any]] = []
         self._preferences = preferences
@@ -33,6 +34,7 @@ class QueueManager:
         self._get_now_playing_user = get_now_playing_user
         self._filename_from_path = filename_from_path
         self._get_available_songs = get_available_songs
+        self._get_turns_taken = get_turns_taken
 
     def is_song_in_queue(self, song_path: str) -> bool:
         """Check if a song is already in the queue."""
@@ -64,33 +66,35 @@ class QueueManager:
         return -1
 
     def _calculate_fair_queue_position(self, user: str) -> int:
-        """Calculate insertion position using Nagle Fair Queuing.
+        """Return where a new song from `user` belongs under fair queuing.
 
-        Users take turns in rounds: a user's Nth song is placed after all
-        other users' Nth songs (or at queue end).
+        Singers take turns in rounds, ranked by the turns they have had tonight
+        rather than by what is left in the queue, so the song on screen and the
+        ones already sung both count against them. Catching up is capped at the
+        round that just played, or a singer arriving at midnight would claim
+        every round the room got through before they walked in.
         """
-        # Count how many songs this user already has in queue
-        user_song_count = sum(1 for item in self.queue if item["user"] == user)
+        turns_taken = dict(self._get_turns_taken()) if self._get_turns_taken else {}
+        now_playing = self._get_now_playing_user() if self._get_now_playing_user else None
+        if now_playing:
+            # History cannot count this one until it ends.
+            singer = now_playing.lower()
+            turns_taken[singer] = turns_taken.get(singer, 0) + 1
 
-        # Find position after the last song in "round N" where N = user_song_count
-        # Round 0 = first song from each user, Round 1 = second song, etc.
-        target_round = user_song_count
-        songs_seen_per_user: dict[str, int] = {}
+        current_round = max(max(turns_taken.values(), default=0) - 1, 0)
+        next_round = {singer: max(turns, current_round) for singer, turns in turns_taken.items()}
 
-        for idx, item in enumerate(self.queue):
-            queue_user = item["user"]
-            songs_seen_per_user[queue_user] = songs_seen_per_user.get(queue_user, 0) + 1
-            # This song is in round (count - 1) for its user
-            song_round = songs_seen_per_user[queue_user] - 1
-            if song_round == target_round:
-                # Found a song in the target round, insert after it
-                # Keep scanning to find the LAST song in this round
-                pass
-            elif song_round > target_round:
-                # We've moved past target round, insert here
-                return idx
+        rounds: list[int] = []
+        for item in self.queue:
+            singer = item["user"].lower()
+            round_number = next_round.get(singer, current_round)
+            next_round[singer] = round_number + 1
+            rounds.append(round_number)
 
-        # All songs are in rounds <= target_round, append to end
+        target = next_round.get(user.lower(), current_round)
+        for index, round_number in enumerate(rounds):
+            if round_number > target:
+                return index
         return len(self.queue)
 
     def enqueue(

--- a/pikaraoke/lib/queue_manager.py
+++ b/pikaraoke/lib/queue_manager.py
@@ -90,18 +90,23 @@ class QueueManager:
             turns_taken[singer] = turns_taken.get(singer, 0) + 1
 
         current_round = max(max(turns_taken.values(), default=0) - 1, 0)
-        next_round = {singer: max(turns, current_round) for singer, turns in turns_taken.items()}
+        # Ranked on the round first, then on turns sung, so that within one round
+        # the singer who has had least goes first. Taking a turn settles the debt
+        # whatever it was, which is what holds catching up to a single song.
+        ranks = {
+            singer: (max(turns, current_round), turns) for singer, turns in turns_taken.items()
+        }
 
-        rounds: list[int] = []
+        placed: list[tuple[int, int]] = []
         for item in self.queue:
             singer = item["user"].lower()
-            round_number = next_round.get(singer, current_round)
-            next_round[singer] = round_number + 1
-            rounds.append(round_number)
+            round_number, turns = ranks.get(singer, (current_round, 0))
+            ranks[singer] = (round_number + 1, round_number + 1)
+            placed.append((round_number, turns))
 
-        target = next_round.get(user.lower(), current_round)
-        for index, round_number in enumerate(rounds):
-            if round_number > target:
+        target = ranks.get(user.lower(), (current_round, 0))
+        for index, rank in enumerate(placed):
+            if rank > target:
                 return index
         return len(self.queue)
 

--- a/pikaraoke/lib/queue_manager.py
+++ b/pikaraoke/lib/queue_manager.py
@@ -15,6 +15,10 @@ from flask_babel import _
 from pikaraoke.lib.events import EventSystem
 from pikaraoke.lib.preference_manager import PreferenceManager
 
+# Names the system queues under when no singer asked for the song, so they are
+# exempt from per-singer limits and hold no turn in the fair queue.
+_PLACEHOLDER_SINGERS = frozenset({"pikaraoke", "randomizer"})
+
 
 class QueueManager:
     """Manages the song queue: enqueueing, editing, reordering, and fair queue logic."""
@@ -43,7 +47,7 @@ class QueueManager:
     def is_user_limited(self, user: str) -> bool:
         """Check if a user has reached their queue limit."""
         limit = self._preferences.get_or_default("limit_user_songs_by")
-        if limit == 0 or user in ("Pikaraoke", "Randomizer"):
+        if limit == 0 or user.lower() in _PLACEHOLDER_SINGERS:
             return False
 
         now_playing_user = self._get_now_playing_user() if self._get_now_playing_user else None
@@ -74,9 +78,12 @@ class QueueManager:
         round that just played, or a singer arriving at midnight would claim
         every round the room got through before they walked in.
         """
-        turns_taken = dict(self._get_turns_taken()) if self._get_turns_taken else {}
+        history = self._get_turns_taken() if self._get_turns_taken else {}
+        turns_taken = {
+            singer: turns for singer, turns in history.items() if singer not in _PLACEHOLDER_SINGERS
+        }
         now_playing = self._get_now_playing_user() if self._get_now_playing_user else None
-        if now_playing:
+        if now_playing and now_playing.lower() not in _PLACEHOLDER_SINGERS:
             # History cannot count this one until it ends.
             singer = now_playing.lower()
             turns_taken[singer] = turns_taken.get(singer, 0) + 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,11 +160,17 @@ class MockSoundManager:
 class MockPlayHistory:
     """Minimal mock of PlayHistoryManager, which needs a database in the real thing."""
 
-    def __init__(self, session=None):
+    def __init__(self, session=None, turns_taken=None):
         self.session = session
+        # {lower-case name: songs sung tonight}, for staging a session already
+        # under way.
+        self.turns_taken = turns_taken or {}
 
     def get_current_session(self) -> dict | None:
         return self.session
+
+    def get_turns_taken(self) -> dict[str, int]:
+        return self.turns_taken
 
     def get_current_session_name(self) -> str | None:
         return self.session["name"] if self.session else None
@@ -225,6 +231,7 @@ class MockKaraoke:
             get_now_playing_user=lambda: self.playback_controller.now_playing_user,
             filename_from_path=SongManager.filename_from_path,
             get_available_songs=lambda: self.song_manager.songs,
+            get_turns_taken=lambda: self.play_history.get_turns_taken(),
         )
 
     @property

--- a/tests/unit/test_karaoke_queue.py
+++ b/tests/unit/test_karaoke_queue.py
@@ -433,3 +433,27 @@ class TestFairQueuePosition:
         users = [item["user"] for item in qm.queue]
         # UserC has sung nothing, but the three rounds they missed are gone.
         assert users == ["UserB", "UserC", "UserC"]
+
+    def test_fair_queue_ignores_songs_the_system_queued(self, mock_karaoke):
+        """Filler nobody asked for holds no turn, so it cannot flatten the rounds."""
+        qm = mock_karaoke.queue_manager
+        mock_karaoke.play_history.turns_taken = {"randomizer": 6, "usera": 2}
+
+        qm.enqueue("/songs/a3---a03.mp4", "UserA")
+        qm.enqueue("/songs/b1---b01.mp4", "UserB")
+
+        users = [item["user"] for item in qm.queue]
+        # UserB has sung nothing tonight, so six rounds of filler cannot demote them.
+        assert users == ["UserB", "UserA"]
+
+    def test_fair_queue_ignores_filler_on_screen(self, mock_karaoke):
+        """A random song at the microphone is nobody's turn either."""
+        qm = mock_karaoke.queue_manager
+        mock_karaoke.play_history.turns_taken = {"randomizer": 1, "usera": 1}
+        mock_karaoke.playback_controller.now_playing_user = "Randomizer"
+
+        qm.enqueue("/songs/a2---a02.mp4", "UserA")
+        qm.enqueue("/songs/b1---b01.mp4", "UserB")
+
+        users = [item["user"] for item in qm.queue]
+        assert users == ["UserB", "UserA"]

--- a/tests/unit/test_karaoke_queue.py
+++ b/tests/unit/test_karaoke_queue.py
@@ -439,8 +439,22 @@ class TestFairQueuePosition:
         qm.enqueue("/songs/c2---c02.mp4", "UserC")
 
         users = [item["user"] for item in qm.queue]
-        # UserC has sung nothing, but the three rounds they missed are gone.
-        assert users == ["UserB", "UserC", "UserC"]
+        # UserC has sung nothing, so they lead the round, but the three rounds
+        # they missed are gone: the second song waits its turn behind UserB.
+        assert users == ["UserC", "UserB", "UserC"]
+
+    def test_fair_queue_ranks_the_under_served_first(self, mock_karaoke):
+        """Within the round in progress, fewest turns sung goes first."""
+        qm = mock_karaoke.queue_manager
+        mock_karaoke.play_history.turns_taken = {"usera": 5, "userb": 3, "userc": 1}
+
+        qm.enqueue("/songs/a6---a06.mp4", "UserA")
+        qm.enqueue("/songs/b4---b04.mp4", "UserB")
+        qm.enqueue("/songs/c2---c02.mp4", "UserC")
+
+        users = [item["user"] for item in qm.queue]
+        # The cap holds them all to one round; it no longer levels them inside it.
+        assert users == ["UserC", "UserB", "UserA"]
 
     def test_fair_queue_ignores_songs_the_system_queued(self, mock_karaoke):
         """Filler nobody asked for holds no turn, so it cannot flatten the rounds."""

--- a/tests/unit/test_karaoke_queue.py
+++ b/tests/unit/test_karaoke_queue.py
@@ -383,3 +383,53 @@ class TestFairQueuePosition:
 
         # add_to_front should still put song at position 0
         assert mock_karaoke.queue_manager.queue[0]["file"] == "/songs/a2---a02.mp4"
+
+    def test_fair_queue_counts_the_song_on_screen(self, mock_karaoke):
+        """The singer at the microphone has had their turn for this round."""
+        qm = mock_karaoke.queue_manager
+        for index in range(1, 6):
+            qm.enqueue(f"/songs/a{index}---a0{index}.mp4", "UserA")
+        # UserA's first song leaves the queue for the screen.
+        qm.pop_next()
+        mock_karaoke.playback_controller.now_playing_user = "UserA"
+
+        qm.enqueue("/songs/b1---b01.mp4", "UserB")
+        qm.enqueue("/songs/c1---c01.mp4", "UserC")
+
+        users = [item["user"] for item in qm.queue]
+        # Both newcomers sing before UserA's second, not after it.
+        assert users == ["UserB", "UserC", "UserA", "UserA", "UserA", "UserA"]
+
+    def test_fair_queue_counts_songs_already_sung(self, mock_karaoke):
+        """Turns carry across an empty queue, where position alone forgets them."""
+        mock_karaoke.play_history.turns_taken = {"usera": 2}
+
+        mock_karaoke.queue_manager.enqueue("/songs/a3---a03.mp4", "UserA")
+        mock_karaoke.queue_manager.enqueue("/songs/b1---b01.mp4", "UserB")
+
+        users = [item["user"] for item in mock_karaoke.queue_manager.queue]
+        assert users == ["UserB", "UserA"]
+
+    def test_fair_queue_matches_singers_case_insensitively(self, mock_karaoke):
+        """History keys on a folded name, so the queue has to look one up the same way."""
+        mock_karaoke.play_history.turns_taken = {"usera": 2}
+
+        mock_karaoke.queue_manager.enqueue("/songs/a3---a03.mp4", "usera")
+        mock_karaoke.queue_manager.enqueue("/songs/b1---b01.mp4", "UserB")
+
+        users = [item["user"] for item in mock_karaoke.queue_manager.queue]
+        assert users == ["UserB", "usera"]
+
+    def test_fair_queue_latecomer_cannot_claim_missed_rounds(self, mock_karaoke):
+        """Somebody walking in at midnight joins the round in progress."""
+        qm = mock_karaoke.queue_manager
+        mock_karaoke.play_history.turns_taken = {"usera": 3, "userb": 3}
+        mock_karaoke.playback_controller.now_playing_user = "UserA"
+        qm.enqueue("/songs/b4---b04.mp4", "UserB")
+
+        qm.enqueue("/songs/c1---c01.mp4", "UserC")
+        qm.enqueue("/songs/c2---c02.mp4", "UserC")
+
+        users = [item["user"] for item in qm.queue]
+        # UserC has sung nothing, but the three rounds they missed are gone.
+        assert users == ["UserB", "UserC", "UserC"]

--- a/tests/unit/test_karaoke_queue.py
+++ b/tests/unit/test_karaoke_queue.py
@@ -310,6 +310,14 @@ class TestIsUserLimited:
 
         assert mock_karaoke.queue_manager.is_user_limited("User1") is True
 
+    def test_is_user_limited_matches_names_case_insensitively(self, mock_karaoke):
+        """One singer typing a different capitalisation is still the same singer."""
+        mock_karaoke.preferences.set("limit_user_songs_by", 2)
+        mock_karaoke.playback_controller.now_playing_user = "USER1"
+        mock_karaoke.queue_manager.enqueue("/songs/song1---abc.mp4", "user1")
+
+        assert mock_karaoke.queue_manager.is_user_limited("User1") is True
+
 
 class TestFairQueuePosition:
     """Tests for round-robin fair queue insertion."""

--- a/tests/unit/test_play_history_manager.py
+++ b/tests/unit/test_play_history_manager.py
@@ -665,6 +665,49 @@ class TestGetSingers:
         assert [s["performer"] for s in history.get_singers(first, limit=5)] == ["Alice"]
 
 
+class TestGetTurnsTaken:
+    def test_empty_when_nothing_played(self, history):
+        assert history.get_turns_taken() == {}
+
+    def test_counts_songs_sung_through(self, history, sing, song_id):
+        sing(song_id, None, "Alice", "A Song")
+        sing(song_id, None, "Alice", "A Song")
+        sing(song_id, None, "Bob", "A Song")
+
+        assert history.get_turns_taken() == {"alice": 2, "bob": 1}
+
+    def test_excludes_skipped_songs(self, history, events, sing, song_id):
+        sing(song_id, None, "Alice", "A Song")
+        history.record_play(song_id, None, "Alice", "A Song")
+        events.emit("song_ended", "skip")
+
+        assert history.get_turns_taken() == {"alice": 1}
+
+    def test_excludes_the_song_still_playing(self, history, song_id):
+        history.record_play(song_id, None, "Alice", "A Song")
+
+        assert history.get_turns_taken() == {}
+
+    def test_folds_casing_variants_into_one_singer(self, history, sing, song_id):
+        sing(song_id, None, "Mike", "A Song")
+        sing(song_id, None, "mike", "A Song")
+
+        assert history.get_turns_taken() == {"mike": 2}
+
+    def test_scoped_to_the_active_session(self, history, sing, song_id):
+        sing(song_id, None, "Alice", "A Song")
+        history.start_session("Tonight")
+        sing(song_id, None, "Bob", "A Song")
+
+        assert history.get_turns_taken() == {"bob": 1}
+
+    def test_empty_when_no_session_is_open(self, history, sing, song_id):
+        sing(song_id, None, "Alice", "A Song")
+        history.end_session()
+
+        assert history.get_turns_taken() == {}
+
+
 class TestGetTopSongs:
     def test_empty_when_nothing_played(self, history):
         assert history.get_top_songs() == []


### PR DESCRIPTION
## Fair queue: rank by turns taken, not queue position

Closes #870

The round-robin position was worked out from what each singer had left in the queue, so any turn already consumed was invisible to it. The song on screen has left the queue, which is why a newcomer's first song landed *behind* the second song of the singer at the microphone. The same blind spot has a larger form: when the queue drains, everyone resets to equal no matter who has sung eight songs.

Rounds are now ranked by how many songs each singer has sung tonight, read from play history:

- **Skipped songs are not turns.** A song pulled after ten seconds keeps the singer's place rather than sending them to the back for something they never sang.
- **The song on screen counts**, taken from the now-playing state — its play row stays unresolved until the song ends, so the two sources can't double-count it.
- **Catching up is capped at the round that just played.** An under-served singer always goes ahead of a well-served one, but the head start is one round. Without the cap, someone arriving at midnight with no turns would claim every round the room got through before they walked in.

Scoped to the active session: a name that sang ten songs last Friday walks in tonight owing nothing.

The issue also suggests replacing rounds with a spreading algorithm on the grounds that it would encourage batch queuing. That is left out deliberately — rewarding whoever queues most aggressively runs against what the setting is for, and the starvation it targets is the latecomer case, which the cap already covers.

### Test plan

With **Fair queue** enabled:

- [x] A queues five songs; while A's first plays, B then C each queue one. Order becomes A1, B1, C1, A2 — not A1, A2, B1.
- [x] A sings two songs and the queue empties. A and B both queue one: B's plays first.
- [x] Skip B's song a few seconds in. B queues again and keeps their place instead of dropping behind.
- [x] After several rounds, a new singer queues three songs: they get one turn at the front, then interleave normally.
- [x] Turn fair queue off: songs append in the order they were added, as before.
