### PR TITLE
chore: update translations

### DIFF
--- a/build_scripts/update_translations.py
+++ b/build_scripts/update_translations.py
@@ -124,10 +124,12 @@ def prune_obsolete() -> None:
 
 
 # Matches printf-style placeholders: %s, %d, %(name)s, %(name)d, etc.
-# Also matches HTML tags: <b>, </b>, <a href="...">, etc.
+# Also matches HTML tags, and the {token} placeholders that Jinja and JS swap out with
+# str.replace() at the call site -- a translated token breaks that substitution silently.
 _PLACEHOLDER_RE = re.compile(
     r"%(?:\([^)]+\))?[sdifFeEgGcrboxXn%]"  # printf: %s, %d, %(name)s, %%
     r"|<[^>]+>"  # HTML tags
+    r"|\{[a-z_]+\}"  # {token} substituted at the call site
 )
 
 

--- a/build_scripts/update_translations.py
+++ b/build_scripts/update_translations.py
@@ -19,6 +19,12 @@ from pathlib import Path
 
 import polib
 from deep_translator import GoogleTranslator
+from deep_translator.exceptions import (
+    RequestError,
+    ServerException,
+    TooManyRequests,
+    TranslationNotFound,
+)
 
 from pikaraoke.constants import LANGUAGES
 
@@ -57,6 +63,11 @@ AUTO_TRANSLATED_COMMENT = "auto-translated"
 
 # Rate limiting: seconds between Google Translate requests
 REQUEST_DELAY = 0.5
+
+# Roughly one request in twenty comes back empty or refused. Retrying costs a couple of
+# seconds; not retrying leaves the string English in one locale, which review rarely catches.
+RETRY_DELAY = 2.0
+TRANSIENT_ERRORS = (TranslationNotFound, RequestError, TooManyRequests, ServerException)
 
 
 def run_pybabel(args: list[str]) -> None:
@@ -162,6 +173,21 @@ def _validate_placeholders(source: str, translated: str) -> bool:
     return all(translated_counts[ph] >= count for ph, count in source_counts.items())
 
 
+def _translate_once(text: str, translator: GoogleTranslator) -> str:
+    """Translate one string, giving a transient failure a second chance.
+
+    Permanent errors (an unsupported language, an over-long payload) are left to propagate:
+    a second identical request would fail identically.
+    """
+    try:
+        result = translator.translate(text)
+    except TRANSIENT_ERRORS:
+        time.sleep(RETRY_DELAY)
+        result = translator.translate(text)
+    time.sleep(REQUEST_DELAY)
+    return result
+
+
 def translate_entry(entry: polib.POEntry, translator: GoogleTranslator) -> str | None:
     """Translate a single PO entry. Returns translated text or None on failure."""
     source = entry.msgid
@@ -169,8 +195,7 @@ def translate_entry(entry: polib.POEntry, translator: GoogleTranslator) -> str |
         return None
     try:
         protected, tokens = _protect_placeholders(source)
-        raw = translator.translate(protected)
-        time.sleep(REQUEST_DELAY)
+        raw = _translate_once(protected, translator)
         translated = _restore_placeholders(raw, tokens)
 
         if not _validate_placeholders(source, translated):

--- a/pikaraoke/messages.pot
+++ b/pikaraoke/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,100 +19,100 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr ""
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr ""
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr ""
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr ""
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr ""
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr ""
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr ""
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr ""
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr ""
 
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr ""
 
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr ""
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr ""
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr ""
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr ""
 
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr ""
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr ""
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr ""
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr ""
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr ""
 
@@ -142,16 +142,16 @@ msgid "Song added to the queue: %s"
 msgstr ""
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr ""
 
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr ""
 
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr ""
 
@@ -244,53 +244,80 @@ msgstr ""
 msgid "Error: No filename parameters were specified!"
 msgstr ""
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr ""
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
 msgstr ""
 
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr ""
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
 msgstr ""
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr ""
 
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
 msgstr ""
 
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr ""
+
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr ""
+
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or "
+"deleted from another device."
+msgstr ""
+
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr ""
+
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
 msgstr ""
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr ""
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr ""
 
@@ -368,6 +395,62 @@ msgstr ""
 msgid "Error deleting from queue"
 msgstr ""
 
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr ""
+
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr ""
+
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr ""
+
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr ""
+
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr ""
+
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr ""
+
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr ""
+
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr ""
+
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr ""
+
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr ""
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr ""
@@ -432,49 +515,53 @@ msgstr ""
 msgid "Failed to stream subtitle: "
 msgstr ""
 
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+" show up on queued songs. Current: {name}"
 msgstr ""
 
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
+#. Confirmation dialog when removing a song from the queue. {title} is replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
 msgstr ""
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr ""
 
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
 msgstr ""
 
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
 msgstr ""
 
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr ""
 
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used"
 " in classical Western music, equal to a twelfth of an octave or half a "
@@ -483,39 +570,62 @@ msgstr ""
 
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
 
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr ""
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
 
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr ""
+
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr ""
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr ""
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr ""
+
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr ""
+
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr ""
+
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
 msgstr ""
 
 #. Message about the wait for loading the songs
@@ -546,7 +656,8 @@ msgid ""
 msgstr ""
 
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr ""
 
@@ -555,79 +666,180 @@ msgstr ""
 msgid "Loading songs..."
 msgstr ""
 
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr ""
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr ""
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
 msgstr ""
 
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
 msgstr ""
 
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
 msgstr ""
 
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
 msgstr ""
 
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr ""
+
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr ""
+
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
 msgstr ""
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr ""
 
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr ""
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr ""
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
+#. Button to open the batch song renamer page.
+#: templates/files.html:218
+msgid "Bulk rename"
 msgstr ""
 
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
 msgstr ""
 
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr ""
+
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr ""
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr ""
+
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr ""
+
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
 msgstr ""
 
 #. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
+#: templates/files.html:457
+msgid "Sort Alphabetically"
 msgstr ""
 
-#. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
+#. Button which changes how the songs are sorted so they become sorted by date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr ""
+
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr ""
+
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr ""
+
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr ""
+
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr ""
+
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr ""
+
+#: templates/history.html:182 templates/queue.html:164 templates/queue.html:326
+#: templates/sessions.html:153
+msgid "Options"
+msgstr ""
+
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr ""
+
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr ""
+
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr ""
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr ""
+
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr ""
+
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
 msgstr ""
 
 #. Message which shows in the "Now Playing" section when there is no song
@@ -654,42 +866,46 @@ msgid ""
 msgstr ""
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr ""
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr ""
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr ""
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr ""
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr ""
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr ""
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr ""
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
+msgstr ""
+
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
 msgstr ""
 
 #. Confirmation text whe the user selects quit.
@@ -723,315 +939,462 @@ msgstr ""
 
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr ""
+
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr ""
+
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr ""
+
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr ""
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr ""
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr ""
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr ""
 
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr ""
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr ""
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr ""
 
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr ""
 
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr ""
 
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr ""
 
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr ""
 
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr ""
 
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr ""
+
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr ""
+
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr ""
+
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr ""
+
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr ""
+
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr ""
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr ""
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr ""
 
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr ""
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr ""
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr ""
 
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr ""
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
+msgstr ""
+
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr ""
+
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
 msgstr ""
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr ""
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr ""
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set"
 " to 0 to disable it."
 msgstr ""
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr ""
 
+#: templates/info.html:547
+msgid "Audio"
+msgstr ""
+
+#: templates/info.html:555
+msgid "Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+
+#: templates/info.html:563
+msgid "Latency"
+msgstr ""
+
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr ""
+
+#: templates/info.html:573
+msgid "Experimental"
+msgstr ""
+
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr ""
+
+#: templates/info.html:582
+msgid "Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr ""
+
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr ""
+
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr ""
 
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr ""
 
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr ""
 
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr ""
 
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr ""
 
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr ""
 
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr ""
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr ""
 
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr ""
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr ""
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr ""
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr ""
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
 " usage)"
 msgstr ""
 
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke"
+" Version HD\")"
+msgstr ""
+
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before "
 "sending it to the splash screen. "
 msgstr ""
 
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr ""
+
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate "
+"(macOS)."
+msgstr ""
+
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr ""
+
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr ""
+
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr ""
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr ""
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr ""
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr ""
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr ""
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr ""
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr ""
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr ""
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr ""
 
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr ""
 
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr ""
 
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr ""
 
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr ""
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr ""
 
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr ""
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
@@ -1043,13 +1406,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr ""
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
 "* This update link above may fail if you don't have proper file "
 "permissions.\n"
@@ -1057,19 +1420,19 @@ msgid ""
 msgstr ""
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr ""
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr ""
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card "
 "is larger than 4GB,\n"
@@ -1079,23 +1442,23 @@ msgid ""
 msgstr ""
 
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr ""
 
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr ""
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr ""
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1103,179 +1466,229 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr ""
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr ""
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr ""
 
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
 msgstr ""
 
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr ""
+
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr ""
+
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr ""
+
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr ""
+
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr ""
 
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr ""
+
+#: templates/queue.html:219
 msgid "Queued"
 msgstr ""
 
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr ""
 
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr ""
 
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr ""
+
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr ""
 
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr ""
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr ""
 
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr ""
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr ""
 
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> random songs"
 msgstr ""
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr ""
 
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr ""
 
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr ""
 
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr ""
 
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr ""
 
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr ""
 
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr ""
+
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr ""
 
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr ""
 
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr ""
 
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr ""
 
-#: templates/search.html:242
-msgid "Available songs in local library"
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
 msgstr ""
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
 msgstr ""
 
-#: templates/search.html:584
-msgid "Available Songs"
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
 msgstr ""
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
 msgstr ""
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
 msgstr ""
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
 msgstr ""
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
 msgstr ""
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr ""
+
+#. Subtitle under the Add New heading, explaining that this page gets songs the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr ""
+
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr ""
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
 msgstr ""
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
+msgstr ""
+
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
 msgstr ""
 
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
 msgstr ""
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr ""
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
 msgstr ""
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1283,40 +1696,183 @@ msgid ""
 msgstr ""
 
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 msgstr ""
 
-#: templates/splash.html:23
-msgid "Connection lost. Is the server still running?"
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to"
+" watch it."
+msgstr ""
+
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr ""
+
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr ""
+
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr ""
+
+#. Menu item which names the auto-started session that is recording now, making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr ""
+
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr ""
+
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This"
+" cannot be undone."
+msgstr ""
+
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr ""
+
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr ""
+
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid "Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr ""
+
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr ""
+
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr ""
+
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr ""
+
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr ""
+
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr ""
+
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr ""
+
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr ""
+
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr ""
+
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr ""
+
+#. Menu item which makes an old session the one new songs are recorded against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr ""
+
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr ""
+
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr ""
+
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr ""
+
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
 msgstr ""
 
 #: templates/splash.html:24
+msgid "Connection lost. Is the server still running?"
+msgstr ""
+
+#: templates/splash.html:25
 msgid ""
 "This browser is not fully supported. You may experience streaming issues."
 " Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr ""
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr ""
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr ""
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
 "      with the page once before it allows autoplay of videos. Pikaraoke "
@@ -1326,7 +1882,7 @@ msgid ""
 msgstr ""
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr ""
 

--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -109,7 +109,7 @@
             // Get the current name from the cookie dynamically
             let currentName = Cookies.get("user");
             var promptMsg = (window.translations && window.translations.promptChangeUsername)
-                ? window.translations.promptChangeUsername.replace('CURRENT_NAME', currentName)
+                ? window.translations.promptChangeUsername.replace('{name}', currentName)
                 : "Do you want to change the name of the person using this device? This will show up on queued songs. Current: " + currentName;
             let name = window.prompt(promptMsg);
             // Only update if user clicked OK and entered a non-empty name
@@ -163,7 +163,7 @@
         $(document).on('click', '.confirm-delete', function(e) {
             e.preventDefault();
             var msg = (window.translations && window.translations.confirmDeleteFromQueue)
-                ? window.translations.confirmDeleteFromQueue.replace('SONG_TITLE', this.title)
+                ? window.translations.confirmDeleteFromQueue.replace('{title}', this.title)
                 : `Are you sure you want to delete "${this.title}" from the queue?`;
             if (window.confirm(msg)) {
                 $.get(this.href);

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -29,18 +29,18 @@
     // translation must therefore be filtered by hand: |tojson for a JS value (as below),
     // |forceescape for HTML that JS builds as a string. See tests/unit/test_template_i18n.py.
     window.translations = {
-      // {# MSG: Prompt to change the username displayed next to queued songs. CURRENT_NAME is replaced with the name #}
-      promptChangeUsername: {{ _('Do you want to change the name of the person using this device? This will show up on queued songs. Current: CURRENT_NAME') | tojson }},
+      // {# MSG: Prompt to change the username displayed next to queued songs. {name} is replaced with the name #}
+      promptChangeUsername: {{ _('Do you want to change the name of the person using this device? This will show up on queued songs. Current: {name}') | tojson }},
       // {# MSG: Confirmation prompt to clear entire queue. User must type ok to confirm #}
       promptClearQueue: {{ _('Are you sure you want to clear the ENTIRE queue? Type ok to continue') | tojson }},
-      // {# MSG: Confirmation dialog when removing a song from the queue. SONG_TITLE is replaced with the title #}
-      confirmDeleteFromQueue: {{ _('Are you sure you want to delete SONG_TITLE from the queue?') | tojson }},
+      // {# MSG: Confirmation dialog when removing a song from the queue. {title} is replaced with the title #}
+      confirmDeleteFromQueue: {{ _('Are you sure you want to delete {title} from the queue?') | tojson }},
       // {# MSG: Confirmation dialog when permanently deleting a song file from the library #}
       confirmDeleteFromLibrary: {{ _("Are you sure you want to delete this song from the library?") | tojson }},
-      // {# MSG: Label showing the number of semitones for pitch shift. SEMITONE_VALUE is replaced with a number like +3 or -2. #}
-      semitonesLabel: {{ _("SEMITONE_VALUE semitones") | tojson }},
-      // {# MSG: Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is replaced with a label like "+3 semitones". #}
-      confirmTranspose: {{ _("Transpose this song: SEMITONE_LABEL?") | tojson }},
+      // {# MSG: Label showing the number of semitones for pitch shift. {value} is replaced with a number like +3 or -2. #}
+      semitonesLabel: {{ _("{value} semitones") | tojson }},
+      // {# MSG: Confirmation dialog when changing the key/pitch of a song. {label} is replaced with a label like "+3 semitones". #}
+      confirmTranspose: {{ _("Transpose this song: {label}?") | tojson }},
       // {# MSG: Confirmation dialog when restarting the currently playing track. #}
       confirmRestartTrack: {{ _("Are you sure you want to restart this track?") | tojson }},
       // {# MSG: Informational tooltip explaining what a semitone is. #}
@@ -62,7 +62,7 @@
 
     function getSemitonesLabel(value) {
       var display = value > 0 ? "+" + value : String(value);
-      return window.translations.semitonesLabel.replace("SEMITONE_VALUE", display);
+      return window.translations.semitonesLabel.replace("{value}", display);
     }
 
     function isEqual(obj1, obj2) {
@@ -140,8 +140,8 @@
     // Gettext output is Markup, which Jinja never autoescapes, so an apostrophe
     // in a translation would close this string literal. See
     // tests/unit/test_template_i18n.py.
-    // {# MSG: Accessible label for the banner naming the karaoke session in progress. SESSION_NAME is replaced with the session's name. #}
-    var sessionRibbonLabel = {{ _('Current session: SESSION_NAME') | tojson }};
+    // {# MSG: Accessible label for the banner naming the karaoke session in progress. {name} is replaced with the session's name. #}
+    var sessionRibbonLabel = {{ _('Current session: {name}') | tojson }};
 
     // Shows the banner naming the session in progress, or hides it when there
     // is none. A nameless auto-started session counts as none: the ribbon has
@@ -155,7 +155,7 @@
       $ribbon.toggleClass("is-hidden", !text);
       $ribbon.find(".session-ribbon-text").text(text);
       $ribbon.attr("title", text);
-      $ribbon.attr("aria-label", sessionRibbonLabel.replace("SESSION_NAME", text));
+      $ribbon.attr("aria-label", sessionRibbonLabel.replace("{name}", text));
     }
 
     // The ribbon sits on every page and outlives SPA navigation, so ending a
@@ -409,8 +409,8 @@
        state it starts in. An auto-started session has no name and so shows no
        ribbon. #}
     <div class="session-ribbon{% if not session_name %} is-hidden{% endif %}" id="session-ribbon"
-      {# MSG: Accessible label for the banner naming the karaoke session in progress. SESSION_NAME is replaced with the session's name. #}
-      aria-label="{{ _('Current session: SESSION_NAME').replace('SESSION_NAME', session_name) }}"
+      {# MSG: Accessible label for the banner naming the karaoke session in progress. {name} is replaced with the session's name. #}
+      aria-label="{{ _('Current session: {name}').replace('{name}', session_name) }}"
       title="{{ session_name }}">
       <span class="session-ribbon-dot" aria-hidden="true"></span>
       <span class="session-ribbon-text">{{ session_name }}</span>

--- a/pikaraoke/templates/home.html
+++ b/pikaraoke/templates/home.html
@@ -100,7 +100,7 @@
 			} else {
 				value = 0;
 			}
-			r = confirm(window.translations.confirmTranspose.replace("SEMITONE_LABEL", getSemitonesLabel(value)));
+			r = confirm(window.translations.confirmTranspose.replace("{label}", getSemitonesLabel(value)));
 			if (r) {
 				$.get(window.pikaraokeConfig.basePath + "/transpose/" + value);
 			}

--- a/pikaraoke/templates/partials/pager.html
+++ b/pikaraoke/templates/partials/pager.html
@@ -34,9 +34,9 @@
 	{{ _end(_('Next page'), 'right-big', page_href | replace('PAGENUMBER', page + 1), end < total) }}
 	{# Tokens rather than Jinja placeholders, because renderPager() below substitutes
 	   the same string client-side and shares this one msgid. #}
-	{# MSG: Pagination summary. START, END and TOTAL are replaced with numbers, reading for example "1-100 of 2000". #}
+	{# MSG: Pagination summary. {start}, {end} and {total} are replaced with numbers, reading for example "1-100 of 2000". #}
 	<span class="is-size-7">
-		{{- _('START-END of TOTAL') | replace('START', start) | replace('END', end) | replace('TOTAL', total) -}}
+		{{- _('{start}-{end} of {total}') | replace('{start}', start) | replace('{end}', end) | replace('{total}', total) -}}
 	</span>
 	{% if size_options %}
 	<span class="is-flex-grow-1"></span>
@@ -78,15 +78,15 @@
 	// translation would close the JS string literal and break this whole script.
 	// |tojson emits the literal instead. See tests/unit/test_template_i18n.py.
 	var pagerText = {
-		// {# MSG: Pagination summary. START, END and TOTAL are replaced with numbers, reading for example "1-100 of 2000". #}
-		showing: {{ _('START-END of TOTAL') | tojson }}
+		// {# MSG: Pagination summary. {start}, {end} and {total} are replaced with numbers, reading for example "1-100 of 2000". #}
+		showing: {{ _('{start}-{end} of {total}') | tojson }}
 	};
 
 	function renderPager(prefix, page, total) {
 		var start = total ? page.offset + 1 : 0;
 		var end = Math.min(page.offset + page.limit, total);
 		$("#" + prefix + "-page-info").text(
-			pagerText.showing.replace("START", start).replace("END", end).replace("TOTAL", total)
+			pagerText.showing.replace("{start}", start).replace("{end}", end).replace("{total}", total)
 		);
 		$("#" + prefix + "-prev").prop("disabled", page.offset === 0);
 		$("#" + prefix + "-next").prop("disabled", end >= total);

--- a/pikaraoke/templates/partials/session_filter.html
+++ b/pikaraoke/templates/partials/session_filter.html
@@ -17,9 +17,9 @@
 			{# MSG: Dropdown option covering every karaoke session ever recorded. #}
 			<option value="">{% trans %}All sessions{% endtrans %}</option>
 			{% for s in sessions %}
-			{# MSG: Label for a session the host never named. NUMBER is replaced with a number. #}
+			{# MSG: Label for a session the host never named. {number} is replaced with a number. #}
 			<option value="{{ s.uuid }}" {% if s.uuid == selected_session %}selected{% endif %}>
-				{{ s.name or _('Session NUMBER') | replace('NUMBER', s.id) }}
+				{{ s.name or _('Session {number}') | replace('{number}', s.id) }}
 			</option>
 			{% endfor %}
 		</select>

--- a/pikaraoke/templates/sessions.html
+++ b/pikaraoke/templates/sessions.html
@@ -33,31 +33,31 @@
 	var sessionText = {
 		// {# MSG: Shown on the sessions page when no session is currently running. #}
 		noSession: {{ _('No active session') | tojson }},
-		// {# MSG: Label for a session the host never named. NUMBER is replaced with a number. #}
-		unnamed: {{ _('Session NUMBER') | tojson }},
+		// {# MSG: Label for a session the host never named. {number} is replaced with a number. #}
+		unnamed: {{ _('Session {number}') | tojson }},
 		// {# MSG: Prompt asking the host to name a session. #}
 		promptRename: {{ _('Name this session:') | tojson }},
 		// {# MSG: Menu item which names the auto-started session that is recording now, making it the active session everyone sees. #}
 		nameToPromote: {{ _('Name to make active') | tojson }},
 		// {# MSG: Menu item which changes the name of a session that already has one. #}
 		renameSession: {{ _('Rename') | tojson }},
-		// {# MSG: Confirmation before deleting a session and every play recorded in it. SESSION is replaced with its name. #}
-		confirmDeleteSession: {{ _('Delete SESSION and all of its plays? This cannot be undone.') | tojson }},
-		// {# MSG: Confirmation before deleting every play in a session while keeping the session. SESSION is replaced with its name. #}
-		confirmClearPlays: {{ _('Delete every play recorded in SESSION? The session itself is kept. This cannot be undone.') | tojson }},
+		// {# MSG: Confirmation before deleting a session and every play recorded in it. {session} is replaced with its name. #}
+		confirmDeleteSession: {{ _('Delete {session} and all of its plays? This cannot be undone.') | tojson }},
+		// {# MSG: Confirmation before deleting every play in a session while keeping the session. {session} is replaced with its name. #}
+		confirmClearPlays: {{ _('Delete every play recorded in {session}? The session itself is kept. This cannot be undone.') | tojson }},
 		// {# MSG: Shown when no sessions have been recorded yet. #}
 		noSessions: {{ _('No sessions yet.') | tojson }},
 		// {# MSG: Shown when a session has no plays, so nobody has sung in it. #}
 		noSingers: {{ _('Nobody has sung in this session.') | tojson }},
 		// {# MSG: Confirmation before making an old session the one new songs are recorded against. #}
-		confirmActivate: {{ _('Make SESSION the active session? New songs will be recorded against it.') | tojson }}
+		confirmActivate: {{ _('Make {session} the active session? New songs will be recorded against it.') | tojson }}
 	};
 
 	// A host-started session always has a name, so only one that auto-started on
 	// the first play falls back to its number. The date is already its own
 	// column, so repeating it here only makes the label long.
 	function sessionLabel(session) {
-		return session.name || sessionText.unnamed.replace("NUMBER", session.id);
+		return session.name || sessionText.unnamed.replace("{number}", session.id);
 	}
 
 	// The play log lives on its own page, scoped by the uuid in its query string.
@@ -297,7 +297,7 @@
 		closeSessionOptions();
 
 		if (action === "activate") {
-			if (window.confirm(sessionText.confirmActivate.replace("SESSION", label))) {
+			if (window.confirm(sessionText.confirmActivate.replace("{session}", label))) {
 				putSession(uuid, { action: "activate" }).done(loadSessions);
 			}
 		} else if (action === "end") {
@@ -307,13 +307,13 @@
 			// click that names it; there is no other way to activate one.
 			renameSession(uuid, $sessionModal.data("unnamed") && !$sessionModal.data("active"));
 		} else if (action === "clear") {
-			if (window.confirm(sessionText.confirmClearPlays.replace("SESSION", label))) {
+			if (window.confirm(sessionText.confirmClearPlays.replace("{session}", label))) {
 				var params = $.param({ scope: "session", session: uuid });
 				$.ajax({ url: "{{ url_for('sessions_api.reset_history') }}?" + params, type: "DELETE" })
 					.done(loadSessions);
 			}
 		} else if (action === "delete") {
-			if (window.confirm(sessionText.confirmDeleteSession.replace("SESSION", label))) {
+			if (window.confirm(sessionText.confirmDeleteSession.replace("{session}", label))) {
 				$.ajax({ url: sessionUrl(uuid), type: "DELETE" }).done(loadSessions);
 			}
 		}

--- a/pikaraoke/translations/de_DE/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/de_DE/LC_MESSAGES/messages.po
@@ -7,118 +7,119 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-13 22:53-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: de_DE\n"
 "Language-Team: de_DE <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponieren um %s Halbtöne: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Lautstärke: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Heruntergeladen und in die Warteschlange eingereiht (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Video wird heruntergeladen: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Video wird heruntergeladen: %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Fehler beim Herunterladen des Liedes: "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Heruntergeladen und in die Warteschlange eingereiht: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Heruntergeladen: %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Fehler beim Hinzufügen des Liedes zur Warteschlange: "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Songdatei nicht gefunden: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Stream war nicht abspielbar! Titel überspringen"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "Lied endete unerwartet: %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Übersprungen: %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Fortsetzen: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pause: %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Die Einstellungen wurden erfolgreich geändert"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Etwas ist schiefgelaufen! Die Einstellungen wurden nicht geändert"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Die Einstellungen wurden erfolgreich zurückgesetzt"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
-msgstr "Etwas ist schiefgelaufen! Die Einstellungen wurden nicht zurückgesetzt"
+msgstr ""
+"Etwas ist schiefgelaufen! Die Einstellungen wurden nicht zurückgesetzt"
 
 # auto-translated
 #: lib/queue_manager.py:111
@@ -129,7 +130,8 @@ msgstr "Song befindet sich bereits in der Warteschlange: %s"
 #: lib/queue_manager.py:119
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
-msgstr "Das Limit von %s Lied(er) per Benutzer in der Warteschlange ist erreicht!"
+msgstr ""
+"Das Limit von %s Lied(er) per Benutzer in der Warteschlange ist erreicht!"
 
 #: lib/queue_manager.py:132
 #, python-format
@@ -147,18 +149,18 @@ msgid "Song added to the queue: %s"
 msgstr "Lied wurde der Warteschlange hinzugefügt: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Warteschlange leeren"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Fehler beim Auflösen der Datei: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Stream konnte nicht vorbereitet werden"
 
@@ -212,7 +214,8 @@ msgstr "Dateisystem wird erweitert und das System wird neu gestartet!"
 #. device.
 #: routes/admin.py:153
 msgid "Cannot expand fs on non-raspberry pi devices!"
-msgstr "Dateisystem kann auf Nicht-Raspberry-Pi-Geräten nicht erweitert werden!"
+msgstr ""
+"Dateisystem kann auf Nicht-Raspberry-Pi-Geräten nicht erweitert werden!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
@@ -253,61 +256,99 @@ msgstr "Batch-Song-Umbenennung"
 msgid "Error: No filename parameters were specified!"
 msgstr "Fehler: Keine Dateinamenparameter angegeben!"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr ""
 "Fehler: Dieses Lied kann nicht bearbeitet werden, da es in der aktuellen "
 "Warteschlange ist: "
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
-"Fehler beim Umbenennen der Datei: '%s' in '%s', Dateiname existiert "
-"bereits"
-
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Durchsuchen"
+"Fehler beim Umbenennen der Datei: '%s' in '%s', Dateiname existiert bereits"
 
 # auto-translated
-#: routes/files.py:126
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Lieder"
+
+# auto-translated
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Sie sind nicht berechtigt, Songs zu löschen"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
 msgstr ""
-"Fehler: Dieses Lied kann nicht gelöscht werden, da es in der aktuellen "
-"Warteschlange ist"
+"Fehler: Dieses Lied kann nicht gelöscht werden, da es sich in der "
+"Warteschlange befindet oder abgespielt wird"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Lied gelöscht: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Sie haben keine Berechtigung zum Bearbeiten von Songs"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Sie sind nicht berechtigt, Songs umzubenennen"
 
-#: routes/files.py:211
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Dieses Lied wird abgespielt. Benennen Sie es um, wenn es fertig ist."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Geben Sie einen Namen für dieses Lied ein."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Dieses Lied ist nicht mehr in der Bibliothek. Möglicherweise wurde es "
+"umbenannt oder von einem anderen Gerät gelöscht."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Fehler beim Umbenennen der Datei: '%s' in '%s', %sbereits"
+msgid "A song called '%s' already exists."
+msgstr "Ein Lied namens „%s“ existiert bereits."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Die Wiedergabe dieses Liedes begann, während Sie es bearbeiteten. Benennen "
+"Sie es um, wenn es fertig ist."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Fehler beim Umbenennen der Datei: %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Datei umbenannt: %s in %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "CPU-Nutzungsabfrage wird nicht unterstützt"
 
@@ -391,6 +432,72 @@ msgstr "Fehler beim Verschieben in der Warteschlange nach unten"
 msgid "Error deleting from queue"
 msgstr "Fehler beim Entfernen aus der Warteschlange"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Neu hinzufügen"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Sie haben keine Berechtigung, diese Seite anzuzeigen"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Ein Name ist erforderlich"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Eine Sitzung ist erforderlich"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Spiel nicht gefunden"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Sitzung nicht gefunden"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Gespielt bei"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Künstler"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Lied"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke – Spielverlauf"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Sing bloß nie wieder... niemals."
@@ -457,65 +564,68 @@ msgid "Failed to stream subtitle: "
 msgstr "Untertitel konnte nicht gestreamt werden:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"Möchten Sie den Namen der Person ändern, die dieses Gerät verwendet? Dies"
-" wird bei Songs in der Warteschlange angezeigt. Aktuell: CURRENT_NAME"
+"Möchten Sie den Namen der Person ändern, die dieses Gerät verwendet? Dies "
+"wird bei Songs in der Warteschlange angezeigt. Aktuell: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
-"Sind Sie sicher, dass Sie die GESAMTE Warteschlange löschen möchten? "
-"Geben Sie „OK“ ein, um fortzufahren"
+"Sind Sie sicher, dass Sie die GESAMTE Warteschlange löschen möchten? Geben "
+"Sie „OK“ ein, um fortzufahren"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
 msgstr ""
-"Sind Sie sicher, dass Sie SONG_TITLE aus der Warteschlange löschen "
-"möchten?"
+"Sind Sie sicher, dass Sie {title} aus der Warteschlange löschen möchten?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Dieses Lied wirklich aus der Bibliothek löschen?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE Halbtöne"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} Halbtöne"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Dieses Lied transponieren: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Dieses Lied transponieren: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Möchten Sie diesen Titel wirklich neu starten?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
 "Ein Halbton wird auch als Halbton bezeichnet. Es ist das kleinste in der "
 "klassischen westlichen Musik verwendete Intervall und entspricht einer "
@@ -524,56 +634,82 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"Sind Sie sicher, dass Sie das Dateisystem erweitern möchten? Dadurch wird"
-" Ihr Raspberry Pi neu gestartet."
+"Sind Sie sicher, dass Sie das Dateisystem erweitern möchten? Dadurch wird "
+"Ihr Raspberry Pi neu gestartet."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Fehler"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
-"Bitte gib deinen Namen ein. Der Name wird neben den von dir hinzugefügten"
-" Liedern angezeigt."
+"Bitte gib deinen Namen ein. Der Name wird neben den von dir hinzugefügten "
+"Liedern angezeigt."
+
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Aktuelle Sitzung: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Startseite"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Warteschlange"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Suche"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Ranglisten"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Spielverlauf"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Sitzungen"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Einstellungen"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Der Ladevorgang kann einige Sekunden dauern, da die Songtitel online "
-"verglichen werden. Die Ladezeit kann variieren\n"
+"Der Ladevorgang kann einige Sekunden dauern, da die Songtitel online verglichen werden. Die Ladezeit kann variieren\n"
 "\tbasierend auf Ihrer Internetverbindung."
 
 # auto-translated
@@ -604,7 +740,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Alle Lieder anzeigen"
 
@@ -613,82 +750,212 @@ msgstr "Alle Lieder anzeigen"
 msgid "Loading songs..."
 msgstr "Lieder werden geladen..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr ""
+"Klicken Sie auf einen Vorschlag, um ihn als neuen Dateinamen zu verwenden."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Kein Vorschlag!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Lied bearbeiten"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Liedname bearbeiten"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Automatische Formatierung"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Künstler-/Liedreihenfolge tauschen"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Song umbenennen"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Vorschlag von Last.fm"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Aktueller Dateiname"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Neuer Dateiname"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Automatische Formatierung"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Künstler/Titel tauschen"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Von iTunes vorschlagen"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes-Suchland"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Speichern"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Stornieren"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Dieses Lied löschen"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Alphabetisch sortiert"
+# auto-translated
+#. Button to open the batch song renamer page.
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Massenumbenennung"
 
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Nach Datum sortiert"
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Verfügbar in der Bibliothek"
 
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Nach Datum sortiert"
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Alle Ordner"
 
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Suche nach Titel, Künstler..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Löschen"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Alle Lieder"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Ordner"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
 msgstr "Alphabetisch sortieren"
 
-#. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Alle Lieder bearbeiten"
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Nach Datum sortieren"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Diesen Eintrag aus dem Spielprotokoll löschen?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Es wurde noch nichts gespielt."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Gespielt"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Übersprungen"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Spielen"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Optionen"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Alle Interpreten anzeigen"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Ausblenden übersprungen"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Status"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Zur Warteschlange hinzufügen"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Dieses Lied ist nicht mehr in der Bibliothek"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Eintrag löschen"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -709,50 +976,55 @@ msgstr "Kein Lied in der Warteschlange"
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
-"Bist du sicher, dass du dieses Lied überspringen möchtest? Wenn du diesen"
-" Song nicht selbst hinzugefügt hast, frage um Erlaubnis!"
+"Bist du sicher, dass du dieses Lied überspringen möchtest? Wenn du diesen "
+"Song nicht selbst hinzugefügt hast, frage um Erlaubnis!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Jetzt läuft"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Nächstes Lied"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Player-Steuerung"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Lied neu starten"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Abspielen/Pause"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Aktuelles Lied stoppen"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Tonart ändern"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Ändern"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Mikrofone"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -788,157 +1060,295 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Keine Mikrofone erkannt. Schließen Sie ein USB- oder Bluetooth-Mikrofon an "
+"und klicken Sie auf Aktualisieren."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Scannen..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Aktualisieren"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Den gesamten Spielverlauf löschen – jede Sitzung und jedes Spiel, endgültig?"
+" Geben Sie „ok“ ein, um fortzufahren."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Spielverlauf gelöscht"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Bibliothekssynchronisierung abgeschlossen"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Information"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL von %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Praktischer URL-QR-Code, um ihn mit einem Freund zu teilen:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Admin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Administratorpasswort eingeben"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Anmelden"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Songbibliothek"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Bibliothek"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Lieder in der Bibliothek:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Jetzt synchronisieren"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Gleicht die Bibliothek mit dem Songverzeichnis im Hintergrund ab."
 
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Umbenennung"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Künstler – Titel"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Titel – Künstler"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Reihenfolge der von iTunes vorgeschlagenen Songnamen"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Den gesamten Verlauf zurücksetzen"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Löscht jede Sitzung und jedes aufgezeichnete Spiel. Dies kann nicht "
+"rückgängig gemacht werden."
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Benutzereinstellungen"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Einstellungen für den Begrüßungsbildschirm"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Hintergrundvideo deaktivieren"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Hintergrundmusik deaktivieren"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Bewertungsbildschirm nach jedem Lied deaktivieren"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Benachrichtigungen ausblenden"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Splash-Uhr anzeigen"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "URL und QR-Code ausblenden"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Blenden Sie das Logo auf dem Begrüßungsbildschirm aus"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Blenden Sie den Sitzungsnamen auf dem Begrüßungsbildschirm aus"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
-"Alle Overlays ausblenden, einschließlich 'Jetzt läuft', 'Als Nächstes' "
-"und QR-Code"
+"Alle Overlays ausblenden, einschließlich 'Jetzt läuft', 'Als Nächstes' und "
+"QR-Code"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Standardlautstärke der Videos (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Lautstärke der Hintergrundmusik (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"Inaktivzeit bis sich der Bildschirmschoner aktiviert. Zum Deaktivieren "
-"auf 0 setzen."
+"Inaktivzeit bis sich der Bildschirmschoner aktiviert. Zum Deaktivieren auf 0"
+" setzen."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Die Verzögerung in Sekunden vor dem Start des nächsten Liedes"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"Auf dem Server erkannte Mikrofone. Der Ton wird direkt an die Lautsprecher "
+"weitergeleitet."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latenz"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Echounterdrückung"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Experimental"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(reduziert Feedback, erhöht die Latenz)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Mikrofonunterstützung ist nicht verfügbar. Erforderliche Audiotools sind "
+"nicht installiert."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Unter Linux/Raspberry Pi installieren Sie es mit:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "und starten Sie PiKaraoke neu."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Bewerten Sie Phrasen"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 "Fügen Sie in jedes Feld eine Phrase pro Zeile ein und klicken Sie auf "
@@ -946,68 +1356,68 @@ msgstr ""
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Sätze mit NIEDRIGER Punktzahl (Punktzahl < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Könnte besser sein..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID-Score-Sätze (30 > Score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Das war ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Phrasen mit HOHER Punktzahl (60 < Punktzahl)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Wunderbar..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Spracheinstellungen"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Bevorzugte Sprache (Neustart erforderlich)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Servereinstellungen"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Audio-Lautstärke normalisieren"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Videos in hoher Qualität herunterladen"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1017,17 +1427,37 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
-"Aktivieren Sie die CDG-Pixelskalierung (schärfere Grafik für CDG-Dateien,"
-" kann die CPU-Auslastung erhöhen)."
+"Aktivieren Sie die CDG-Pixelskalierung (schärfere Grafik für CDG-Dateien, "
+"kann die CPU-Auslastung erhöhen)."
+
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Aktivieren Sie die automatische Bereinigung von YouTube-Titeln (entfernen "
+"Sie Füllwörter wie „Karaoke Version HD“)."
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Durchsuchen von Ordnern aktivieren (fügt der Seite „Songs“ eine "
+"Ordneransicht hinzu, wenn die Bibliothek Unterordner hat)"
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1036,258 +1466,330 @@ msgstr ""
 "(negativ = Audio vorrücken | positiv = Audio verzögern)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
-"Limit an Liedern, die ein Benutzer zur Warteschlange hinzufügen kann (0 ="
-" unbegrenzt)"
+"Limit an Liedern, die ein Benutzer zur Warteschlange hinzufügen kann (0 = "
+"unbegrenzt)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
-"Faire Warteschlange aktivieren (Round-Robin-Modus sorgt dafür, dass sich "
-"die Benutzer abwechseln)"
+"Faire Warteschlange aktivieren (Round-Robin-Modus sorgt dafür, dass sich die"
+" Benutzer abwechseln)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
 "Puffergröße in Kilobytes. Transkodiert diesen Teil des Videos, bevor es "
 "abgespielt wird."
 
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Standardlieder pro Seite."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Halten Sie den Server wach: in einem Container nicht verfügbar. Deaktivieren"
+" Sie den Ruhezustand auf dem Host."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Halten Sie den Server wach: Benötigt systemd-inhibit (Linux) oder caffeinate"
+" (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr ""
+"Halten Sie den Server wach: wird auf dieser Plattform nicht unterstützt."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Halten Sie den Server wach, während PiKaraoke läuft"
+
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Einstellungen löschen"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Systemstatistiken"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Systeminfo"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Plattform:"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "OS-Version:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp-Version:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg-Version:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke-Version:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Systemstatistiken"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Laden..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Festplattennutzung:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Erinnerung:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Aktualisierungen"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP-Update"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
 "Wenn das Herunterladen oder die Suche nicht funktionieren, wird eine "
-"Aktualisierung von yt-dlp das Problem wahrscheinlich beheben. Die aktuell"
-" installierte Version ist: \"%(youtubedl_version)s\\"
+"Aktualisierung von yt-dlp das Problem wahrscheinlich beheben. Die aktuell "
+"installierte Version ist: \"%(youtubedl_version)s\\"
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "yt-dlp aktualisieren"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
 "* Diese Aktualisierung kann ohne die nötigen Dateiberechtigungen "
 "fehlschlagen. Pikaraoke-Log auf Fehler überprüfen."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Sonstiges"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Raspberry Pi-Dateisystem erweitern"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Wenn du das vorgefertigte Pikaraoke-Pi-Image installiert hast und deine "
-"SD-Karte größer als 4GB ist, solltest du das Dateisystem erweitern, um "
-"den gesamten Speicherplatz nutzbar zu machen. Dies musst du nur einmal "
-"machen. Das System startet hierzu neu."
+"Wenn du das vorgefertigte Pikaraoke-Pi-Image installiert hast und deine SD-"
+"Karte größer als 4GB ist, solltest du das Dateisystem erweitern, um den "
+"gesamten Speicherplatz nutzbar zu machen. Dies musst du nur einmal machen. "
+"Das System startet hierzu neu."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Klicken Sie hier, um sich vom Administratormodus abzumelden."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Abmelden"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Herunterfahren"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
 msgstr ""
-"Zieh nicht einfach den Stecker! Fahr den Server immer korrekt herunter, "
-"um Datenkorruption zu vermeiden."
+"Zieh nicht einfach den Stecker! Fahr den Server immer korrekt herunter, um "
+"Datenkorruption zu vermeiden."
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Pikaraoke beenden"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "System neustarten"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "System herunterfahren"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Optionen"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Vorherige Seite"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Nächste Seite"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} von {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Pro Seite"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Alle Sitzungen"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Ausstehende Downloads"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Erneuter Versuch"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "In der Warteschlange"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Download-Fehler"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Wiederholen"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Zurückweisen"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Zum Neuanordnen ziehen"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "Die Warteschlange ist leer"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Spielen"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1297,132 +1799,160 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> zufällige Songs hinzu"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Alles löschen"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Als nächstes spielen"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Nach oben verschieben"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Nach oben bewegen"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Nach unten bewegen"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Nach unten bewegen"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Umbenennen"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Aus der Warteschlange entfernen"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Neustart"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Überspringen"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Download-Warteschlange"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Verfügbare Lieder in der lokalen Bibliothek"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Zeigen"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Suchen / Neu hinzufügen"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Rang"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Verfügbare Lieder"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Spielt"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Zur Warteschlange hinzufügen"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Top-Songs"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Löschen"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Top-Performer"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Erweitert"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Bisher hat niemand gesungen."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"Tippe ein Lied ein (Titel/Künstler), um die verfügbaren Lieder zu "
-"durchsuchen und klicke auf \"Zur Warteschlange hinzufügen\", um es zur "
-"Warteschlange hinzufügen."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Hinzufügen..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Wenn das Lied nicht im \"Verfügbare Lieder\"-Dropdown-Menü erscheint, "
-"klicke auf \"Suche\", um es auf Youtube zu finden"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "In der Bibliothek"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Fügen Sie neue Songs von YouTube hinzu"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Durchsuchen Sie YouTube nach Titel, Künstler ..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Suche"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Nicht-Karaoke-Treffer einbeziehen"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Erweitert"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "Direktes Herunterladen von einer YouTube-URL:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Fügen Sie eine YouTube-URL ein:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Nach dem Herunterladen zur Warteschlange hinzufügen"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Herunterladen"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Für später speichern"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1431,7 +1961,7 @@ msgstr "Suche auf Youtube nach <small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1441,41 +1971,218 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Für dieses Video ist keine Vorschau verfügbar. Verwenden Sie den YouTube-"
+"Link zum Ergebnis, um es anzusehen."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Keine aktive Sitzung"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Sitzung {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Benennen Sie diese Sitzung:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Name, der aktiviert werden soll"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr ""
+"{session} und alle seine Spiele löschen? Dies kann nicht rückgängig gemacht "
+"werden."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Alle in {session} aufgezeichneten Stücke löschen? Die Sitzung selbst bleibt "
+"erhalten. Dies kann nicht rückgängig gemacht werden."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Noch keine Sitzungen."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "In dieser Session hat niemand gesungen."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"{session} zur aktiven Sitzung machen? Dafür werden neue Songs aufgenommen."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Zeigen Sie, wer gesungen hat"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Zeigen Sie diese Stücke"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Aktuelle Sitzung"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Benennen Sie diese Sitzung..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Sitzung starten"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Sitzung beenden"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Sitzungsverlauf"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Automatisch gestartet ausblenden"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sitzung"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Begonnen"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Aktiv werden"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "CSV exportieren"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Liste exportieren (Text)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Klare Spielzüge"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Sitzung löschen"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Verbindung verloren. Läuft der Server noch?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "Dieser Browser wird nicht vollständig unterstützt. Möglicherweise treten "
 "Streaming-Probleme auf. Für optimale Ergebnisse verwenden Sie bitte "
 "Chrome/Safari/Firefox/Edge."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Als Nächstes:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Nächster Sänger:"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Deine Punktzahl"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
@@ -1485,7 +2192,6 @@ msgstr ""
 "onClick=\"handleConfirmation()\">Bestätigen</a>."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Bestätigen"
-

--- a/pikaraoke/translations/es_VE/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/es_VE/LC_MESSAGES/messages.po
@@ -5,118 +5,118 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version:  \n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: frederick.chang@hotmail.com\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-07-19 03:30-0400\n"
 "Last-Translator: FREDERICK CHANG <frederick.chang@hotmail.com>\n"
-"Language: es_VE\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es_VE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Cambiando a %s semitonos: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volumen: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Descargada y agregada a la cola (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Descargando vídeo: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Descargando vídeo: %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Error al descargar la canción: "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Descargada y agregada a la cola: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Descargado: %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Error al colocar la canción a la cola: "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Archivo de canción no encontrado: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "¡La transmisión no se podía reproducir! Saltar pista"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "La canción terminó de forma anormal: %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Saltar: %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Reanudar: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pausa: %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Tus preferencias se han modificado correctamente"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Algo ha ocurrido. Sus preferencias no se han modificado"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Tus preferencias se han borrado correctamente"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Algo ha ocurrido. Tus preferencias no se han borrado"
 
@@ -147,18 +147,18 @@ msgid "Song added to the queue: %s"
 msgstr "Canción agregada a la cola: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Borrar cola"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Error al resolver el archivo: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "No se pudo preparar la transmisión"
 
@@ -253,57 +253,98 @@ msgstr "Renombrador de canciones por lotes"
 msgid "Error: No filename parameters were specified!"
 msgstr "Error: No se especificaron parámetros de nombre de archivo!"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr ""
-"Error: No se puede editar esta canción porque está actualmente en la "
-"cola: "
+"Error: No se puede editar esta canción porque está actualmente en la cola: "
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
-msgstr "Error renombrando archivo: '%s' to '%s', El nombre del archivo ya existe"
-
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Navegador"
+msgstr ""
+"Error renombrando archivo: '%s' to '%s', El nombre del archivo ya existe"
 
 # auto-translated
-#: routes/files.py:126
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Canciones"
+
+# auto-translated
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "No tienes permiso para eliminar canciones."
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Error: No puedes borrar esta canción porque actualmente esta en la cola"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Error: no se puede eliminar esta canción porque está en cola o "
+"reproduciéndose"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Canción borrada: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "No tienes permiso para editar canciones."
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "No tienes permiso para cambiar el nombre de las canciones."
 
-#: routes/files.py:211
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Esta canción está sonando. Cambie el nombre cuando termine."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Introduce un nombre para esta canción."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Esta canción ya no está en la biblioteca. Es posible que se le haya cambiado"
+" el nombre o se haya eliminado de otro dispositivo."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Error renombrando archivo: '%s' to '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "Ya existe una canción llamada '%s'."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Esta canción comenzó a reproducirse mientras la editabas. Cambie el nombre "
+"cuando termine."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Error al cambiar el nombre del archivo: %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Archivo renombrado: %s to %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Consulta de uso de CPU no admitida"
 
@@ -387,6 +428,72 @@ msgstr "Error al bajar en la cola"
 msgid "Error deleting from queue"
 msgstr "Error al eliminar de la cola"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Agregar nuevo"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "No tienes permiso para ver esta página."
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Se requiere un nombre"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Se requiere una sesión"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Reproducir no encontrado"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Sesión no encontrada"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Jugado en"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Ejecutante"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Canción"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Historial de reproducción"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "No vuelvas a cantar más nunca... NUNCA."
@@ -453,86 +560,91 @@ msgid "Failed to stream subtitle: "
 msgstr "No se pudo transmitir el subtítulo:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"¿Quieres cambiar el nombre de la persona que utiliza este dispositivo? "
-"Esto aparecerá en las canciones en cola. Actual: CURRENT_NAME"
+"¿Quieres cambiar el nombre de la persona que utiliza este dispositivo? Esto "
+"aparecerá en las canciones en cola. Actual: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
-msgstr "¿Está seguro de que desea borrar TODA la cola? Escribe ok para continuar"
+msgstr ""
+"¿Está seguro de que desea borrar TODA la cola? Escribe ok para continuar"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "¿Estás seguro de que deseas eliminar SONG_TITLE de la cola?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "¿Está seguro de que desea eliminar {title} de la cola?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Estas seguro que quieres eliminar esta canción de la librería?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE semitonos"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} semitonos"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Transponer esta canción: ¿SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Transponer esta canción: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "¿Estás seguro de que quieres reiniciar esta pista?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
-"Un semitono también se conoce como medio paso. Es el intervalo más "
-"pequeño utilizado en la música clásica occidental, igual a una duodécima "
-"de octava o medio tono."
+"Un semitono también se conoce como medio paso. Es el intervalo más pequeño "
+"utilizado en la música clásica occidental, igual a una duodécima de octava o"
+" medio tono."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"¿Está seguro de que desea ampliar el sistema de archivos? Esto reiniciará"
-" tu Raspberry Pi."
+"¿Está seguro de que desea ampliar el sistema de archivos? Esto reiniciará tu"
+" Raspberry Pi."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Error"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -540,32 +652,58 @@ msgstr ""
 "Por favor, escriba su nombre. Esto aparecerá junto a las canciones que "
 "pongas en cola desde este dispositivo."
 
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Sesión actual: {name}"
+
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Inicio"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Lista de Espera o Cola"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Buscador"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Clasificaciones"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Historial de juego"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Sesiones"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Ajustes"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"El proceso de carga puede tardar unos segundos, ya que los títulos de las"
-" canciones se comparan en línea. El tiempo de carga puede variar\n"
+"El proceso de carga puede tardar unos segundos, ya que los títulos de las canciones se comparan en línea. El tiempo de carga puede variar\n"
 "\tsegún su conexión a Internet."
 
 # auto-translated
@@ -596,7 +734,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Mostrar todas las canciones"
 
@@ -605,84 +744,211 @@ msgstr "Mostrar todas las canciones"
 msgid "Loading songs..."
 msgstr "Cargando canciones..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "Haga clic en una sugerencia para usarla como nuevo nombre de archivo."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Ninguna sugerencia!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Editar Canción"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Editar el nombre de la canción"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Auto-Formato"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Intercambiar artista/Orden de la canción"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Cambiar nombre de canción"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Sugerencia de Last.fm"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Nombre de archivo actual"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Nuevo nombre de archivo"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Formato automático"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Intercambiar artista/título"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Sugerir desde iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "País de búsqueda de iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Guardar"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Borrar esta canción"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr ""
-"Ordenado\n"
-"  alfabéticamente"
+# auto-translated
+#. Button to open the batch song renamer page.
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "cambio de nombre masivo"
 
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Ordenado por fecha"
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Disponible en la biblioteca"
 
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Ordenado por fecha"
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Todas las carpetas"
 
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Buscar por título, artista..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Borrar"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Todas las canciones"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Carpetas"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
 msgstr "Ordenar alfabéticamente"
 
-#. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Editar todas las canciones"
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Ordenar por fecha"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "¿Eliminar esta entrada del registro de reproducción?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Aún no se ha jugado nada."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Jugó"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Saltado"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Jugando"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Opciones"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Mostrar todos los artistas"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Ocultar omitido"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Estado"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Añadir a la cola"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Esta canción ya no está en la biblioteca."
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Eliminar entrada"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -703,50 +969,55 @@ msgstr "No hay ninguna canción en cola."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
 "¿Estás seguro de que quieres saltarte esta canción? Si no agregaste esta "
 "canción, ¡Pide Permiso Primero!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Reproduciendo"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Siguiente canción"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Control del Reproductor"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Reiniciar canción"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Reproducir/Pausar"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Detener la canción actual"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Cambiar Tono"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Cambiar"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "micrófonos"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -782,433 +1053,621 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"No se detectaron micrófonos. Conecte un micrófono USB o Bluetooth y haga "
+"clic en Actualizar."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Exploración..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Refrescar"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"¿Eliminar TODO el historial de juego: cada sesión y cada jugada, para "
+"siempre? Escribe \"ok\" para continuar."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Historial de juego borrado"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Sincronización de biblioteca completa"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Información"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL de %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Código QR del URL para compartir con un amigo:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Administración"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Ingrese la contraseña del administrador"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Acceso"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Biblioteca de canciones"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Biblioteca"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Canciones en la biblioteca:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Sincronizar ahora"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
-msgstr "Concilia la biblioteca con el directorio de canciones en segundo plano."
+msgstr ""
+"Concilia la biblioteca con el directorio de canciones en segundo plano."
+
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Cambiar el nombre"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artista - Título"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Título - Artista"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Orden de los nombres de canciones sugeridos por iTunes"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Restablecer todo el historial"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Elimina cada sesión y cada jugada registrada. Esto no se puede deshacer."
 
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Preferencias del usuario"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Configuración de la presentación de pantalla"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Desactivar el vídeo de fondo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Desactivar la música de fondo"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Desactivar la pantalla de puntuación después de cada canción"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Ocultar notificaciones"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Mostrar reloj de bienvenida"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Ocultar la URL y el código QR"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Ocultar el logo en la pantalla de inicio"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Ocultar el nombre de la sesión en la pantalla de inicio"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Ocultar todas las superposiciones, incluidas las de reproducción actual, "
 "próximamente y el código QR"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volumen predeterminado de los vídeos (mín. 0, máx. 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volumen de la música de fondo (mín. 0, máx. 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
 "Tiempo de inactividad en segundos antes de que se active el protector de "
 "pantalla. Establézcalo en 0 para desactivarlo."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "El retraso en segundos antes de comenzar la siguiente canción"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"Micrófonos detectados en el servidor. El audio se dirige directamente a los "
+"altavoces."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Estado latente"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Cancelación de eco"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Experimental"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(reduce la retroalimentación, agrega latencia)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"La compatibilidad con micrófono no está disponible. Las herramientas de "
+"audio necesarias no están instaladas."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "En Linux/Raspberry Pi, instálelo con:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "y reinicie PiKaraoke."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Frases de partitura"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Agregue una frase por línea en cada cuadro y presione guardar."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frases con puntuación BAJA (puntuación < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Podría ser mejor..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frases de puntuación MID (30 > puntuación < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Eso estuvo bien..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frases con puntuación ALTA (60 < puntuación)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Maravilloso..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Configuración de idioma"
 
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Idioma preferido (requiere reinicio)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Configuración del servidor"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normalizar el volumen del audio"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Descargar vídeos de alta calidad"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
 "Transcodificar el vídeo completamente antes de reproducirlo (mejor "
-"compatibilidad con navegadores, inicios más lentos). Se ignorará el "
-"tamaño del búfer.*"
+"compatibilidad con navegadores, inicios más lentos). Se ignorará el tamaño "
+"del búfer.*"
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
-"Habilite la escala de píxeles CDG (imágenes más nítidas para archivos "
-"CDG, pueden aumentar el uso de la CPU)"
+"Habilite la escala de píxeles CDG (imágenes más nítidas para archivos CDG, "
+"pueden aumentar el uso de la CPU)"
+
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Habilite la limpieza automática de títulos de YouTube (elimina palabras "
+"irrelevantes como \"Karaoke Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Habilitar la exploración de carpetas (agrega una vista de Carpetas a la "
+"página de Canciones cuando la biblioteca tiene subcarpetas)"
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
-"Corrija la sincronización de audio y video en segundos (negativo = avanza"
-" el audio | positivo = retrasa el audio)"
+"Corrija la sincronización de audio y video en segundos (negativo = avanza el"
+" audio | positivo = retrasa el audio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
-"Límite de canciones que un usuario individual puede agregar a la cola (0 "
-"= ilimitado)"
+"Límite de canciones que un usuario individual puede agregar a la cola (0 = "
+"ilimitado)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Habilitar cola justa (el modo por turnos garantiza que los usuarios se "
 "turnen)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
-"Tamaño del búfer en kilobytes. Transcodifique esta cantidad de vídeo "
-"antes de enviarlo a la pantalla de inicio. "
+"Tamaño del búfer en kilobytes. Transcodifique esta cantidad de vídeo antes "
+"de enviarlo a la pantalla de inicio. "
+
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Canciones predeterminadas por página."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Mantener el servidor despierto: no disponible en un contenedor. Desactive la"
+" suspensión en el host."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Mantenga el servidor despierto: necesita systemd-inhibit (Linux) o "
+"caffeinate (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Mantener el servidor despierto: no es compatible con esta plataforma."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Mantenga el servidor despierto mientras PiKaraoke se está ejecutando"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Borrar preferencias"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Estadísticas del sistema"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Información del sistema"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Plataforma:"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Versión del Sistema Operativo:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp versión:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg versión:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versión:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Estadísticas del sistema"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "UPC:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Cargando..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Uso del disco:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Memoria:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Actualizaciones"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "Actualización de YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Si las descargas o búsquedas dejaron de funcionar, la actualización de "
-"yt-dlp probablemente lo solucionará.\n"
+"Si las descargas o búsquedas dejaron de funcionar, la actualización de yt-dlp probablemente lo solucionará.\n"
 "   La versión instalada actualmente es: \"%(youtubedl_version)s\""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Actualizar yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"Este enlace de actualización anterior puede fallar si no tiene los "
-"permisos de archivo adecuados.\n"
+"Este enlace de actualización anterior puede fallar si no tiene los permisos de archivo adecuados.\n"
 "    Consulte el registro de pikaraoke en busca de errores."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Otros"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Expandir el sistema de archivos Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Si acaba de instalar la imagen pikaraoke prediseñada y su tarjeta SD "
-"tiene más de 4 GB,\n"
-"    es posible que desee ampliar el sistema de archivos para utilizar el "
-"espacio restante. Sólo necesitas hacer esto una vez.\n"
+"Si acaba de instalar la imagen pikaraoke prediseñada y su tarjeta SD tiene más de 4 GB,\n"
+"    es posible que desee ampliar el sistema de archivos para utilizar el espacio restante. Sólo necesitas hacer esto una vez.\n"
 "    Esto reiniciará el sistema."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Haga clic aquí para cerrar sesión en el modo administrador."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Finalizar la sesión"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Apagar"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1218,70 +1677,107 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Salir del pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Reiniciar el sistema"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Sistema de apagado"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Opciones"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Pagina anterior"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Página siguiente"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} de {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Por página"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Todas las sesiones"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Descargas pendientes"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Reintentando"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "En cola"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Errores de descarga"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Fallido"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Rever"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Despedir"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Arrastra para reordenar"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "La cola esta vacia"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Jugar"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1291,137 +1787,160 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> canciones aleatorias"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Borrar todo"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Reproducir siguiente"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Mover hacia arriba"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Subir"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Mover hacia abajo"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Mover hacia abajo"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Rebautizar"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Quitar de la cola"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Reanudar"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Saltar"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Cola de descarga"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Canciones disponibles en la biblioteca local"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Espectáculo"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Buscar / Agregar nuevo"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Rango"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Canciones disponibles"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "juega"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Añadir a la cola"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Canciones más populares"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Borrar"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Mejores artistas"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Avanzado"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Nadie ha cantado todavía."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"Escriba una canción\n"
-"          (título/artista) para buscar las canciones disponibles y haga "
-"click en \"Agregar a la cola\"\n"
-"          para agregarla a la cola."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Añadiendo..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Sí\n"
-"          la canción no aparece en el menú desplegable \"Canciones "
-"disponibles\", haz click en\n"
-"          'Buscar' para encontrarla en Youtube"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "en la biblioteca"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Agregar nuevas canciones de YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Busca en YouTube por título, artista..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Buscador"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Incluir videos que no sean de karaoke"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Avanzado"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "URL de descarga directa de YouTube:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Pega una URL de YouTube:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr ""
-"Agregar a la cola una vez \n"
-"          descargado"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Descargar"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Guardar para más tarde"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1432,7 +1951,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1442,52 +1961,225 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Vista previa no disponible para este vídeo. Utilice el enlace de YouTube en "
+"el resultado para verlo."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Ninguna sesión activa"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Sesión {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Nombra esta sesión:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Nombre para activar"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "¿Eliminar {session} y todas sus jugadas? Esto no se puede deshacer."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"¿Eliminar todas las jugadas grabadas en {session}? Se mantiene la sesión en "
+"sí. Esto no se puede deshacer."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Aún no hay sesiones."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Nadie ha cantado en esta sesión."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"¿Hacer {session} la sesión activa? Se grabarán nuevas canciones en él."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "mostrar quien canto"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Muestra estas obras"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Sesión actual"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Nombra esta sesión..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Iniciar sesión"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Finalizar sesión"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Historial de sesiones"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Ocultar inicio automático"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sesión"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Comenzó"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Activar"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Exportar CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Lista de exportación (texto)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Jugadas claras"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Eliminar sesión"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Conexión perdida. ¿El servidor sigue funcionando?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "Este navegador no es totalmente compatible. Es posible que experimente "
-"problemas de transmisión. Utilice Chrome/Safari/Firefox/Edge para obtener"
-" mejores resultados."
+"problemas de transmisión. Utilice Chrome/Safari/Firefox/Edge para obtener "
+"mejores resultados."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "A continuación:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Próximo cantante:"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Tu puntuación"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "Debido a limitaciones con los permisos del navegador, debes interactuar\n"
-"      con la página una vez para que se active la reproducción automática"
-" de videos. De lo contrario, Pikaraoke\n"
+"      con la página una vez para que se active la reproducción automática de videos. De lo contrario, Pikaraoke\n"
 "      no reproducirá. Haz clic en el botón de abajo para\n"
 "      <a onClick=\"handleConfirmation()\">confirmar</a> ."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Confirmar"
-

--- a/pikaraoke/translations/fi_FI/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/fi_FI/LC_MESSAGES/messages.po
@@ -7,127 +7,127 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: minna.soudunsaari@gmail.com\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2024-05-08 18:57-0300\n"
 "Last-Translator: FULL NAME <minna.soudunsaari@gmail.com>\n"
-"Language: fi_FI\n"
 "Language-Team: fi_FI <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fi_FI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponoidaan %s puolisävelellä: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Ääni kovemmalle: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Jonoon lisätty kappale (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Lataa: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Ladataan videota: %s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Virhe kappaleen lataamisessa:"
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Jonoon lisätty kappale: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Lataa: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Virhe kappaleen jonossa:"
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Kappaletiedostoa ei löydy: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Streamia ei voitu toistaa! Jäljen ohittaminen"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "Kappale päättyi epänormaalisti: %s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Ohita: %s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Jatka: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Tauko: %s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Asetuksesi muutettiin onnistuneesti"
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Jotain meni pieleen! Asetuksiasi ei muutettu"
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Asetuksesi tyhjennettiin onnistuneesti"
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Jotain meni pieleen! Asetuksiasi ei tyhjennetty"
 
@@ -160,18 +160,18 @@ msgstr "Jonoon lisätty kappale: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Tyhjennä jono"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Virhe ratkaistaessa tiedostoa: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Striimin valmistelu epäonnistui"
 
@@ -277,63 +277,102 @@ msgid "Error: No filename parameters were specified!"
 msgstr "Virhe: Tiedostonimen parametreja ei määritetty!"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "Virhe: Tätä kappaletta ei voi muokata, koska se on nykyisessä jonossa:"
+msgstr ""
+"Virhe: Tätä kappaletta ei voi muokata, koska se on nykyisessä jonossa:"
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 "Virhe nimettäessä tiedostoa '%s' uudelleen '%s':ksi. Tiedostonimi on jo "
 "olemassa"
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Selaa"
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Songs"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Sinulla ei ole lupaa poistaa kappaleita"
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Virhe: Tätä kappaletta ei voi poistaa, koska se on nykyisessä jonossa"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Virhe: Tätä kappaletta ei voi poistaa, koska se on jonossa tai toistetaan"
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Kappale poistettu: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Sinulla ei ole lupaa muokata kappaleita"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Sinulla ei ole lupaa nimetä kappaleita uudelleen"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Tämä kappale soi. Nimeä se uudelleen, kun se on valmis."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Anna tälle kappaleelle nimi."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Tämä kappale ei ole enää kirjastossa. Se on saatettu nimetä uudelleen tai "
+"poistaa toisesta laitteesta."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Virhe nimettäessä tiedostoa '%s' uudelleen '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "Kappale nimeltä %s on jo olemassa."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Tämä kappale alkoi soida, kun editoit sitä. Nimeä se uudelleen, kun se on "
+"valmis."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Virhe tiedoston uudelleennimeämisessä: %s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Nimetty tiedosto uudelleen: %s nimeksi %s"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Suorittimen käyttökyselyä ei tueta"
 
@@ -427,6 +466,72 @@ msgid "Error deleting from queue"
 msgstr "Virhe poistettaessa jonosta"
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Lisää Uusi"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Sinulla ei ole lupaa tarkastella tätä sivua"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Nimi vaaditaan"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Istunto vaaditaan"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Peliä ei löydy"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Istuntoa ei löydy"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Pelasi klo"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Esiintyjä"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Song"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Pelihistoria"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Älä koskaan laula enää... koskaan."
@@ -507,61 +612,65 @@ msgid "Failed to stream subtitle: "
 msgstr "Tekstityksen suoratoisto epäonnistui:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"Haluatko muuttaa tätä laitetta käyttävän henkilön nimeä? Tämä näkyy "
-"jonossa olevissa kappaleissa. Nykyinen: CURRENT_NAME"
+"Haluatko muuttaa tätä laitetta käyttävän henkilön nimeä? Tämä näkyy jonossa "
+"olevissa kappaleissa. Nykyinen: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Haluatko varmasti tyhjentää KOKO jonon? Kirjoita ok jatkaaksesi"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Haluatko varmasti poistaa kappaleen SONG_TITLE jonosta?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Haluatko varmasti poistaa kohteen {title} jonosta?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Oletko varma että haluat poistaa tämän kappaleen karaokelaitteelta?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE puolisäveltä"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} puolisävelet"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Transponoidaanko tämä kappale: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Transponoi tämä kappale: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Oletko varma, että haluat aloittaa tämän kappaleen uudelleen?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
 "Puolisäveltä kutsutaan myös puoliaskeleeksi. Se on pienin klassisessa "
 "länsimaisessa musiikissa käytetty intervalli, joka vastaa oktaavin "
@@ -570,23 +679,23 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"Haluatko varmasti laajentaa tiedostojärjestelmää? Tämä käynnistää "
-"raspberry pi -laitteen uudelleen."
+"Haluatko varmasti laajentaa tiedostojärjestelmää? Tämä käynnistää raspberry "
+"pi -laitteen uudelleen."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Virhe"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -594,32 +703,58 @@ msgstr ""
 "Kirjoita nimesi. Tämä nimi tulee näkymään kappalejonossa "
 "jonottamiesikappaleiden vieressä."
 
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Nykyinen istunto: {name}"
+
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Kotisivu"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Jono"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Etsi"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Rankingit"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Pelihistoria"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Istunnot"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Asetukset"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Latausprosessi voi kestää muutaman sekunnin, koska kappaleiden nimiä "
-"verrataan verkossa. Latausaika voi vaihdella\n"
+"Latausprosessi voi kestää muutaman sekunnin, koska kappaleiden nimiä verrataan verkossa. Latausaika voi vaihdella\n"
 "\tInternet-yhteytesi perusteella."
 
 # auto-translated
@@ -650,7 +785,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Näytä kaikki kappaleet"
 
@@ -660,83 +796,211 @@ msgstr "Näytä kaikki kappaleet"
 msgid "Loading songs..."
 msgstr "Ladataan kappaleita..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "Napsauta ehdotusta käyttääksesi sitä uutena tiedostonimenä."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Ei ehdotuksia!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Muokkaa kappaletta"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Muokkaa kappaleen nimeä"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Automaattinen muokkaus"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Vaihda artisti/kappale paikat"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Nimeä kappale uudelleen"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Ehdota Last.fm:stä"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Nykyinen tiedostonimi"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Uusi tiedostonimi"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Automaattinen muotoilu"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Vaihda artisti/nimike"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Ehdota iTunesista"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes-hakumaa"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Tallenna"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Peruuttaa"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Poista tämä kappale"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Aakkosjärjestyksessä"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Päivämääräjärjestyksessä"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Päivämääräjärjestyksessä"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "Aakkosjärjestykseen"
-
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Muokkaa kaikkia kappaleita"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Joukkonimeä uudelleen"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Saatavilla kirjastossa"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Kaikki kansiot"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Hae nimen, esittäjän mukaan..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Tyhjennä"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Kaikki kappaleet"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Kansiot"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Lajittele aakkosjärjestyksessä"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Lajittele päivämäärän mukaan"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Poistetaanko tämä merkintä soittolokista?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Mitään ei ole vielä pelattu."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Pelasi"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Ohitettu"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Pelaaminen"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Vaihtoehdot"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Näytä kaikki esiintyjät"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Piilota ohitettu"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Status"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Lisää Jonoon"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Tämä kappale ei ole enää kirjastossa"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Poista merkintä"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -757,50 +1021,55 @@ msgstr "Ei jonosso olevia kappaleita."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
 "Haluatko varmasti skipata tämän kappaleen? Jos kappale ei ole itse "
 "lisäämäsi, kysythän ensin luvan!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Soi tällä hetkellä"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Seuraava kappale"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Soittimen säätimet"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Aloita kappale uudelleen"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Play/Pause"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Pysäytä Nykyinen Kappale"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Vaihda Sävelasteikkoa"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Vaihda"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Mikrofonit"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -836,240 +1105,376 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Mikrofoneja ei havaittu. Liitä USB- tai Bluetooth-mikrofoni ja napsauta "
+"Päivitä."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Skannataan..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Päivitä"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Poistetaanko KAIKKI soittohistoria – jokainen istunto ja jokainen toisto "
+"lopullisesti? Type \"ok\" to continue."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Pelihistoria tyhjennetty"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Kirjaston synkronointi valmis"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informaatio."
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Kätevä URL QR-koodi kaverille jaettavaksi:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Admin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Kirjoita järjestelmänvalvojan salasana\""
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Laulukirjasto"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Kirjasto"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Kirjastossa olevat kappaleet:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Synkronoi nyt"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Täsmentää kirjaston taustalla olevan kappalehakemiston kanssa."
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Nimetään uudelleen"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artisti - Otsikko"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Otsikko - Artisti"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "iTunesin ehdotettujen kappaleiden nimien järjestys"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Nollaa koko historia"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Poistaa jokaisen istunnon ja jokaisen tallennetun toiston. Tätä ei voi "
+"kumota."
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Käyttäjäasetukset"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Aloitusnäytön asetukset"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Poista taustavideo käytöstä"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Poista taustamusiikki käytöstä"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Poista tulosnäyttö käytöstä jokaisen kappaleen jälkeen"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Piilota ilmoitukset"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Näytä splash kello"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Piilota URL-osoite ja QR-koodi"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Piilota logo aloitusnäytössä"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Piilota istunnon nimi aloitusnäytössä"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
-"Piilota kaikki peittokuvat, mukaan lukien nyt toistettava, seuraavaksi ja"
-" QR-koodi"
+"Piilota kaikki peittokuvat, mukaan lukien nyt toistettava, seuraavaksi ja "
+"QR-koodi"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Videoiden oletusäänenvoimakkuus (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Taustamusiikin äänenvoimakkuus (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
 "Joutokäyntiaika sekunteina, ennen kuin näytönsäästäjä aktivoituu. Aseta "
 "arvoksi 0 poistaaksesi sen käytöstä."
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Viive sekunneissa ennen seuraavan kappaleen aloittamista"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "Palvelimella havaittu mikrofonit. Ääni ohjataan suoraan kaiuttimiin."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latenssi"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Kaiun poisto"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Kokeellinen"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(vähentää palautetta, lisää viivettä)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Mikrofonituki ei ole saatavilla. Vaadittuja äänityökaluja ei ole asennettu."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Linux / Raspberry Pi, asenna se seuraavasti:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "ja käynnistä PiKaraoke uudelleen."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Pisteet lauseita"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
-msgstr "Lisää yksi lause jokaiselle riville kuhunkin ruutuun ja paina Tallenna."
+msgstr ""
+"Lisää yksi lause jokaiselle riville kuhunkin ruutuun ja paina Tallenna."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "MATALAPISTEET -lauseet (pisteet < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Voisi olla parempi..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Pistelauseet (30 > pisteet < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Se oli ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Korkeat pisteet -lauseet (60 < pisteet)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Ihanaa..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Kieliasetukset"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Ensisijainen kieli (vaatii uudelleenkäynnistyksen)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Palvelimen asetukset"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normalisoi äänenvoimakkuus"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Lataa korkealaatuisia videoita"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1079,17 +1484,37 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
-"Ota CDG-pikselin skaalaus käyttöön (terävämpi kuva CDG-tiedostoille, "
-"saattaa lisätä suorittimen käyttöä)"
+"Ota CDG-pikselin skaalaus käyttöön (terävämpi kuva CDG-tiedostoille, saattaa"
+" lisätä suorittimen käyttöä)"
+
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Ota käyttöön automaattinen YouTube-otsikon puhdistus (poistaa melusanat, "
+"kuten \"Karaoke Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Ota kansioiden selaus käyttöön (lisää Kansiot-näkymän Kappaleet-sivulle, kun"
+" kirjastossa on alikansioita)"
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1099,7 +1524,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Raja kappaleita, joita yksittäinen käyttäjä voi lisätä jonoon (0 = "
@@ -1107,7 +1532,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Ota reilu jono käyttöön (kierrostila varmistaa, että käyttäjät "
@@ -1115,253 +1540,320 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
 "Puskurin koko kilotavuina. Transkoodaa tämä määrä videota ennen sen "
 "lähettämistä aloitusnäytölle."
 
 # auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Oletuskappaleet sivulla."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Pidä palvelin hereillä: ei saatavilla säilössä. Poista nukkuminen käytöstä "
+"isännässä."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Pidä palvelin hereillä: tarvitsee systemd-inhibitin (Linux) tai kofeiinin "
+"(macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Pidä palvelin hereillä: ei tueta tällä alustalla."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Pidä palvelin hereillä PiKaraoken ollessa käynnissä"
+
+# auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Tyhjennä asetukset"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Järjestelmätiedot"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Järjestelmän Tiedot"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Alusta:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Käyttöjärjestelmän versio:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp -versio:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg-versio:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versio:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Järjestelmän tilastot"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Ladataan..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Levyn käyttö:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Muisti:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Päivitykset"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP päivitys"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Jos lataukset tai haut lakkasivat toimimasta, ongelman voi "
-"todennäköisesti korjatapäivittämällä 'yt-dlp':n.\n"
+"Jos lataukset tai haut lakkasivat toimimasta, ongelman voi todennäköisesti korjatapäivittämällä 'yt-dlp':n.\n"
 "   Tämänhetkinen asennettu versio: \"%(youtubedl_version)s\""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Päivitä yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"Ylläoleva päivityslinkki saattaa epäonnistua, jos sinulla ei ole "
-"tarvittavia tiedoston käyttöoikeuksia.\n"
+"Ylläoleva päivityslinkki saattaa epäonnistua, jos sinulla ei ole tarvittavia tiedoston käyttöoikeuksia.\n"
 "    Tarkista pikaraoke-log virheet."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Muut"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Laajenna Raspberry Pi -tiedostojärjestelmää"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Jos asensit juuri valmiin Pikaraoke pi-imagen   ja SD-korttisi on "
-"suurempi kuin 4 Gt,\n"
-"    voit halutessasi laajentaa tiedostojärjestelmää hyödyntääksesi "
-"jäljellä olevan tilan. Sinun tarvitsee tehdä tämä vain kerran.\n"
+"Jos asensit juuri valmiin Pikaraoke pi-imagen   ja SD-korttisi on suurempi kuin 4 Gt,\n"
+"    voit halutessasi laajentaa tiedostojärjestelmää hyödyntääksesi jäljellä olevan tilan. Sinun tarvitsee tehdä tämä vain kerran.\n"
 "    Tämä käynnistää järjestelmän uudelleen."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Napsauta tätä kirjautuaksesi ulos järjestelmänvalvojatilasta."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Sammuta"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
 msgstr ""
-"Älä vain vedä pistokkeesta! Sammuta karaokelaite (=server) aina huolella,"
-" jotta tiedostot eivät vioitu."
+"Älä vain vedä pistokkeesta! Sammuta karaokelaite (=server) aina huolella, "
+"jotta tiedostot eivät vioitu."
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Sammuta Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Käynnistä järjestelmä uudelleen"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Sammuta järjestelmä"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Vaihtoehdot"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Edellinen sivu"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Seuraava sivu"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} / {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "per sivu"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Kaikki istunnot"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Odottavat lataukset"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Yritetään uudelleen"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "Jonossa"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Latausvirheet"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Epäonnistui"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Yritä uudelleen"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Hylkää"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Järjestä uudelleen vetämällä"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "Jono on tyhjä"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Pelata"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Tauko"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1371,131 +1863,160 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> satunnaista kappaletta"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Tyhjennä kappalejono"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Pelaa seuraavaksi"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Siirrä alkuun"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Siirrä ylös"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Siirrä alas"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Siirrä alas"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Nimeä uudelleen"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Poista jonosta"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Ohita"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Latausjono"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Kappaleet saatavilla karaokelaitteen muistissa"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Show"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Etsi / Uusi Kappale"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Sijoitus"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Saatavilla olevat kappaleet"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Toistetaan"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Lisää Jonoon"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Huippukappaleita"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Tyhjennä"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Huippusuorittajat"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Tarkemmat hakuvaihtoehdot"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Kukaan ei ole vielä laulanut."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"Kirjoita kappale (kappale/artisti) nähdäksesi tarjolla olevat kappaleet "
-"ja paina 'Lisää Jonoon'-nappia."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Lisätään..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Jos kappaleesi ei näy \"Saatavilla olevat kappaleet\", avattavassa "
-"valikossa klikkaa \"Etsi\" tarkistaaksesi Youtuben tarjonnan."
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "Kirjastossa"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Lisää uusia kappaleita YouTubesta"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Hae YouTubesta nimen, esittäjän mukaan..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Etsi"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Sisällytä myös ei-karaoke versiot."
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Tarkemmat hakuvaihtoehdot"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "Lataa suoraan Youtube URL:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Liitä YouTube-URL-osoite:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Lisää kappalejonoon lataamisen jälkeen."
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Lataa"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Säästä myöhempää käyttöä varten"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1504,7 +2025,7 @@ msgstr "Etsi Youtubesta <small><i>’%(search_term)s’</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1514,55 +2035,228 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Esikatselu ei ole käytettävissä tälle videolle. Käytä tuloksen YouTube-"
+"linkkiä katsoaksesi sen."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Ei aktiivista istuntoa"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Istunto {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Nimeä tämä istunto:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Aktivoitava nimi"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "Poistetaanko {session} ja kaikki sen toistot? Tätä ei voi kumota."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Poistetaanko kaikki {session}:ssa tallennetut toistot? Itse istunto "
+"säilytetään. Tätä ei voi kumota."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Ei istuntoja vielä."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Kukaan ei ole laulanut tässä istunnossa."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"Tehdäänkö {session} aktiiviseksi istunnoksi? Sitä vastaan ​​äänitetään uusia"
+" kappaleita."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Näytä kuka lauloi"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Näytä nämä näytelmät"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Nykyinen istunto"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Nimeä tämä istunto..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Aloita istunto"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Lopeta istunto"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Istuntohistoria"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Piilota automaattisesti käynnistynyt"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Istunto"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Aloitettu"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Aktivoi"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Vie CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Vie luettelo (teksti)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Selkeät toistot"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Poista istunto"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Yhteys katkesi. Onko palvelin vielä käynnissä?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "Tätä selainta ei tueta täysin. Saatat kohdata suoratoistoongelmia. Käytä "
 "Chromea/Safaria/Firefoxia/Edgeä saadaksesi parhaat tulokset."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Seuraavaksi:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Seuraava laulaja:"
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Sinun pisteesi"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
-"Selaimen käyttöoikeuksiin liittyvien rajoitusten vuoksi sinun on oltava "
-"vuorovaikutuksessa\n"
-"      sivulla kerran ennen kuin se sallii videoiden automaattisen "
-"toiston. Pikaraoke ei tule\n"
+"Selaimen käyttöoikeuksiin liittyvien rajoitusten vuoksi sinun on oltava vuorovaikutuksessa\n"
+"      sivulla kerran ennen kuin se sallii videoiden automaattisen toiston. Pikaraoke ei tule\n"
 "      pelata toisin. Napsauta alla olevaa painiketta\n"
 "      <a onClick=\"handleConfirmation()\">vahvista</a>."
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Vahvistaa"
-

--- a/pikaraoke/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/fr_FR/LC_MESSAGES/messages.po
@@ -7,116 +7,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-13 22:52-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: fr_FR\n"
 "Language-Team: fr_FR <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transposition par %s demi-tons : %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume : %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Téléchargé et mis en file d'attente (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Téléchargement de la vidéo : %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Téléchargement de la vidéo : %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Erreur lors du téléchargement d'une chanson : "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Téléchargé et mis en file d'attente : %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Téléchargé : %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Erreur lors de la mise en file d'attente d'une chanson : "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Fichier de morceau introuvable : %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Le flux n'était pas lisible ! Sauter une piste"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "La chanson s'est terminée de manière anormale : %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Passer : %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Reprendre : %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pause : %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Vos préférences ont été modifiées avec succès"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Il y a eu un problème ! Vos préférences n'ont pas été modifiées"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Vos préférences ont été effacées avec succès"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Il y a eu un problème ! Vos préférences n'ont pas été effacées"
 
@@ -130,8 +130,8 @@ msgstr "La chanson est déjà dans la file d'attente : %s"
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr ""
-"Vous avez atteint la limite de %s chanson(s) par utilisateur dans la file"
-" d'attente !"
+"Vous avez atteint la limite de %s chanson(s) par utilisateur dans la file "
+"d'attente !"
 
 #: lib/queue_manager.py:132
 #, python-format
@@ -149,18 +149,18 @@ msgid "Song added to the queue: %s"
 msgstr "Chanson ajoutée à la file d'attente : %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Effacer la file d'attente"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Erreur de résolution du fichier : %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Échec de la préparation du flux"
 
@@ -209,16 +209,16 @@ msgstr "Vous n'avez pas le droit de redémarrer"
 #: routes/admin.py:148
 msgid "Expanding filesystem and rebooting system now!"
 msgstr ""
-"Augmentation de la taille du système de fichiers et redémarrage du "
-"système maintenant !"
+"Augmentation de la taille du système de fichiers et redémarrage du système "
+"maintenant !"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
 #: routes/admin.py:153
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
-"Impossible d'augmenter la taille du système de fichiers sur des appareils"
-" autres que Raspberry Pi !"
+"Impossible d'augmenter la taille du système de fichiers sur des appareils "
+"autres que Raspberry Pi !"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
@@ -259,61 +259,99 @@ msgstr "Renommeur de chanson par lots"
 msgid "Error: No filename parameters were specified!"
 msgstr "Erreur : Aucun nom de fichier n'a été spécifié !"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr ""
-"Erreur : Impossible d'éditer cette chanson car elle se trouve dans la "
-"file d'attente actuelle : "
+"Erreur : Impossible d'éditer cette chanson car elle se trouve dans la file "
+"d'attente actuelle : "
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
-"Erreur de renommage de fichier : '%s' en '%s', le nom de fichier existe "
-"déjà"
-
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Parcourir"
+"Erreur de renommage de fichier : '%s' en '%s', le nom de fichier existe déjà"
 
 # auto-translated
-#: routes/files.py:126
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Chansons"
+
+# auto-translated
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Vous n'êtes pas autorisé à supprimer des chansons"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
 msgstr ""
-"Erreur : Impossible de supprimer cette chanson car elle se trouve dans la"
-" file d'attente actuelle"
+"Erreur : Impossible de supprimer cette chanson car elle est en file "
+"d'attente ou en cours de lecture"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Chanson supprimée : %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Vous n'êtes pas autorisé à modifier des chansons"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Vous n'êtes pas autorisé à renommer les chansons"
 
-#: routes/files.py:211
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Cette chanson joue. Renommez-le une fois terminé."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Entrez un nom pour cette chanson."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Cette chanson n'est plus dans la bibliothèque. Il a peut-être été renommé ou"
+" supprimé d'un autre appareil."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Erreur de renommage de fichier : '%s' en '%s', %s déjà"
+msgid "A song called '%s' already exists."
+msgstr "Une chanson appelée « %s » existe déjà."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"La lecture de cette chanson a commencé pendant que vous la modifiiez. "
+"Renommez-le une fois terminé."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Erreur de renommage du fichier : %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Fichier renommé : %s to %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Requête sur l'utilisation du CPU non prise en charge"
 
@@ -397,6 +435,72 @@ msgstr "Erreur lors du déplacement vers le bas dans la file d'attente"
 msgid "Error deleting from queue"
 msgstr "Erreur lors de la suppression de la file d'attente"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Ajouter un nouveau"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Vous n'êtes pas autorisé à afficher cette page"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Un nom est requis"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Une séance est nécessaire"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Lecture introuvable"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Séance introuvable"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Joué à"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Interprète"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Chanson"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Historique de lecture"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Ne chantez plus jamais... jamais."
@@ -463,122 +567,151 @@ msgid "Failed to stream subtitle: "
 msgstr "Échec de la diffusion du sous-titre :"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
 "Voulez-vous changer le nom de la personne utilisant cet appareil ? Cela "
-"apparaîtra sur les chansons en file d'attente. Actuel : CURRENT_NAME"
+"apparaîtra sur les chansons en file d'attente. Actuel : {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
-"Êtes-vous sûr de vouloir effacer la file d'attente ENTIÈRE ? Tapez ok "
-"pour continuer"
+"Êtes-vous sûr de vouloir effacer la file d'attente ENTIÈRE ? Tapez ok pour "
+"continuer"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Voulez-vous vraiment supprimer SONG_TITLE de la file d'attente ?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Êtes-vous sûr de vouloir supprimer {title} de la file d'attente ?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette chanson de la bibliothèque ?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE demi-tons"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} demi-tons"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Transposer cette chanson : SEMITONE_LABEL ?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Transposer cette chanson : {label} ?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Êtes-vous sûr de vouloir redémarrer cette piste ?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
-"Un demi-ton est également appelé demi-ton. C'est le plus petit intervalle"
-" utilisé dans la musique classique occidentale, égal à un douzième "
-"d'octave ou un demi-ton."
+"Un demi-ton est également appelé demi-ton. C'est le plus petit intervalle "
+"utilisé dans la musique classique occidentale, égal à un douzième d'octave "
+"ou un demi-ton."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"Êtes-vous sûr de vouloir étendre le système de fichiers ? Cela "
-"redémarrera votre Raspberry Pi."
+"Êtes-vous sûr de vouloir étendre le système de fichiers ? Cela redémarrera "
+"votre Raspberry Pi."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Erreur"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
-"Veuillez saisir votre nom. Celui-ci s'affichera à côté des chansons que "
-"vous mettez en file d'attente depuis de cet appareil."
+"Veuillez saisir votre nom. Celui-ci s'affichera à côté des chansons que vous"
+" mettez en file d'attente depuis de cet appareil."
+
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Session en cours : {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Accueil"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "File d'attente"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Recherche"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Classements"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Historique de lecture"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Séances"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Paramètres"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Le processus de chargement peut prendre quelques secondes, car les titres"
-" des chansons sont comparés en ligne. Le temps de chargement peut varier"
-"\n"
+"Le processus de chargement peut prendre quelques secondes, car les titres des chansons sont comparés en ligne. Le temps de chargement peut varier\n"
 "\ten fonction de votre connexion Internet."
 
 # auto-translated
@@ -609,7 +742,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Afficher toutes les chansons"
 
@@ -619,85 +753,212 @@ msgstr "Afficher toutes les chansons"
 msgid "Loading songs..."
 msgstr "Chargement des chansons..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr ""
+"Cliquez sur une suggestion pour l'utiliser comme nouveau nom de fichier."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Aucune suggestion !"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Modifier la chanson"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Modifier le nom de la chanson"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Formatage automatique"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Échanger l'ordre artiste/chanson"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Renommer la chanson"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Suggestion de Last.fm"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Nom de fichier actuel"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Nouveau nom de fichier"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Formatage automatique"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Échanger artiste/titre"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Suggérer depuis iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "Pays de recherche iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Enregistrer"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Annuler"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Supprimer cette musique"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr ""
-"Trié\n"
-"  alphabétiquement"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Trié par date"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Trié par date"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "Tri alphabétique"
-
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Modifier toutes les chansons"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Renommer en masse"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Disponible à la bibliothèque"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Tous les dossiers"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Recherche par titre, artiste..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Effacer"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Toutes les chansons"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Dossiers"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Trier par ordre alphabétique"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Trier par date"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Supprimer cette entrée du journal de lecture ?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Rien n'a encore été joué."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Joué"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Sauté"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Jouant"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Possibilités"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Afficher tous les artistes"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Masquer ignoré"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Statut"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Ajouter à la file d'attente"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Cette chanson n'est plus dans la bibliothèque"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Supprimer l'entrée"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -718,50 +979,55 @@ msgstr "Aucune chanson dans la file d'attente."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
 "Êtes-vous sûr de vouloir ignorer cette chanson ? Si vous ne l'avez pas "
 "ajouté, demandez d'abord la permission !"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "En cours de lecture"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Prochaine chanson"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Contrôles du lecteur"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Recommencer la chanson"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Lecture/Pause"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Arrêter la chanson en cours"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Modifier la tonalité"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Modifier"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Micros"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -797,254 +1063,414 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Aucun microphone détecté. Connectez un micro USB ou Bluetooth et cliquez sur"
+" Actualiser."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Balayage..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Rafraîchir"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Supprimer TOUT l'historique de jeu – chaque session et chaque jeu, pour de "
+"bon ? Tapez « ok » pour continuer."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Historique de lecture effacé"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Synchronisation de la bibliothèque terminée"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informations"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL de %(site_title)s :"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "URL QR code à partager avec un ami :"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Administrateur"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Saisissez le mot de passe administrateur"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Connexion"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Bibliothèque de chansons"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Bibliothèque"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Chansons en bibliothèque :"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Synchroniser maintenant"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
-msgstr "Réconcilie la bibliothèque avec le répertoire de chansons en arrière-plan."
+msgstr ""
+"Réconcilie la bibliothèque avec le répertoire de chansons en arrière-plan."
+
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Renommer"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artiste - Titre"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Titre - Artiste"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Ordre des noms de chansons suggérés par iTunes"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Réinitialiser tout l'historique"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Supprime chaque session et chaque lecture enregistrée. Cela ne peut pas être"
+" annulé."
 
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Préférences utilisateur"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Paramètres de l'écran de démarrage"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Désactiver la vidéo d'arrière-plan"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Désactiver la musique de fond"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Désactiver l'écran des scores après chaque chanson"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Masquer les notifications"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Afficher l'horloge de démarrage"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Masquer l'URL et le QR code"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Masquer le logo sur l'écran de démarrage"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Masquer le nom de la session sur l'écran de démarrage"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Masquer toutes les surcouches, y compris la lecture en cours, la lecture "
 "suivante et le QR code"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume par défaut des vidéos (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume de la musique de fond (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"Temps d'inactivité en secondes avant que l'économiseur d'écran ne "
-"s'active.  Utilisez 0 pour désactiver."
+"Temps d'inactivité en secondes avant que l'économiseur d'écran ne s'active."
+"  Utilisez 0 pour désactiver."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Délai en secondes avant le début de la chanson suivante"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"Microphones détectés sur le serveur. L'audio est acheminé directement vers "
+"les haut-parleurs."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latence"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Annulation de l'écho"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Expérimental"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(réduit le feedback, ajoute de la latence)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"La prise en charge du microphone n'est pas disponible. Les outils audio "
+"requis ne sont pas installés."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Sous Linux / Raspberry Pi, installez-le avec :"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "et redémarrez PiKaraoke."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Phrases de partition"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
-msgstr "Ajoutez une phrase par ligne dans chaque case et cliquez sur Enregistrer."
+msgstr ""
+"Ajoutez une phrase par ligne dans chaque case et cliquez sur Enregistrer."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Phrases à score FAIBLE (score < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Ça pourrait être mieux..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Phrases de score MID (30 > score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "C'était ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Phrases à score ÉLEVÉ (60 < score)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Merveilleux..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Paramètres du serveur"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Langue préférée (nécessite un redémarrage)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Paramètres du serveur"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normaliser le volume"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Télécharger des vidéos de haute qualité"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
-"Transcode complètement la vidéo avant de la lire (meilleure compatibilité"
-" avec les navigateurs, démarrages plus lents). La taille de la mémoire "
-"tampon sera ignorée.*"
+"Transcode complètement la vidéo avant de la lire (meilleure compatibilité "
+"avec les navigateurs, démarrages plus lents). La taille de la mémoire tampon"
+" sera ignorée.*"
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
-"Activer la mise à l'échelle des pixels CDG (des visuels plus nets pour "
-"les fichiers CDG, peuvent augmenter l'utilisation du processeur)"
+"Activer la mise à l'échelle des pixels CDG (des visuels plus nets pour les "
+"fichiers CDG, peuvent augmenter l'utilisation du processeur)"
+
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Activer le nettoyage automatique des titres YouTube (supprime les mots "
+"parasites tels que \"Karaoke Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Activer la navigation dans les dossiers (ajoute une vue Dossiers à la page "
+"Morceaux lorsque la bibliothèque comporte des sous-dossiers)"
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
-"Corrige la synchronisation audio et vidéo en quelques secondes (négatif ="
-" avance l'audio | positif = retarde l'audio)"
+"Corrige la synchronisation audio et vidéo en quelques secondes (négatif = "
+"avance l'audio | positif = retarde l'audio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limite de chansons qu'un utilisateur individuel peut ajouter à la file "
@@ -1052,179 +1478,210 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
-"Activer la file d'attente équitable (le mode round-robin garantit que les"
-" utilisateurs se relaient)"
+"Activer la file d'attente équitable (le mode round-robin garantit que les "
+"utilisateurs se relaient)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
-"Taille de la mémoire tampon en kilo-octets. Transcodez cette quantité de "
-"la vidéo avant de l'envoyer à l'écran de démarrage. "
+"Taille de la mémoire tampon en kilo-octets. Transcodez cette quantité de la "
+"vidéo avant de l'envoyer à l'écran de démarrage. "
+
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Chansons par défaut par page."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Gardez le serveur éveillé : indisponible dans un conteneur. Désactivez la "
+"veille sur l'hôte."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Gardez le serveur éveillé : nécessite une inhibition de systemd (Linux) ou "
+"de la caféine (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Gardez le serveur éveillé : non pris en charge sur cette plateforme."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr ""
+"Gardez le serveur éveillé pendant que PiKaraoke est en cours d'exécution"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Effacer les préférences"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Statistiques système :"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Informations système"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Plateforme :"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Version OS :"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "Version yt-dlp :"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "Version FFmpeg :"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Version pikaraoke :"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Statistiques système :"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "Processeur :"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Chargement..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Utilisation du disque :"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Mémoire:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Mises à jour"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "Mise à jour yt-dlp"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Si les téléchargements ou les recherches ont cessé de fonctionner, la "
-"mise à jour de yt-dlp devrait résoudre le problème.\n"
+"Si les téléchargements ou les recherches ont cessé de fonctionner, la mise à jour de yt-dlp devrait résoudre le problème.\n"
 "   La version installée actuellement est : \"%(youtubedl_version)s\""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Mettre à jour yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"Le lien de mise à jour ci-dessus peut échouer si vous n'avez pas les "
-"droits nécessaires.\n"
+"Le lien de mise à jour ci-dessus peut échouer si vous n'avez pas les droits nécessaires.\n"
 "    Vérifiez le journal d'erreurs de pikaraoke."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Autre"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Redimensionner le système de fichiers Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Si vous venez d'installer l'image préconstruite de pikaraoke pi et que "
-"votre carte SD a une capacité supérieure à 4 Go,\n"
-"    vous devriez étendre le système de fichiers pour utiliser l'espace "
-"restant. Vous n'avez besoin de faire cela qu'une seule fois.\n"
+"Si vous venez d'installer l'image préconstruite de pikaraoke pi et que votre carte SD a une capacité supérieure à 4 Go,\n"
+"    vous devriez étendre le système de fichiers pour utiliser l'espace restant. Vous n'avez besoin de faire cela qu'une seule fois.\n"
 "    Cette opération redémarrera le système."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Cliquez ici pour vous déconnecter du mode administrateur."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Se déconnecter"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Arrêt"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1234,70 +1691,107 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Quitter pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Redémarrer le système"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Arrêter le système"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Possibilités"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Page précédente"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Page suivante"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} sur {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Par page"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Toutes les séances"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Téléchargements en attente"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Réessayer"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "En file d'attente"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Erreurs de téléchargement"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Échoué"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Réessayer"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Rejeter"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Faites glisser pour réorganiser"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "La file d'attente est vide"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Jouer"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1307,137 +1801,160 @@ msgstr ""
 "class=\"input mx-2 p-2\" pattern=\"\\d*\" maxlength=\"2\" value=\"3\" "
 "min=\"1\" max=\"99\" style=\"width: 42px\" />"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Tout effacer"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Jouer ensuite"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Déplacer vers le haut"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Monter"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Descendre"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Déplacer vers le bas"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Rebaptiser"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Supprimer de la file d'attente"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Redémarrage"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Sauter"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "File d'attente de téléchargement"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Chansons disponibles dans la bibliothèque locale"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Montrer"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Recherche / Ajout"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Rang"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Chansons disponibles"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Pièces"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Ajouter à la file d'attente"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Meilleures chansons"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Effacer"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Les plus performants"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Avancés"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Personne n'a encore chanté."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"Saisissez une chanson\n"
-"          (titre/artiste) pour chercher parmi les chansons disponibles et"
-" cliquez sur 'Ajouter à la file d'attente'\n"
-"          pour l'ajouter à la file d'attente."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Ajout..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Si\n"
-"          la chanson n'apparaît pas dans la liste déroulante \"Chansons "
-"disponibles\", cliquez sur\n"
-"          'Rechercher' pour la trouver sur Youtube"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "En bibliothèque"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Ajouter de nouvelles chansons de YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Recherchez YouTube par titre, artiste..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Recherche"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Inclure les résultats non-karaoké"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Avancés"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "Téléchargement direct URL Youtube :"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Collez une URL YouTube :"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr ""
-"Ajouter à la file d'attente une fois\n"
-"          téléchargé"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Télécharger"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Enregistrer pour plus tard"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1448,7 +1965,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1458,53 +1975,227 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Aperçu indisponible pour cette vidéo. Utilisez le lien YouTube sur le "
+"résultat pour le regarder."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Aucune session active"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Séance {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Nommez cette séance :"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Nom à rendre actif"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr ""
+"Supprimer {session} et toutes ses lectures ? Cela ne peut pas être annulé."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Supprimer chaque lecture enregistrée dans {session} ? La séance elle-même "
+"est conservée. Cela ne peut pas être annulé."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Aucune séance pour l'instant."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Personne n'a chanté lors de cette séance."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"Faire de {session} la session active ? De nouvelles chansons seront "
+"enregistrées contre lui."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Montrer qui a chanté"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Montre ces pièces"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Session en cours"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Nommez cette session..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Démarrer la session"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Fin de séance"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Historique des sessions"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Masquer le démarrage automatique"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Session"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Commencé"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Rendre actif"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Exporter au format CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Exporter la liste (texte)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Effacer les jeux"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Supprimer la séance"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Connexion perdue. Le serveur fonctionne-t-il toujours ?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
-"Ce navigateur n'est pas entièrement pris en charge. Vous pouvez "
-"rencontrer des problèmes de streaming. Veuillez utiliser "
-"Chrome/Safari/Firefox/Edge pour de meilleurs résultats."
+"Ce navigateur n'est pas entièrement pris en charge. Vous pouvez rencontrer "
+"des problèmes de streaming. Veuillez utiliser Chrome/Safari/Firefox/Edge "
+"pour de meilleurs résultats."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "À suivre :"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Chanteur suivant :"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Votre score"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "En raison de limitations liées aux autorisations du navigateur,\n"
-"       vous devez interagir avec la page une fois avant qu'elle "
-"n'autorise la lecture automatique des vidéos. Dans le cas contraire, "
-"pikaraoke\n"
+"       vous devez interagir avec la page une fois avant qu'elle n'autorise la lecture automatique des vidéos. Dans le cas contraire, pikaraoke\n"
 "      ne pourra pas fonctionner. Cliquez sur le bouton ci-dessous pour\n"
 "      <a onClick=\"handleConfirmation()\">confirmer</a> ."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Confirmer"
-

--- a/pikaraoke/translations/id_ID/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/id_ID/LC_MESSAGES/messages.po
@@ -4,118 +4,118 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version:  1.1.1\n"
+"Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2026-02-13 11:48+0700\n"
 "Last-Translator: birudanoranye@gmail.com\n"
-"Language: id_ID\n"
 "Language-Team: Indonesian <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Menggeser nada %s setengah nada: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Antrian download (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Mulai mengunduh: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Sedang mengunduh video: %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Gagal mengunduh lagu: "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Berhasil diunduh dan ditambahkan ke antrian: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Telah diunduh: %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Gagal menambahkan lagu ke antrian: "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "File lagu tidak ditemukan: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Streaming tidak dapat diputar! Melewati jalur"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "Lagu berhenti tidak normal: %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Lewati: %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Lanjutkan: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Jeda: %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Pengaturan Anda berhasil disimpan"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Terjadi kesalahan! Pengaturan tidak berhasil disimpan"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Pengaturan berhasil dihapus"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Terjadi kesalahan! Pengaturan tidak berhasil dihapus"
 
@@ -146,17 +146,17 @@ msgid "Song added to the queue: %s"
 msgstr "Lagu berhasil ditambahkan ke antrian: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Kosongkan antrian"
 
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Gagal membaca file: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Gagal menyiapkan streaming"
 
@@ -249,55 +249,96 @@ msgstr "Pengganti Nama Lagu Massal"
 msgid "Error: No filename parameters were specified!"
 msgstr "Gagal: tidak ada parameter nama file yang diberikan!"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "Gagal mengedit: lagu ini sedang ada di antrian: "
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "Gagal mengganti nama: '%s' → '%s', nama file sudah ada"
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Jelajahi"
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Lagu"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Anda tidak memiliki izin untuk menghapus lagu"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Gagal menghapus: lagu ini sedang ada di antrian"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Kesalahan: Tidak dapat menghapus lagu ini karena sedang dalam antrean atau "
+"sedang diputar"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Lagu dihapus: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Anda tidak memiliki izin untuk mengedit lagu"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Anda tidak memiliki izin untuk mengganti nama lagu"
 
-#: routes/files.py:211
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Lagu ini sedang diputar. Ganti namanya jika sudah selesai."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Masukkan nama untuk lagu ini."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Lagu ini sudah tidak ada lagi di perpustakaan. Mungkin telah diganti namanya"
+" atau dihapus dari perangkat lain."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Gagal mengganti nama: '%s' → '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "Lagu berjudul '%s' sudah ada."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Lagu ini mulai diputar saat Anda mengeditnya. Ganti namanya jika sudah "
+"selesai."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Kesalahan saat mengganti nama file: %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Nama file diubah: %s → %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Tidak mendukung pengecekan penggunaan CPU"
 
@@ -378,6 +419,72 @@ msgstr "Gagal memindahkan ke bawah"
 msgid "Error deleting from queue"
 msgstr "Gagal menghapus dari antrian"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Tambahkan Baru"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Anda tidak memiliki izin untuk melihat halaman ini"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Diperlukan nama"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Diperlukan sesi"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Pemutaran tidak ditemukan"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Sesi tidak ditemukan"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Dimainkan Pada"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Pemain"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Lagu"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Mainkan Sejarah"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Jangan nyanyi lagi... selamanya."
@@ -442,117 +549,149 @@ msgstr "Wah, siapa yang ngajak Freddie Mercury masuk ke sini?"
 msgid "Failed to stream subtitle: "
 msgstr "Gagal memutar subtitle: "
 
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+# auto-translated
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"Apakah Anda ingin mengganti nama pengguna perangkat ini? Nama ini akan "
-"muncul di samping lagu yang diantrikan. Nama saat ini: CURRENT_NAME"
+"Apakah Anda ingin mengubah nama orang yang menggunakan perangkat ini? Ini "
+"akan muncul pada lagu yang antri. Saat ini: {name}"
 
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Yakin ingin mengosongkan SELURUH antrian? Ketik ok untuk melanjutkan"
 
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Yakin ingin menghapus SONG_TITLE dari antrian?"
+# auto-translated
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Apakah Anda yakin ingin menghapus {title} dari antrean?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Yakin ingin menghapus lagu ini dari pustaka?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE seminada"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} seminada"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Ubah urutan lagu ini: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Ubah urutan lagu ini: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Apakah Anda yakin ingin memulai ulang trek ini?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
-"Seminada juga dikenal sebagai setengah langkah. Ini adalah interval "
-"terkecil yang digunakan dalam musik klasik Barat, sama dengan seperdua "
-"belas oktaf atau setengah nada."
+"Seminada juga dikenal sebagai setengah langkah. Ini adalah interval terkecil"
+" yang digunakan dalam musik klasik Barat, sama dengan seperdua belas oktaf "
+"atau setengah nada."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"Apakah Anda yakin ingin memperluas sistem file? Ini akan me-reboot "
-"raspberry pi Anda."
+"Apakah Anda yakin ingin memperluas sistem file? Ini akan me-reboot raspberry"
+" pi Anda."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Kesalahan"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
-"Masukkan nama Anda. Nama ini akan muncul di samping lagu yang Anda "
-"masukkan ke antrian dari perangkat ini."
+"Masukkan nama Anda. Nama ini akan muncul di samping lagu yang Anda masukkan "
+"ke antrian dari perangkat ini."
+
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Sesi saat ini: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Beranda"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Antrian"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Cari"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Peringkat"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Mainkan Sejarah"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Sesi"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Pengaturan"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Proses pemuatan mungkin memakan waktu beberapa detik karena judul lagu "
-"dibandingkan secara online. Waktu pemuatan mungkin berbeda\n"
+"Proses pemuatan mungkin memakan waktu beberapa detik karena judul lagu dibandingkan secara online. Waktu pemuatan mungkin berbeda\n"
 "\tberdasarkan koneksi internet Anda."
 
 # auto-translated
@@ -581,7 +720,8 @@ msgstr ""
 "\tuntuk mengganti nama"
 
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Tampilkan semua lagu"
 
@@ -590,88 +730,210 @@ msgstr "Tampilkan semua lagu"
 msgid "Loading songs..."
 msgstr "Memuat daftar lagu..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "Klik saran untuk menggunakannya sebagai nama file baru."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Tidak ada saran!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Edit Lagu"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Ubah Judul Lagu"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Format otomatis"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Tukar urutan artis/judul"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Ganti Nama Lagu"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Sarankan dari Last.fm"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Nama file saat ini"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Nama file baru"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Format Otomatis"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Tukar Artis/Judul"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Sarankan dari iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "Negara pencarian iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Simpan"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Membatalkan"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Hapus lagu ini"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Diurutkan berdasarkan abjad"
-
 # auto-translated
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr ""
-"Urutkan berdasarkan\n"
-"\t\t\tTanggal"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Diurutkan berdasarkan tanggal"
-
-# auto-translated
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr ""
-"Urutkan berdasarkan\n"
-"\t\t\tSesuai abjad"
-
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Edit semua lagu"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Ganti nama secara massal"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Tersedia di perpustakaan"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Semua folder"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Cari berdasarkan judul, artis..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Hapus"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Semua lagu"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Folder"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Urutkan Berdasarkan Abjad"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Urutkan berdasarkan Tanggal"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Hapus entri ini dari log pemutaran?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Belum ada yang dimainkan."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Dimainkan"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Dilewati"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Bermain"
+
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Opsi"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Tampilkan semua pemain"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Sembunyikan dilewati"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Status"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Tambah ke antrian"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Lagu ini sudah tidak ada lagi di perpustakaan"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Hapus entri"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -692,50 +954,55 @@ msgstr "Belum ada lagu di antrian."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
-"Yakin ingin melewati lagu ini? Jika bukan Anda yang menambahkannya, "
-"mintalah izin terlebih dahulu!"
+"Yakin ingin melewati lagu ini? Jika bukan Anda yang menambahkannya, mintalah"
+" izin terlebih dahulu!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Sedang Diputar"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Lagu Berikutnya"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Kontrol Pemutar"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Putar ulang dari awal"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Putar/Jeda"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Hentikan lagu saat ini"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Ubah Nada (Key)"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Terapkan"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Mikrofon"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -765,484 +1032,705 @@ msgid ""
 "Are you sure you want to update yt-dlp right now? Current and pending "
 "downloads may fail."
 msgstr ""
-"Yakin ingin memperbarui yt-dlp sekarang? Download yang sedang berjalan "
-"atau menunggu bisa gagal."
+"Yakin ingin memperbarui yt-dlp sekarang? Download yang sedang berjalan atau "
+"menunggu bisa gagal."
 
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Tidak ada mikrofon yang terdeteksi. Hubungkan mikrofon USB atau Bluetooth "
+"dan klik Refresh."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Memindai..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Menyegarkan"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Hapus SEMUA riwayat permainan - setiap sesi dan setiap permainan, selamanya?"
+" Ketik \"ok\" untuk melanjutkan."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Riwayat pemutaran terhapus"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Sinkronisasi perpustakaan selesai"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informasi"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "Alamat URL %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Kode QR alamat yang mudah dibagikan ke teman:"
 
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Admin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Masukkan kata sandi administrator"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Masuk"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Perpustakaan Lagu"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Perpustakaan"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Lagu di perpustakaan:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Sinkronkan Sekarang"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Rekonsiliasi perpustakaan dengan direktori lagu di latar belakang."
 
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Mengganti nama"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artis - Judul"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Judul - Artis"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Urutan nama lagu yang disarankan iTunes"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Setel ulang semua riwayat"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Menghapus setiap sesi dan setiap pemutaran yang direkam. Hal ini tidak dapat"
+" dibatalkan."
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Pengaturan Pengguna"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Pengaturan Layar Pembuka"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Nonaktifkan video latar belakang"
 
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Nonaktifkan musik latar belakang"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Nonaktifkan layar skor setelah setiap lagu"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Sembunyikan notifikasi"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Tampilkan jam splash"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Sembunyikan URL dan kode QR"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Sembunyikan logo di layar splash"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Sembunyikan nama sesi di layar splash"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Sembunyikan semua overlay (sedang diputar, berikutnya, dan QR code)"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume default video (min 0, maks 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume musik latar belakang (min 0, maks 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"Lama waktu tidak aktif (dalam detik) sebelum screensaver aktif. Isi 0 "
-"untuk menonaktifkan."
+"Lama waktu tidak aktif (dalam detik) sebelum screensaver aktif. Isi 0 untuk "
+"menonaktifkan."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Jeda (detik) sebelum memutar lagu berikutnya"
 
+# auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "Mikrofon terdeteksi di server. Audio disalurkan langsung ke speaker."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latensi"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Pembatalan gema"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Eksperimental"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(mengurangi umpan balik, menambah latensi)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Dukungan mikrofon tidak tersedia. Alat audio yang diperlukan tidak diinstal."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Di Linux/Raspberry Pi, instal dengan:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "dan mulai ulang PiKaraoke."
+
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Frasa Penilaian"
 
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Tambahkan satu frasa per baris di setiap kotak, lalu tekan simpan."
 
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frasa Skor RENDAH (skor < 30)"
 
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Bisa lebih baik lagi..."
 
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frasa Skor SEDANG (30 < skor < 60)"
 
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Lumayan lah..."
 
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frasa Skor TINGGI (skor > 60)"
 
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Luar biasa!"
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Pengaturan Bahasa"
 
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Bahasa pilihan (perlu restart aplikasi)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Pengaturan Server"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normalisasi volume audio"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Unduh video berkualitas tinggi"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
-"Lakukan transcode video sepenuhnya sebelum diputar (kompatibilitas "
-"browser lebih baik, tapi mulai lebih lambat). Ukuran buffer akan "
-"diabaikan.*"
+"Lakukan transcode video sepenuhnya sebelum diputar (kompatibilitas browser "
+"lebih baik, tapi mulai lebih lambat). Ukuran buffer akan diabaikan.*"
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
 "Aktifkan penskalaan piksel CDG (gambar lebih tajam untuk file CDG, bisa "
 "meningkatkan penggunaan CPU)"
 
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Aktifkan pembersihan judul YouTube otomatis (menghilangkan kata-kata berisik"
+" seperti \"Karaoke Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Aktifkan penelusuran folder (menambahkan tampilan Folder ke halaman Lagu "
+"ketika perpustakaan memiliki subfolder)"
+
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
-"Atur sinkronisasi audio dan video (dalam detik). Nilai negatif = percepat"
-" audio | positif = tunda audio"
+"Atur sinkronisasi audio dan video (dalam detik). Nilai negatif = percepat "
+"audio | positif = tunda audio"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
-"Batas lagu yang boleh ditambahkan satu pengguna ke antrian (0 = tanpa "
-"batas)"
+"Batas lagu yang boleh ditambahkan satu pengguna ke antrian (0 = tanpa batas)"
 
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
-msgstr "Aktifkan antrian yang adil (mode round-robin memastikan giliran pengguna)"
+msgstr ""
+"Aktifkan antrian yang adil (mode round-robin memastikan giliran pengguna)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
 "Ukuran buffer (kilobyte). Sebelum dikirim ke layar pembuka, video akan "
 "ditranscode sebanyak ukuran ini."
 
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Lagu default per halaman."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Jaga agar server tetap aktif: tidak tersedia dalam wadah. Nonaktifkan mode "
+"tidur pada host."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Jaga agar server tetap aktif: memerlukan systemd-inhibit (Linux) atau "
+"caffeinate (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Jaga agar server tetap aktif: tidak didukung pada platform ini."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Jaga agar server tetap aktif saat PiKaraoke sedang berjalan"
+
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Hapus pengaturan"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Data Sistem"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Informasi Sistem"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Platform:"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Versi OS:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "Versi yt-dlp:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "Versi FFmpeg:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Versi Pikaraoke:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Statistik Sistem"
 
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Memuat..."
 
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Penggunaan Disk:"
 
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Memori:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Pembaruan"
 
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "Perbarui yt-dlp"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Jika unduhan atau penelusuran berhenti berfungsi, memperbarui yt-dlp "
-"mungkin akan memperbaikinya.<br/>\n"
+"Jika unduhan atau penelusuran berhenti berfungsi, memperbarui yt-dlp mungkin akan memperbaikinya.<br/>\n"
 "\t\t\t\t\t\tVersi terinstal saat ini adalah: \"%(youtubedl_version)s\"."
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Perbarui yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"* Tautan pembaruan di atas mungkin gagal jika Anda tidak memiliki izin "
-"file yang tepat.\n"
+"* Tautan pembaruan di atas mungkin gagal jika Anda tidak memiliki izin file yang tepat.\n"
 "\t\t\t\t\t\t\tPeriksa log pikaraoke untuk kesalahan."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Lainnya"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Perluas partisi Raspberry Pi"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Jika Anda baru saja memasang gambar pikaraoke pi bawaan dan kartu SD Anda"
-" lebih besar dari 4 GB,\n"
-"\t\t\t\t\t\t\tAnda mungkin ingin memperluas sistem file untuk "
-"memanfaatkan ruang yang tersisa. Anda hanya perlu melakukan ini sekali "
-"saja.\n"
+"Jika Anda baru saja memasang gambar pikaraoke pi bawaan dan kartu SD Anda lebih besar dari 4 GB,\n"
+"\t\t\t\t\t\t\tAnda mungkin ingin memperluas sistem file untuk memanfaatkan ruang yang tersisa. Anda hanya perlu melakukan ini sekali saja.\n"
 "\t\t\t\t\t\t\tIni akan me-reboot sistem."
 
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Klik di sini untuk keluar dari mode admin."
 
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Keluar"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Matikan"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
 msgstr ""
-"Jangan langsung mencabut kabel! Matikan server dengan benar agar data "
-"tidak rusak."
+"Jangan langsung mencabut kabel! Matikan server dengan benar agar data tidak "
+"rusak."
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Keluar dari Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Restart Sistem"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Matikan Sistem"
 
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Opsi"
+# auto-translated
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Halaman sebelumnya"
 
-#: templates/queue.html:213
+# auto-translated
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Halaman berikutnya"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} dari {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Per halaman"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Semua sesi"
+
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Download tertunda"
 
+# auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Mencoba lagi"
+
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "Dalam antrian"
 
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Kesalahan Download"
 
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Gagal"
 
-#: templates/queue.html:236
+# auto-translated
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Mencoba kembali"
+
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Tutup"
 
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Seret untuk mengatur ulang urutan"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "Antrian kosong"
 
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Putar"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Jeda"
 
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1252,127 +1740,152 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> lagu acak"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Hapus semua"
 
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Putar Selanjutnya"
 
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Pindah ke atas"
 
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Naik satu"
 
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Turun satu"
 
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Pindah ke bawah"
 
-#: templates/queue.html:539
+# auto-translated
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Ganti nama"
+
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Hapus dari antrian"
 
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Putar ulang"
 
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Lewati"
 
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Antrian download"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Lagu yang tersedia di pustaka lokal"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Menunjukkan"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Cari / Tambah Baru"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Pangkat"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Lagu Tersedia"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Dimainkan"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Tambah ke antrian"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Lagu teratas"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Hapus"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Berkinerja terbaik"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Belum ada yang bernyanyi."
+
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Menambahkan..."
+
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "Di perpustakaan"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Tambahkan lagu baru dari YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Cari YouTube berdasarkan judul, artis..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Cari"
+
+#. Checkbox label which enables matching songs which are not karaoke versions
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
+msgid "Include non-karaoke matches"
+msgstr "Sertakan hasil yang bukan versi karaoke"
+
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
 msgid "Advanced"
 msgstr "Lanjutan"
 
 # auto-translated
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"- Ketikkan lagu (judul/artis) yang akan dicari\n"
-"\t\t\t\t\t\t\t\tlagu yang tersedia dan klik 'Tambahkan ke antrian' untuk "
-"menambahkannya ke antrian."
-
-# auto-translated
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"- Jika lagunya tidak muncul di\n"
-"\t\t\t\t\t\t\t\ttarik-turun \"Lagu yang Tersedia\", klik 'Cari' untuk "
-"menemukannya di Youtube"
-
-#. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
-msgid "Include non-karaoke matches"
-msgstr "Sertakan hasil yang bukan versi karaoke"
-
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "URL YouTube langsung untuk diunduh:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Tempelkan url YouTube:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Tambahkan ke antrian setelah selesai diunduh"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Unduh"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Simpan untuk nanti"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1383,7 +1896,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1392,52 +1905,224 @@ msgstr ""
 "Hasil pencarian untuk\n"
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
-#: templates/splash.html:23
+# auto-translated
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Pratinjau tidak tersedia untuk video ini. Gunakan tautan YouTube pada "
+"hasilnya untuk menontonnya."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Tidak ada sesi aktif"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Sesi {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Beri nama sesi ini:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Nama untuk diaktifkan"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr ""
+"Hapus {session} dan semua pemutarannya? Hal ini tidak dapat dibatalkan."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Hapus setiap pemutaran yang direkam di {session}? Sesi itu sendiri disimpan."
+" Hal ini tidak dapat dibatalkan."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Belum ada sesi."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Tidak ada yang bernyanyi di sesi ini."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr "Jadikan {session} sesi aktif? Lagu-lagu baru akan direkam dengan itu."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Tunjukkan siapa yang bernyanyi"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Tunjukkan drama ini"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Sesi Saat Ini"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Beri nama sesi ini..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Mulai sesi"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Akhiri sesi"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Riwayat Sesi"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Sembunyikan mulai otomatis"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sidang"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Dimulai"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Jadikan aktif"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Ekspor CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Ekspor daftar (teks)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Permainan yang jelas"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Hapus sesi"
+
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Koneksi terputus. Apakah server masih berjalan?"
 
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "Browser ini tidak sepenuhnya didukung. Anda mungkin mengalami masalah "
-"streaming. Gunakan Chrome, Safari, Firefox, atau Edge untuk hasil "
-"terbaik."
+"streaming. Gunakan Chrome, Safari, Firefox, atau Edge untuk hasil terbaik."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Selanjutnya:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Penyanyi berikutnya:"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Skor Anda"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "Karena keterbatasan izin browser, Anda harus berinteraksi\n"
-"      dengan halaman satu kali sebelum mengizinkan pemutaran otomatis "
-"video. Pikaraoke tidak akan melakukannya\n"
+"      dengan halaman satu kali sebelum mengizinkan pemutaran otomatis video. Pikaraoke tidak akan melakukannya\n"
 "      bermain sebaliknya. Klik tombol di bawah untuk\n"
 "      <a onClick=\"handleConfirmation()\">konfirmasi</a>."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Konfirmasi"
-

--- a/pikaraoke/translations/it_IT/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/it_IT/LC_MESSAGES/messages.po
@@ -7,116 +7,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2024-10-30 14:44-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: it_IT\n"
 "Language-Team: it_IT <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Trasposizione di %s semitoni: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Scaricato ed aggiunto in coda (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Scaricamento video: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Scaricamento video: %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Errore nello scaricamento della canzone: "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Scaricato ed aggiunto in coda: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Scaricato: %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Errore durante l'aggiunta del brano alla coda: "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "File del brano non trovato: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Lo streaming non era riproducibile! Salto traccia"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "La canzone si è conclusa in modo anomalo: %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Salta: %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Riprendere: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pausa: %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Le tue preferenze sono state modificate con successo"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Qualcosa è andato storto! Le tue preferenze non sono state modificate"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Le tue preferenze sono state cancellate con successo"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Qualcosa è andato storto! Le tue preferenze non sono state cancellate"
 
@@ -147,18 +147,18 @@ msgid "Song added to the queue: %s"
 msgstr "Brano aggiunto alla coda: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Coda ripulita"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Errore durante la risoluzione del file: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Impossibile preparare lo streaming"
 
@@ -212,7 +212,8 @@ msgstr "Espansione del file system e riavvio del sistema in corso!"
 #. device.
 #: routes/admin.py:153
 msgid "Cannot expand fs on non-raspberry pi devices!"
-msgstr "Impossibile espandere file system su dispositivi diversi da Raspberry Pi!"
+msgstr ""
+"Impossibile espandere file system su dispositivi diversi da Raspberry Pi!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
@@ -253,58 +254,99 @@ msgstr "Rinomina brani in batch"
 msgid "Error: No filename parameters were specified!"
 msgstr "Errore: non sono stati specificati parametri per il nome file!"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "Errore: Impossibile modificare questo brano perché è nella coda corrente:"
+msgstr ""
+"Errore: Impossibile modificare questo brano perché è nella coda corrente:"
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
-"Errore durante la ridenominazione del file: '%s' in '%s', il nome del "
-"file esiste già"
-
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Sfoglia"
+"Errore durante la ridenominazione del file: '%s' in '%s', il nome del file "
+"esiste già"
 
 # auto-translated
-#: routes/files.py:126
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Canzoni"
+
+# auto-translated
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Non hai l'autorizzazione per eliminare brani"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Errore: Impossibile eliminare questo brano perché è nella coda corrente"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Errore: impossibile eliminare questo brano perché è in coda o in "
+"riproduzione"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Canzone eliminata: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Non hai l'autorizzazione per modificare i brani"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Non hai l'autorizzazione per rinominare i brani"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Questa canzone sta suonando. Rinominarlo al termine."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Inserisci un nome per questa canzone."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Questa canzone non è più nella libreria. Potrebbe essere stato rinominato o "
+"eliminato da un altro dispositivo."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Errore durante la ridenominazione del file: '%s' in '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "Esiste già una canzone chiamata '%s'."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"La riproduzione di questo brano è iniziata mentre la stavi modificando. "
+"Rinominarlo al termine."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Errore durante la ridenominazione del file: %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "File rinominato: %s in %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Query sull'utilizzo della CPU non supportata"
 
@@ -388,6 +430,72 @@ msgstr "Errore durante lo spostamento verso il basso nella coda"
 msgid "Error deleting from queue"
 msgstr "Errore durante l'eliminazione dalla coda"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Aggiungi nuovo"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Non hai il permesso per visualizzare questa pagina"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "È richiesto un nome"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "È necessaria una sessione"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Gioco non trovato"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Sessione non trovata"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Giocato a"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Esecutore"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Canzone"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Riproduci la cronologia"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Non cantare mai più... mai più."
@@ -454,70 +562,75 @@ msgid "Failed to stream subtitle: "
 msgstr "Impossibile eseguire lo streaming dei sottotitoli:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"Vuoi cambiare il nome della persona che utilizza questo dispositivo? "
-"Questo verrà visualizzato sui brani in coda. Attuale: CURRENT_NAME"
+"Vuoi cambiare il nome della persona che utilizza questo dispositivo? Questo "
+"verrà visualizzato sui brani in coda. Corrente: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
-msgstr "Sei sicuro di voler cancellare l'INTERA coda? Digita ok per continuare"
+msgstr ""
+"Sei sicuro di voler cancellare l'INTERA coda? Digita ok per continuare"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Sei sicuro di voler eliminare SONG_TITLE dalla coda?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Sei sicuro di voler eliminare {title} dalla coda?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Vuoi davvero eliminare questa canzone dalla libreria?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE semitoni"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} semitoni"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Trasponi questa canzone: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Trasponi questa canzone: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Sei sicuro di voler riavviare questa traccia?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
 "Un semitono è noto anche come mezzo passo. È l'intervallo più piccolo "
-"utilizzato nella musica classica occidentale, pari a un dodicesimo di "
-"ottava o mezzo tono."
+"utilizzato nella musica classica occidentale, pari a un dodicesimo di ottava"
+" o mezzo tono."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -527,47 +640,72 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Errore"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
-"Inserisci il tuo nome. Questo verrà visualizzato accanto alle canzoni che"
-" metti in coda da questo dispositivo."
+"Inserisci il tuo nome. Questo verrà visualizzato accanto alle canzoni che "
+"metti in coda da questo dispositivo."
+
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Sessione corrente: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Home"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Coda"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Cerca"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Classifiche"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Gioca alla storia"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Sessioni"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Impostazioni"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Il processo di caricamento potrebbe richiedere alcuni secondi, poiché i "
-"titoli dei brani vengono confrontati online. Il tempo di caricamento può "
-"variare\n"
+"Il processo di caricamento potrebbe richiedere alcuni secondi, poiché i titoli dei brani vengono confrontati online. Il tempo di caricamento può variare\n"
 "\tin base alla tua connessione Internet."
 
 # auto-translated
@@ -598,7 +736,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Mostra tutte le canzoni"
 
@@ -608,84 +747,211 @@ msgstr "Mostra tutte le canzoni"
 msgid "Loading songs..."
 msgstr "Caricamento brani..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "Fare clic su un suggerimento per utilizzarlo come nuovo nome file."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Nessun suggerimento disponibile!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Modifica brano"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Modifica Nome Brano"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Formattazione automatica"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Cambia l'ordine degli artisti/brani"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Rinomina canzone"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Suggerimento da Last.fm"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Nome file corrente"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Nuovo nome file"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Formattazione automatica"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Scambia artista/titolo"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Suggerisci da iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "Paese di ricerca di iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Salva"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Cancellare"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Elimina questa canzone"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr ""
-"Ordinato\n"
-" Alfabeticamente"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Ordinato per data"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Ordinato per data"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "Ordina Alfabeticamente"
-
+# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Modifica brano"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Rinominazione in blocco"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Disponibile in biblioteca"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Tutte le cartelle"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Cerca per titolo, artista..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Pulisci"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Tutte le canzoni"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Cartelle"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Ordina in ordine alfabetico"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Ordina per data"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Eliminare questa voce dal registro di gioco?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Non è stato ancora giocato nulla."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Giocato"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Saltato"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Giocando"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Opzioni"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Mostra tutti gli artisti"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Nascondi ignorato"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Stato"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Aggiungi alla coda"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Questa canzone non è più nella libreria"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Elimina la voce"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -706,50 +972,55 @@ msgstr "Nessun'altra canzone in coda."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
 "Sei sicuro di voler saltare questo brano? Se non hai aggiunto questa "
 "canzone, chiedi prima il permesso!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "In riproduzione"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Prossima canzone"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Controlli riproduzione"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Riavvia canzone"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Riproduci/Pausa"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Interrompi Canzone attuale"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Cambia Tonalità"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Cambia"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Microfoni"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -785,225 +1056,363 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Nessun microfono rilevato. Collega un microfono USB o Bluetooth e fai clic "
+"su Aggiorna."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Scansione..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Aggiorna"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Eliminare TUTTA la cronologia di gioco: ogni sessione e ogni gioco, per "
+"sempre? Digita \"ok\" per continuare."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Cronologia di riproduzione cancellata"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Sincronizzazione della libreria completata"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informazioni"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "\"URL di %(site_title)s:\""
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Codice QR URL utile da condividere con un amico:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Ammin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Inserisci la password di amministrazione"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Login"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Libreria di brani"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Biblioteca"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Canzoni in libreria:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Sincronizza ora"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Riconcilia la libreria con la directory dei brani in background."
 
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Rinominare"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artista - Titolo"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Titolo - Artista"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "L'ordine dei nomi dei brani suggeriti da iTunes"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Reimposta tutta la cronologia"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Elimina ogni sessione e ogni riproduzione registrata. Questa operazione non "
+"può essere annullata."
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Preferenze Utente"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Impostazioni della schermata iniziale"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Disattiva video in sottofondo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Disattiva la musica di sottofondo"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Disattiva la schermata del punteggio dopo ogni canzone"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Nascondi notifiche"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Mostra l'orologio iniziale"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Nascondi l'URL e il codice QR"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Nascondi il logo nella schermata iniziale"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Nascondi il nome della sessione nella schermata iniziale"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Nascondi tutte le sovrapposizioni, comprese canzoni in riproduzione, "
 "successive e codice QR"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume predefinito dei video (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume della musica di sottofondo (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"Tempo di inattività in secondi prima che si attivi lo screen saver. "
-"Imposta su 0 per disattivarlo."
+"Tempo di inattività in secondi prima che si attivi lo screen saver. Imposta "
+"su 0 per disattivarlo."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Il ritardo in secondi prima dell'inizio del brano successivo"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"Microfoni rilevati sul server. L'audio viene indirizzato direttamente agli "
+"altoparlanti."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latenza"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Cancellazione dell'eco"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Sperimentale"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(riduce il feedback, aggiunge latenza)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Il supporto del microfono non è disponibile. Gli strumenti audio richiesti "
+"non sono installati."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Su Linux/Raspberry Pi, installalo con:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "e riavvia PiKaraoke."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Punteggio delle frasi"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Aggiungi una frase per riga in ogni casella e premi Salva."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frasi con punteggio BASSO (punteggio < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Potrebbe essere migliore..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frasi con punteggio MID (30 > punteggio < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Era ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frasi con punteggio ALTO (60 < punteggio)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Meraviglioso..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Impostazioni della lingua"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Lingua preferita (richiede il riavvio)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Impostazioni del server"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normalizza audio volume"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Scarica video in alta qualità"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1014,17 +1423,37 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
-"Abilita il ridimensionamento dei pixel CDG (visualizzazioni più nitide "
-"per i file CDG, possono aumentare l'utilizzo della CPU)"
+"Abilita il ridimensionamento dei pixel CDG (visualizzazioni più nitide per i"
+" file CDG, possono aumentare l'utilizzo della CPU)"
+
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Abilita la pulizia automatica dei titoli di YouTube (rimuove le parole non "
+"significative come \"Karaoke Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Abilita la navigazione delle cartelle (aggiunge una vista Cartelle alla "
+"pagina Brani quando la libreria ha sottocartelle)"
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1033,7 +1462,7 @@ msgstr ""
 "anticipa l'audio | positivo = ritarda l'audio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limite di brani che un singolo utente può aggiungere alla coda (0 = "
@@ -1041,179 +1470,209 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
-"Abilita coda corretta (la modalità round-robin garantisce che gli utenti "
-"si alternino)"
+"Abilita coda corretta (la modalità round-robin garantisce che gli utenti si "
+"alternino)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
-"Dimensione del buffer in kilobytes. Transcodifica questa quantità di "
-"video prima di inviarlo allo schermo. "
+"Dimensione del buffer in kilobytes. Transcodifica questa quantità di video "
+"prima di inviarlo allo schermo. "
+
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Canzoni predefinite per pagina."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Mantieni il server sveglio: non disponibile in un contenitore. Disabilita la"
+" sospensione sull'host."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Mantieni il server sveglio: necessita di systemd-inhibit (Linux) o "
+"caffeinate (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Mantieni il server attivo: non supportato su questa piattaforma."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Mantieni il server attivo mentre PiKaraoke è in esecuzione"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Cancella preferenze"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Statistiche di sistema"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Informazioni di sistema"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Piattaforma:"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Versione SO:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp versione:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg versione:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versione:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Statistiche di sistema"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "PROCESSORE:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Caricamento..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Utilizzo del disco:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Memoria:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Aggiornamenti"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "Aggiornamento YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Se i download o le ricerche hanno smesso di funzionare, l'aggiornamento "
-"di yt-dlp probabilmente risolverà il problema.\n"
+"Se i download o le ricerche hanno smesso di funzionare, l'aggiornamento di yt-dlp probabilmente risolverà il problema.\n"
 " La versione attualmente installata è: \"%(youtubedl_version)s\""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Aggiorna yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"Il link d'aggiornamento potrebbe non funzionare se non hai i permessi "
-"file adeguati.\n"
+"Il link d'aggiornamento potrebbe non funzionare se non hai i permessi file adeguati.\n"
 " Controlla i log di pikaraoke per eventuali errori."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Altro"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Espandi il file system del Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Se hai appena installato l'immagine pre-costruita di pikaraoke pi e la "
-"tua scheda SD è più grande di 4 GB,\n"
-" potresti voler espandere il file system per utilizzare lo spazio "
-"rimanente. Devi farlo solo una volta.\n"
+"Se hai appena installato l'immagine pre-costruita di pikaraoke pi e la tua scheda SD è più grande di 4 GB,\n"
+" potresti voler espandere il file system per utilizzare lo spazio rimanente. Devi farlo solo una volta.\n"
 " Questo riavvierà il sistema."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Fare clic qui per uscire dalla modalità amministratore."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Esci"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Spegnimento"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1223,70 +1682,107 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Esci da Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Riavvia il sistema"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Spegni il sistema"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Opzioni"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Pagina precedente"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Pagina successiva"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} di {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Per pagina"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Tutte le sessioni"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Download in sospeso"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Nuovo tentativo"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "In coda"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Scarica errori"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Fallito"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Riprova"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Congedare"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Trascina per riordinare"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "La coda è vuota"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Giocare"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pausa"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1296,136 +1792,160 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> brani casuali"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Elimina intera coda"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Gioca al prossimo"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Sposta in alto"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Spostati in alto"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Sposta giù"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Sposta in basso"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Rinominare"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Rimuovi dalla coda"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Ricomincia"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Saltare"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Coda di download"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Brani disponibili nella libreria locale"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Spettacolo"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Cerca / Aggiungi nuova"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Rango"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Brani disponibili"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Gioca"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Aggiungi alla coda"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Canzoni migliori"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Pulisci"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Migliori interpreti"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Avanzate"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Nessuno ha ancora cantato."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"Digita una canzone\n"
-" (titolo/artista) per cercare le canzoni disponibili e clicca su "
-"'Aggiungi alla coda'\n"
-" per aggiungerla alla coda."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Aggiunta..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Se\n"
-" la canzone non appare nel menu a discesa \"Brani disponibili\", clicca\n"
-" su 'Cerca' per trovarla su Youtube"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "In biblioteca"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Aggiungi nuovi brani da YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Cerca su YouTube per titolo, artista..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Cerca"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Includi risultati non karaoke"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Avanzate"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "Download diretto da indirizzo YouTube:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Incolla un URL di YouTube:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr ""
-"Aggiungi alla coda una volta\n"
-" scaricato"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Scarica"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Risparmia per dopo"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1436,7 +1956,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1446,52 +1966,227 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Anteprima non disponibile per questo video. Utilizza il collegamento YouTube"
+" sul risultato per guardarlo."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Nessuna sessione attiva"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Sessione {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Assegna un nome a questa sessione:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Nome da rendere attivo"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr ""
+"Eliminare {session} e tutte le sue riproduzioni? Questa operazione non può "
+"essere annullata."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Eliminare ogni riproduzione registrata in {session}? La sessione stessa "
+"viene mantenuta. Questa operazione non può essere annullata."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Nessuna sessione ancora."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Nessuno ha cantato in questa sessione."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"Rendere {session} la sessione attiva? Verranno registrate nuove canzoni."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Mostra chi ha cantato"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Mostra queste commedie"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Sessione corrente"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Assegna un nome a questa sessione..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Avvia sessione"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Fine sessione"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Cronologia delle sessioni"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Nascondi avvio automatico"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sessione"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Iniziato"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Rendi attivo"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Esporta CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Elenco di esportazione (testo)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Giochi chiari"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Elimina sessione"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Connessione persa. Il server è ancora in esecuzione?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
-"Questo browser non è completamente supportato. Potresti riscontrare "
-"problemi di streaming. Utilizza Chrome/Safari/Firefox/Edge per ottenere i"
-" migliori risultati."
+"Questo browser non è completamente supportato. Potresti riscontrare problemi"
+" di streaming. Utilizza Chrome/Safari/Firefox/Edge per ottenere i migliori "
+"risultati."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Prossimo brano:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Prossimo cantante:"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Il tuo punteggio"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "A causa delle limitazioni con i permessi del browser, devi interagire\n"
-" con la pagina una volta prima che consenta la riproduzione automatica "
-"dei video. Pikaraoke non\n"
+" con la pagina una volta prima che consenta la riproduzione automatica dei video. Pikaraoke non\n"
 " verrà riprodotto in caso contrario. Fai clic sul pulsante in basso per\n"
 " <a onClick=\"handleConfirmation()\">conferma</a> ."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Conferma"
-

--- a/pikaraoke/translations/ja_JP/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ja_JP/LC_MESSAGES/messages.po
@@ -7,21 +7,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-13 22:54-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: ja_JP\n"
 "Language-Team: ja_JP <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: ja_JP\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.17.0\n"
 
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "%s 半音ずつ移調します: %s"
@@ -29,110 +29,110 @@ msgstr "%s 半音ずつ移調します: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "ボリューム: %s"
 
 # auto-translated
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "ダウンロードがキューに入れられました (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "ダウンロード開始: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "ビデオをダウンロード中: %s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "曲のダウンロード中にエラーが発生しました:"
 
 # auto-translated
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "ダウンロードされキューに登録されました: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "ダウンロード済み: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "曲のキュー中にエラーが発生しました:"
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "ソング ファイルが見つかりません: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "ストリームは再生できませんでした。トラックをスキップする"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "曲が異常終了しました: %s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "スキップ: %s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "再開: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "一時停止: %s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "設定は正常に変更されました"
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "何か問題が発生しました!あなたの設定は変更されませんでした"
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "設定は正常にクリアされました"
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "何か問題が発生しました!あなたの設定はクリアされませんでした"
 
@@ -168,18 +168,18 @@ msgstr "曲がキューに追加されました: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "キューをクリアする"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "ファイル解決エラー: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "ストリームの準備に失敗しました"
 
@@ -290,62 +290,94 @@ msgid "Error: No filename parameters were specified!"
 msgstr "エラー: ファイル名パラメーターが指定されていません。"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "エラー: この曲は現在のキューにあるため編集できません:"
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "ファイル名変更エラー: '%s' から '%s'、ファイル名はすでに存在します"
 
 # auto-translated
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "ブラウズ"
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "歌"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "曲を削除する権限がありません"
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "エラー: この曲は現在のキューにあるため削除できません"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "エラー: この曲はキューに入れられているか、再生中のため削除できません"
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "削除された曲: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "曲を編集する権限がありません"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "曲の名前を変更する権限がありません"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "この曲が流れています。終了したら名前を変更します。"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "この曲の名前を入力します。"
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "この曲はもうライブラリにありません。名前が変更されたか、別のデバイスから削除された可能性があります。"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "ファイルの名前変更エラー: '%s' から '%s'、%s"
+msgid "A song called '%s' already exists."
+msgstr "「%s」という曲はすでに存在します。"
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr "この曲は編集中に再生が始まりました。終了したら名前を変更します。"
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "ファイルの名前変更中にエラーが発生しました: %s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "ファイル名を変更しました: %s から %s"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "CPU使用率クエリはサポートされていません"
 
@@ -441,6 +473,72 @@ msgid "Error deleting from queue"
 msgstr "キューから削除中にエラーが発生しました"
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "新規追加"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "このページを表示する権限がありません"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "名前は必須です"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "セッションが必要です"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "プレイが見つかりません"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "セッションが見つかりません"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "演奏場所"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "出演者"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "歌"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - プレイ履歴"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "二度と歌わないでください...二度と。"
@@ -521,66 +619,70 @@ msgid "Failed to stream subtitle: "
 msgstr "字幕のストリーミングに失敗しました:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
-msgstr "このデバイスを使用している人の名前を変更しますか?これはキューに入れられた曲に表示されます。現在: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
+msgstr "このデバイスを使用している人の名前を変更しますか?これはキューに入れられた曲に表示されます。現在: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "キュー全体をクリアしてもよろしいですか?続行するには「ok」と入力してください"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "SONG_TITLE をキューから削除してもよろしいですか?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "{title} をキューから削除してもよろしいですか?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "この曲をライブラリから削除してもよろしいですか?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE 半音"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} 半音"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "この曲を移調します: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "この曲を移調します: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "このトラックを再開してもよろしいですか?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr "半音はハーフステップとも呼ばれます。これは西洋古典音楽で使用される最小の音程で、1 オクターブの 12 分の 1 または半音に相当します。"
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -588,44 +690,70 @@ msgstr "ファイルシステムを拡張してもよろしいですか?これ�
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "エラー"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr "お名前を入力してください。これは、このデバイスからキューに追加した曲の隣に表示されます。"
 
 # auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "現在のセッション: {name}"
+
+# auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "家"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "列"
 
 # auto-translated
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "検索"
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "ランキング"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "プレイ履歴"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "セッション"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "設定"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
 "曲のタイトルはオンラインで比較されるため、読み込みプロセスには数秒かかる場合があります。ロード時間は異なる場合があります\n"
@@ -659,7 +787,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "すべての曲を表示"
 
@@ -670,97 +799,215 @@ msgid "Loading songs..."
 msgstr "曲をロード中..."
 
 # auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "候補をクリックして、新しいファイル名として使用します。"
+
+# auto-translated
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "提案はありません！"
 
 # auto-translated
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "曲を編集する"
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "曲名の変更"
 
 # auto-translated
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "曲名の編集"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "現在のファイル名"
 
 # auto-translated
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "自動フォーマット"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "新しいファイル名"
 
 # auto-translated
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "アーティスト/曲順を入れ替える"
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "オートフォーマット"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Last.fm からの提案"
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "アーティスト/タイトルを入れ替える"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "iTunesからの提案"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes の検索国"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "保存"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "キャンセル"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "この曲を削除"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "アルファベット順に並べ替え"
-
-# auto-translated
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr ""
-"並べ替え順\n"
-"\t\t\t日付"
-
-# auto-translated
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "日付順に並べ替え"
-
-# auto-translated
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr ""
-"並べ替え順\n"
-"\t\t\tアルファベット順"
-
-# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "すべての曲を編集する"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "名前の一括変更"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "図書館で利用可能"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "すべてのフォルダー"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "タイトルやアーティストで検索..."
+
+# auto-translated
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "クリア"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "全曲"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "フォルダー"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "アルファベット順に並べ替える"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "日付順に並べ替える"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "このエントリを再生ログから削除しますか?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "まだ何もプレイされていません。"
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "遊んだ"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "スキップされました"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "遊ぶ"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "オプション"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "すべての出演者を表示"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "スキップされた非表示"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "状態"
+
+# auto-translated
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "キューに追加"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "この曲はもうライブラリにありません"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "エントリの削除"
 
 # auto-translated
 #. Message which shows in the "Now Playing" section when there is no song
@@ -785,56 +1032,61 @@ msgstr "キューに登録されている曲はありません。"
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr "このトラックをスキップしてもよろしいですか?この曲を追加していない場合は、まず許可を求めてください。"
 
 # auto-translated
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "プレイ中"
 
 # auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "次の曲"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "プレーヤーのコントロール"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "リスタートソング"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "再生/一時停止"
 
 # auto-translated
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "現在の曲を停止"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "キーの変更"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "変化"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "マイク"
 
 # auto-translated
 #. Confirmation text whe the user selects quit.
@@ -873,19 +1125,50 @@ msgstr "今すぐ yt-dlp を更新してもよろしいですか?現在および
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr "マイクが検出されませんでした。 USB または Bluetooth マイクを接続し、[更新] をクリックします。"
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "走査..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "リフレッシュ"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr "すべてのプレイ履歴を削除します - すべてのセッションとすべてのプレイを永久に削除しますか? 「ok」と入力して続行します。"
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "プレイ履歴が消去されました"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "ライブラリの同期が完了しました"
 
 # auto-translated
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "情報"
 
 # auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s の URL:"
@@ -893,221 +1176,318 @@ msgstr "%(site_title)s の URL:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "友達と共有するのに便利な URL QR コード:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "管理者"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "管理者パスワードを入力してください"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "ログイン"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "ソングライブラリ"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "図書館"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "ライブラリ内の曲:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "今すぐ同期"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "バックグラウンドでライブラリと曲ディレクトリを調整します。"
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "名前の変更"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "アーティスト - タイトル"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "タイトル - アーティスト"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "iTunes で提案された曲名の順序"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "すべての履歴をリセット"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr "記録上のすべてのセッションとすべてのプレイを削除します。これを元に戻すことはできません。"
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "ユーザー設定"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "スプラッシュスクリーンの設定"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "バックグラウンドビデオを無効にする"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "バックグラウンドミュージックを無効にする"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "各曲の後にスコア画面を無効にする"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "通知を非表示にする"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "スプラッシュクロックを表示"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "URLとQRコードを非表示にする"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "スプラッシュ画面のロゴを非表示にする"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "スプラッシュ画面でセッション名を非表示にする"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "現在再生中、次の再生、QR コードを含むすべてのオーバーレイを非表示にします"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "ビデオのデフォルトの音量 (最小 0、最大 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "BGM の音量 (最小 0、最大 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr "スクリーン セーバーがアクティブになるまでのアイドル時間 (秒単位)。無効にするには 0 に設定します。"
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "次の曲が始まるまでの遅延秒数"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "オーディオ"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "サーバー上でマイクが検出されました。オーディオはスピーカーに直接ルーティングされます。"
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "レイテンシー"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "エコーキャンセル"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "実験的"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(フィードバックを減らし、レイテンシを追加します)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr "マイクのサポートは利用できません。必要なオーディオ ツールがインストールされていません。"
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Linux / Raspberry Pi では、次のようにインストールします。"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "そしてPiKaraokeを再起動してください。"
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "スコアフレーズ"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "各ボックスに 1 行に 1 つのフレーズを追加し、保存をクリックします。"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "低スコアのフレーズ (スコア < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "もっと良いかもしれない..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID スコア フレーズ (30 > スコア < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "それは大丈夫でした..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "高スコアのフレーズ (60 < スコア)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "素晴らしい..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "言語設定"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "優先言語 (再起動が必要)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "サーバー設定"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "オーディオの音量を正規化する"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "高品質のビデオをダウンロードする"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1115,15 +1495,31 @@ msgstr "再生前にビデオを完全にトランスコードします (ブラ�
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr "CDG ピクセル スケーリングを有効にする (CDG ファイルのビジュアルがより鮮明になり、CPU 使用率が増加する可能性があります)"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr "YouTube タイトルの自動クリーンアップを有効にする (「カラオケ バージョン HD」などのノイズ ワードを除去)"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr "フォルダーの参照を有効にする (ライブラリにサブフォルダーがある場合、フォルダー ビューを [曲] ページに追加します)"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1131,121 +1527,154 @@ msgstr "音声とビデオの同期を数秒で修正します (負 = 音声を�
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "個々のユーザーがキューに追加できる曲の制限 (0 = 無制限)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "公平なキューを有効にする (ラウンドロビン モードにより、ユーザーが順番に交代できるようになります)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr "キロバイト単位のバッファ サイズ。スプラッシュ画面に送信する前に、この量のビデオをトランスコードします。"
 
 # auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "ページごとのデフォルトの曲。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr "サーバーを起動したままにします。コンテナーでは使用できません。ホストのスリープを無効にします。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr "サーバーを起動したままにします。systemd-inhibit (Linux) または caffeinate (macOS) が必要です。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "サーバーを起動したままにします: このプラットフォームではサポートされていません。"
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "PiKaraoke の実行中はサーバーを起動したままにします"
+
+# auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "設定をクリアする"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "システムデータ"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "システム情報"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "プラットフォーム:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "OSバージョン:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp バージョン:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpegのバージョン:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "ピカオケバージョン："
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "システム統計"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU："
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "読み込み中..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "ディスク使用量:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "メモリ："
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "アップデート"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP アップデート"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
@@ -1255,17 +1684,16 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "yt-dlp を更新する"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
 "* 適切なファイル権限がない場合、上記の更新リンクは失敗する可能性があります。\n"
@@ -1273,26 +1701,24 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "他の"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Raspberry Pi ファイルシステムを拡張する"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
 "事前に構築された pikaraoke pi イメージをインストールしたばかりで、SD カードの容量が 4GB を超えている場合は、\n"
@@ -1301,26 +1727,26 @@ msgstr ""
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "管理者モードからログアウトするには、ここをクリックしてください。"
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "ログアウト"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "シャットダウン"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1329,222 +1755,279 @@ msgstr "ただプラグを抜くのはやめてください！データの破損
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "ピカカラオケをやめる"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "システムを再起動します"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "シャットダウンシステム"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "オプション"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "前のページへ"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "次のページ"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end}/{total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "ページごと"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "すべてのセッション"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "保留中のダウンロード"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "再試行中"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "キューに入れられました"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "ダウンロードエラー"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "失敗した"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "リトライ"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "却下する"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "ドラッグして並べ替えます"
 
 # auto-translated
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "キューは空です"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "遊ぶ"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "一時停止"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> random songs"
 msgstr ""
-"<input id=\"randomNumberInput\" class=\"input mx-2 p-2\" pattern=\"\\d*\""
-" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" "
-"/> ランダムな曲を追加します"
+"<input id=\"randomNumberInput\" class=\"input mx-2 p-2\" pattern=\"\\d*\" "
+"maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" /> "
+"ランダムな曲を追加します"
 
 # auto-translated
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "すべてクリア"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "次にプレイ"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "先頭に移動"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "上に移動"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "下に移動"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "一番下に移動"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "名前の変更"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "キューから削除"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "再起動"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "スキップ"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "ダウンロードキュー"
 
 # auto-translated
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "ローカルライブラリで利用可能な曲"
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "見せる"
 
 # auto-translated
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "検索/新規追加"
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "ランク"
 
 # auto-translated
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "利用可能な曲"
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "演劇"
 
 # auto-translated
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "キューに追加"
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "トップソング"
 
 # auto-translated
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "クリア"
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "トップパフォーマー"
 
 # auto-translated
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "高度な"
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "まだ誰も歌っていません。"
 
 # auto-translated
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"- 曲（タイトル/アーティスト）を入力して検索します\n"
-"\t\t\t\t\t\t\t\t利用可能な曲を選択し、「キューに追加」をクリックしてキューに追加します。"
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "追加中..."
 
 # auto-translated
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"- 曲が表示されない場合\n"
-"\t\t\t\t\t\t\t\t「利用可能な曲」ドロップダウンで「検索」をクリックして YouTube で曲を見つけます"
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "図書館内"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "YouTube から新しい曲を追加する"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "タイトルやアーティストで YouTube を検索..."
+
+# auto-translated
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "検索"
 
 # auto-translated
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "カラオケ以外の試合も含める"
 
 # auto-translated
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "高度な"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "YouTube の URL を直接ダウンロード:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "YouTube の URL を貼り付けます:"
 
 # auto-translated
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "ダウンロードしたらキューに追加"
-
-# auto-translated
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "ダウンロード"
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "後で使うために保存しておきます"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1555,7 +2038,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1565,44 +2048,214 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr "このビデオではプレビューを利用できません。結果を視聴するには、結果の YouTube リンクを使用してください。"
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "アクティブなセッションがありません"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "セッション {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "このセッションに名前を付けます:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "アクティブにする名前"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "{session} とそのすべてのプレイを削除しますか?これを元に戻すことはできません。"
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr "{session} に記録されたすべてのプレイを削除しますか?セッション自体は維持されます。これを元に戻すことはできません。"
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "まだセッションはありません。"
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "このセッションでは誰も歌っていません。"
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr "{session} をアクティブなセッションにしますか?それに合わせて新曲もレコーディングされる予定です。"
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "誰が歌ったのかを表示"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "これらの劇を見せてください"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "現在のセッション"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "このセッションに名前を付けます..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "セッションを開始する"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "セッションを終了する"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "セッション履歴"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "自動起動を非表示にする"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "セッション"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "開始しました"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "アクティブにする"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "CSVのエクスポート"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "エクスポートリスト（テキスト）"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "クリアプレー"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "セッションの削除"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "接続が失われました。サーバーはまだ稼働していますか?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "このブラウザは完全にはサポートされていません。ストリーミングの問題が発生する可能性があります。最良の結果を得るには、Chrome/Safari/Firefox/Edge"
 " を使用してください。"
 
 # auto-translated
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "次は:"
 
 # auto-translated
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "次の歌手:"
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "あなたのスコア"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
@@ -1613,7 +2266,6 @@ msgstr ""
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "確認する"
-

--- a/pikaraoke/translations/ko_KR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ko_KR/LC_MESSAGES/messages.po
@@ -7,21 +7,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-13 22:55-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: ko_KR\n"
 "Language-Team: ko_KR <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.17.0\n"
 
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "%s 반음씩 조옮김: %s"
@@ -29,110 +29,110 @@ msgstr "%s 반음씩 조옮김: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "볼륨: %s"
 
 # auto-translated
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "다운로드 대기 중(#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "다운로드 시작: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "비디오 다운로드 중: %s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "노래 다운로드 중 오류 발생:"
 
 # auto-translated
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "다운로드되어 대기 중: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "다운로드됨: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "노래를 대기열에 추가하는 중에 오류가 발생했습니다."
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "노래 파일을 찾을 수 없습니다: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "스트림을 재생할 수 없습니다! 트랙 건너뛰기"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "노래가 비정상적으로 종료되었습니다: %s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "건너뛰기: %s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "재개: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "일시중지: %s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "환경설정이 성공적으로 변경되었습니다."
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "문제가 발생했습니다. 환경설정이 변경되지 않았습니다."
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "환경설정이 삭제되었습니다."
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "문제가 발생했습니다. 환경설정이 삭제되지 않았습니다."
 
@@ -168,18 +168,18 @@ msgstr "대기열에 추가된 노래: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "대기열 지우기"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "파일을 해결하는 중 오류 발생: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "스트림을 준비하지 못했습니다."
 
@@ -290,62 +290,94 @@ msgid "Error: No filename parameters were specified!"
 msgstr "오류: 파일 이름 매개변수가 지정되지 않았습니다!"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "오류: 이 노래는 현재 대기열에 있으므로 편집할 수 없습니다."
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "파일 이름을 바꾸는 중 오류 발생: '%s'을(를) '%s'(으)로 변경, 파일 이름이 이미 존재합니다."
 
 # auto-translated
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "탐색"
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "노래"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "노래를 삭제할 권한이 없습니다."
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "오류: 이 노래는 현재 대기열에 있으므로 삭제할 수 없습니다."
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "오류: 이 노래는 대기 중이거나 재생 중이므로 삭제할 수 없습니다."
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "삭제된 노래: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "노래를 편집할 권한이 없습니다."
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "노래 이름을 바꿀 권한이 없습니다."
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "이 노래가 재생되고 있습니다. 완료되면 이름을 바꾸십시오."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "이 노래의 이름을 입력하세요."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "이 노래는 더 이상 라이브러리에 없습니다. 다른 장치에서 이름이 변경되었거나 삭제되었을 수 있습니다."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "파일 이름을 바꾸는 중 오류 발생: '%s'을(를) '%s', %s(으)로"
+msgid "A song called '%s' already exists."
+msgstr "'%s'이라는 노래가 이미 존재합니다."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr "편집하는 동안 이 노래가 재생되기 시작했습니다. 완료되면 이름을 바꾸십시오."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "파일 이름을 바꾸는 중 오류 발생: %s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "파일 이름이 변경되었습니다: %s에서 %s(으)로"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "CPU 사용량 쿼리가 지원되지 않습니다."
 
@@ -441,6 +473,72 @@ msgid "Error deleting from queue"
 msgstr "대기열에서 삭제하는 중에 오류가 발생했습니다."
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "새로 추가"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "이 페이지를 볼 수 있는 권한이 없습니다."
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "이름은 필수 항목입니다."
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "세션이 필요합니다."
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "플레이를 찾을 수 없습니다"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "세션을 찾을 수 없습니다"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "플레이 시간"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "수행자"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "노래"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - 플레이 기록"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "다시는 노래하지 마세요... 절대."
@@ -521,66 +619,70 @@ msgid "Failed to stream subtitle: "
 msgstr "자막 스트리밍 실패:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
-msgstr "이 장치를 사용하는 사람의 이름을 변경하시겠습니까? 이는 대기 중인 노래에 표시됩니다. 현재: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
+msgstr "이 장치를 사용하는 사람의 이름을 변경하시겠습니까? 이는 대기 중인 노래에 표시됩니다. 현재: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "대기열 전체를 삭제하시겠습니까? 계속하려면 확인을 입력하세요."
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "대기열에서 SONG_TITLE을 삭제하시겠습니까?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "대기열에서 {title}을(를) 삭제하시겠습니까?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "정말로 이 노래를 라이브러리에서 삭제하시겠습니까?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE 반음"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} 반음"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "이 노래를 조옮김하세요: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "이 노래를 조옮김하세요: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "이 트랙을 다시 시작하시겠습니까?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr "반음은 반음이라고도 합니다. 고전 서양 음악에서 사용되는 가장 작은 간격으로 1/12옥타브 또는 1/2음에 해당합니다."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -588,44 +690,70 @@ msgstr "파일 시스템을 확장하시겠습니까? 그러면 라즈베리 파
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "오류"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr "이름을 입력해주세요. 이 장치에서 대기열에 추가한 노래 옆에 표시됩니다."
 
 # auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "현재 세션: {name}"
+
+# auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "집"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "대기줄"
 
 # auto-translated
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "찾다"
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "순위"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "플레이 기록"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "세션"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "설정"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
 "노래 제목이 온라인에서 비교되므로 로딩 프로세스는 몇 초 정도 걸릴 수 있습니다. 로딩 시간은 다를 수 있습니다\n"
@@ -659,7 +787,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "모든 노래 표시"
 
@@ -670,97 +799,215 @@ msgid "Loading songs..."
 msgstr "노래 로드 중..."
 
 # auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "새 파일 이름으로 사용하려면 제안을 클릭하세요."
+
+# auto-translated
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "제안이 없습니다!"
 
 # auto-translated
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "노래 편집"
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "노래 이름 바꾸기"
 
 # auto-translated
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "노래 이름 편집"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "현재 파일 이름"
 
 # auto-translated
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "새 파일 이름"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
 msgstr "자동 포맷"
 
 # auto-translated
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "아티스트/노래 순서 교체"
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "아티스트/타이틀 교체"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Last.fm에서 제안"
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "iTunes에서 제안"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes 검색 국가"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "구하다"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "취소"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "이 노래 삭제"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
+#. Button to open the batch song renamer page.
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "일괄 이름 바꾸기"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "도서관에서 이용 가능"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "모든 폴더"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "제목, 아티스트로 검색..."
+
+# auto-translated
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "분명한"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "모든 노래"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "폴더"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
 msgstr "알파벳순으로 정렬"
 
 # auto-translated
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr ""
-"정렬 기준\n"
-"\t\t\t날짜"
-
-# auto-translated
-#. Label which displays that the songs are currently sorted by
+#. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "날짜별로 정렬"
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "날짜순으로 정렬"
 
 # auto-translated
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr ""
-"정렬 기준\n"
-"\t\t\t알파벳순"
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "플레이 로그에서 이 항목을 삭제하시겠습니까?"
 
 # auto-translated
-#. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "모든 노래 편집"
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "아직 재생된 항목이 없습니다."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "플레이함"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "건너뛰었습니다."
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "재생"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "옵션"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "모든 출연자 표시"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "건너뛴 숨기기"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "상태"
+
+# auto-translated
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "대기열에 추가"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "이 노래는 더 이상 라이브러리에 없습니다."
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "항목 삭제"
 
 # auto-translated
 #. Message which shows in the "Now Playing" section when there is no song
@@ -785,56 +1032,61 @@ msgstr "대기 중인 노래가 없습니다."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr "이 트랙을 건너뛰시겠습니까? 이 노래를 추가하지 않았다면 먼저 권한을 요청하세요!"
 
 # auto-translated
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "지금 재생 중"
 
 # auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "다음 노래"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "플레이어 제어"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "노래 다시 시작"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "재생/일시 정지"
 
 # auto-translated
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "현재 노래 중지"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "키 변경"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "변화"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "마이크"
 
 # auto-translated
 #. Confirmation text whe the user selects quit.
@@ -873,19 +1125,50 @@ msgstr "지금 yt-dlp을 업데이트하시겠습니까? 현재 및 보류 중�
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr "마이크가 감지되지 않았습니다. USB 또는 Bluetooth 마이크를 연결하고 새로 고침을 클릭하세요."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "스캐닝..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "새로 고치다"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr "모든 플레이 기록을 삭제하세요. 모든 세션과 모든 플레이를 영원히 삭제하시겠습니까? 계속하려면 \"확인\"을 입력하세요."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "플레이 기록이 지워졌습니다."
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "라이브러리 동기화 완료"
 
 # auto-translated
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "정보"
 
 # auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s의 URL:"
@@ -893,221 +1176,318 @@ msgstr "%(site_title)s의 URL:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "친구와 공유할 수 있는 편리한 URL QR 코드:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "관리자"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "관리자 비밀번호를 입력하세요"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "로그인"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "노래 라이브러리"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "도서관"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "라이브러리에 있는 노래:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "지금 동기화"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "백그라운드에서 노래 디렉토리와 라이브러리를 조정합니다."
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "이름 바꾸기"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "아티스트 - 제목"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "제목 - 아티스트"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "iTunes 추천 노래 이름 순서"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "모든 기록 재설정"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr "기록된 모든 세션과 모든 플레이를 삭제합니다. 이 작업은 취소할 수 없습니다."
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "사용자 환경설정"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "스플래시 화면 설정"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "배경 비디오 비활성화"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "배경 음악 비활성화"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "각 노래가 끝난 후 점수 화면을 비활성화합니다."
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "알림 숨기기"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "스플래시 시계 표시"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "URL 및 QR 코드 숨기기"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "시작 화면에서 로고 숨기기"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "시작 화면에서 세션 이름 숨기기"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "지금 재생 중, 다음 동영상, QR 코드를 포함한 모든 오버레이 숨기기"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "동영상 기본 볼륨(최소 0, 최대 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "배경음악 볼륨 (최소 0, 최대 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr "화면 보호기가 활성화되기 전의 유휴 시간(초)입니다. 비활성화하려면 0으로 설정합니다."
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "다음 노래를 시작하기까지의 지연 시간(초)"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "오디오"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "서버에서 마이크가 감지되었습니다. 오디오는 스피커로 직접 라우팅됩니다."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "숨어 있음"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "에코 취소"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "실험적"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(피드백 감소, 대기 시간 추가)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr "마이크 지원을 사용할 수 없습니다. 필수 오디오 도구가 설치되지 않았습니다."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Linux/Raspberry Pi에서는 다음을 사용하여 설치합니다."
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "PiKaraoke를 다시 시작하세요."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "점수 문구"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "각 상자에 한 줄에 하나의 문구를 추가하고 저장을 누르세요."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "낮은 점수 문구(점수 < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "더 좋을 수도..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID 점수 구문(30 > 점수 < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "괜찮았어..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "높은 점수 문구 (60 < 점수)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "훌륭해요..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "언어 설정"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "기본 언어(다시 시작해야 함)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "서버 설정"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "오디오 볼륨 표준화"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "고품질 비디오 다운로드"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1115,15 +1495,31 @@ msgstr "재생하기 전에 비디오를 완전히 트랜스코딩합니다(브�
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr "CDG 픽셀 스케일링 활성화(CDG 파일의 시각적 효과가 더욱 선명해지며 CPU 사용량이 증가할 수 있음)"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr "자동 YouTube 제목 정리 사용('Karaoke Version HD'와 같은 의미 없는 단어 제거)"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr "폴더 탐색 활성화(라이브러리에 하위 폴더가 있는 경우 노래 페이지에 폴더 보기 추가)"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1131,121 +1527,154 @@ msgstr "몇 초 만에 오디오 및 비디오 동기화 수정(음수 = 오디�
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "개별 사용자가 대기열에 추가할 수 있는 노래 제한(0 = 무제한)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "공정한 대기열 활성화(라운드 로빈 모드로 사용자가 차례대로 진행되도록 보장)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr "버퍼 크기(KB)입니다. 스플래시 화면으로 보내기 전에 이 정도의 비디오를 트랜스코딩합니다."
 
 # auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "페이지당 기본 노래."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr "서버를 깨우세요: 컨테이너에서는 사용할 수 없습니다. 호스트에서 절전 모드를 비활성화합니다."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr "서버를 깨우세요: systemd-inhibit(Linux) 또는 카페인(macOS)이 필요합니다."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "서버를 깨우세요: 이 플랫폼에서는 지원되지 않습니다."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "PiKaraoke가 실행되는 동안 서버를 깨워두세요"
+
+# auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "환경설정 지우기"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "시스템 데이터"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "시스템 정보"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "플랫폼:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "운영체제 버전:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp(yt-dlp) 버전:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg 버전:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "피카라오케 버전:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "시스템 통계"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "로드 중..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "디스크 사용량:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "메모리:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "업데이트"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP 업데이트"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
@@ -1255,17 +1684,16 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "yt-dlp 업데이트"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
 "* 위의 업데이트 링크는 적절한 파일 권한이 없을 경우 실패할 수 있습니다.\n"
@@ -1273,26 +1701,24 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "다른"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Raspberry Pi 파일 시스템 확장"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
 "사전 구축된 피노래방 파이 이미지를 방금 설치했고 SD 카드가 4GB보다 큰 경우,\n"
@@ -1301,26 +1727,26 @@ msgstr ""
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "관리자 모드에서 로그아웃하려면 여기를 클릭하세요."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "로그아웃"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "일시 휴업"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1329,222 +1755,279 @@ msgstr "플러그만 뽑지 마세요! 데이터 손상을 방지하려면 항�
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "피카라오케 종료"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "시스템 재부팅"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "셧다운 시스템"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "옵션"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "이전 페이지"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "다음 페이지"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{total}의 {start}-{end}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "페이지당"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "모든 세션"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "다운로드 대기 중"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "재시도 중"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "대기 중"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "다운로드 오류"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "실패한"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "다시 해 보다"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "해고하다"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "드래그하여 재정렬하세요."
 
 # auto-translated
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "대기열이 비어 있습니다."
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "놀다"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "정지시키다"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> random songs"
 msgstr ""
-"<input id=\"randomNumberInput\" class=\"input mx-2 p-2\" pattern=\"\\d*\""
-" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" "
-"/> 임의 노래 추가"
+"<input id=\"randomNumberInput\" class=\"input mx-2 p-2\" pattern=\"\\d*\" "
+"maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" /> 임의"
+" 노래 추가"
 
 # auto-translated
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "모두 지우기"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "다음 플레이"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "맨 위로 이동"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "위로 이동"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "아래로 이동"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "맨 아래로 이동"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "이름 바꾸기"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "대기열에서 제거"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "다시 시작"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "건너뛰다"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "대기열 다운로드"
 
 # auto-translated
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "로컬 라이브러리에서 사용 가능한 노래"
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "보여주다"
 
 # auto-translated
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "검색/새로 추가"
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "계급"
 
 # auto-translated
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "사용 가능한 노래"
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "연극"
 
 # auto-translated
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "대기열에 추가"
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "인기곡"
 
 # auto-translated
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "분명한"
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "최고 성과자"
 
 # auto-translated
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "고급의"
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "아직 노래를 부른 사람은 없습니다."
 
 # auto-translated
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"- 검색할 노래(제목/아티스트)를 입력하세요.\n"
-"\t\t\t\t\t\t\t\t사용 가능한 노래를 선택하고 '대기열에 추가'를 클릭하여 대기열에 추가하세요."
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "첨가..."
 
 # auto-translated
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"- 노래가 나오지 않는 경우\n"
-"\t\t\t\t\t\t\t\t\"사용 가능한 노래\" 드롭다운에서 '검색'을 클릭하여 YouTube에서 찾으세요."
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "도서관에서"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "YouTube에서 새 노래 추가"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "YouTube에서 제목, 아티스트 등으로 검색하세요."
+
+# auto-translated
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "찾다"
 
 # auto-translated
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "노래방이 아닌 경기 포함"
 
 # auto-translated
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "고급의"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "직접 다운로드 YouTube URL:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "YouTube URL 붙여넣기:"
 
 # auto-translated
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "다운로드 후 대기열에 추가"
-
-# auto-translated
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "다운로드"
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "나중을 위해 저장"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1555,7 +2038,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1565,44 +2048,214 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr "이 동영상을 미리 볼 수 없습니다. 결과에 있는 YouTube 링크를 이용하여 시청하세요."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "활성 세션 없음"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "세션 {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "이 세션의 이름을 지정하십시오."
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "활성화할 이름"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "{session} 및 모든 플레이를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr "{session}에 기록된 모든 플레이를 삭제하시겠습니까? 세션 자체는 유지됩니다. 이 작업은 취소할 수 없습니다."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "아직 세션이 없습니다."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "이번 세션에는 아무도 노래를 부르지 않았습니다."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr "{session}을(를) 활성 세션으로 만드시겠습니까? 이에 대한 새로운 노래가 녹음됩니다."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "누가 노래했는지 보여주세요"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "이 연극을 보여주세요"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "현재 세션"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "이 세션의 이름을 지정하세요..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "세션 시작"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "세션 종료"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "세션 기록"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "자동 시작 숨기기"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "세션"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "시작됨"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "활성화"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "CSV 내보내기"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "목록 내보내기(텍스트)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "명확한 플레이"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "세션 삭제"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "연결이 끊겼습니다. 서버가 아직 실행 중인가요?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "이 브라우저는 완전히 지원되지 않습니다. 스트리밍 문제가 발생할 수 있습니다. 최상의 결과를 얻으려면 "
 "Chrome/Safari/Firefox/Edge를 사용하십시오."
 
 # auto-translated
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "다음 단계:"
 
 # auto-translated
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "다음 가수:"
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "당신의 점수"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
@@ -1613,7 +2266,6 @@ msgstr ""
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "확인하다"
-

--- a/pikaraoke/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/nb_NO/LC_MESSAGES/messages.po
@@ -7,21 +7,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-14 10:27-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: nb_NO\n"
 "Language-Team: nb_NO <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: nb_NO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponering med %s halvtoner: %s"
@@ -29,110 +29,110 @@ msgstr "Transponering med %s halvtoner: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volum: %s"
 
 # auto-translated
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Nedlastingskø (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Nedlasting starter: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Laster ned video: %s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Feil ved nedlasting av sang:"
 
 # auto-translated
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Lastet ned og satt i kø: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Lastet ned: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Feil ved å sette sang i kø:"
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Sangfil ikke funnet: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Strømmen var ikke spillbar! Hopp over sporet"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "Sangen avsluttet unormalt: %s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Hopp over: %s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Fortsett: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pause: %s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Preferansene dine ble endret"
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Noe gikk galt! Preferansene dine ble ikke endret"
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Preferansene dine ble slettet"
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Noe gikk galt! Preferansene dine ble ikke slettet"
 
@@ -168,18 +168,18 @@ msgstr "Sang lagt til i køen: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Fjern kø"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Feil ved løsning av fil: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Kunne ikke forberede strømmen"
 
@@ -290,13 +290,12 @@ msgid "Error: No filename parameters were specified!"
 msgstr "Feil: Ingen filnavnparametere ble spesifisert!"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "Feil: Kan ikke redigere denne sangen fordi den er i gjeldende kø:"
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
@@ -304,50 +303,87 @@ msgstr ""
 "allerede"
 
 # auto-translated
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Bla gjennom"
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Sanger"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Du har ikke tillatelse til å slette sanger"
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Feil: Kan ikke slette denne sangen fordi den er i gjeldende kø"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "Feil: Kan ikke slette denne sangen fordi den er i kø eller spilles av"
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Sang slettet: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Du har ikke tillatelse til å redigere sanger"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Du har ikke tillatelse til å gi nytt navn til sanger"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Denne sangen spilles. Gi det nytt navn når det er ferdig."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Skriv inn et navn for denne sangen."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Denne sangen er ikke lenger på biblioteket. Det kan ha blitt omdøpt eller "
+"slettet fra en annen enhet."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Feil ved å gi nytt navn til filen: '%s' til '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "En sang kalt «%s» finnes allerede."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Denne sangen begynte å spille mens du redigerte den. Gi det nytt navn når "
+"det er ferdig."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Feil ved å gi nytt navn til fil: %s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Omdøpt fil: %s til %s"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "CPU-bruk-spørring støttes ikke"
 
@@ -443,6 +479,72 @@ msgid "Error deleting from queue"
 msgstr "Feil ved sletting fra køen"
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Legg til ny"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Du har ikke tillatelse til å se denne siden"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Et navn kreves"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "En økt er nødvendig"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Spillet ble ikke funnet"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Finner ikke økten"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Spilt kl"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Utøver"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Sang"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Spillehistorie"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Aldri syng igjen... aldri."
@@ -523,88 +625,92 @@ msgid "Failed to stream subtitle: "
 msgstr "Kunne ikke strømme undertekst:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"Vil du endre navnet på personen som bruker denne enheten? Dette vil vises"
-" på sanger i kø. Nåværende: CURRENT_NAME"
+"Vil du endre navnet på personen som bruker denne enheten? Dette vil vises på"
+" sanger i kø. Nåværende: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Er du sikker på at du vil tømme HELE køen? Skriv ok for å fortsette"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Er du sikker på at du vil slette SONG_TITLE fra køen?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Er du sikker på at du vil slette {title} fra køen?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Er du sikker på at du vil slette denne sangen fra biblioteket?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE halvtoner"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} halvtoner"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Transponere denne sangen: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Transponere denne sangen: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Er du sikker på at du vil starte dette sporet på nytt?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
-"En halvtone er også kjent som et halvtrinn. Det er det minste intervallet"
-" som brukes i klassisk vestlig musikk, lik en tolvtedel av en oktav eller"
-" en halv tone."
+"En halvtone er også kjent som et halvtrinn. Det er det minste intervallet "
+"som brukes i klassisk vestlig musikk, lik en tolvtedel av en oktav eller en "
+"halv tone."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"Er du sikker på at du vil utvide filsystemet? Dette vil starte Raspberry "
-"Pi på nytt."
+"Er du sikker på at du vil utvide filsystemet? Dette vil starte Raspberry Pi "
+"på nytt."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Feil"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -613,34 +719,59 @@ msgstr ""
 "setter i kø fra denne enheten."
 
 # auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Gjeldende økt: {name}"
+
+# auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Hjem"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Kø"
 
 # auto-translated
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Søk"
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Rangeringer"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Spillhistorikk"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Økter"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Innstillinger"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Lasteprosessen kan ta noen sekunder, ettersom sangtitlene sammenlignes på"
-" nettet. Lastetiden kan variere\n"
+"Lasteprosessen kan ta noen sekunder, ettersom sangtitlene sammenlignes på nettet. Lastetiden kan variere\n"
 "\tbasert på internettforbindelsen din."
 
 # auto-translated
@@ -671,7 +802,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Vis alle sangene"
 
@@ -682,97 +814,215 @@ msgid "Loading songs..."
 msgstr "Laster inn sanger ..."
 
 # auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "Klikk på et forslag for å bruke det som det nye filnavnet."
+
+# auto-translated
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Ingen forslag!"
 
 # auto-translated
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Rediger sang"
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Gi nytt navn til sangen"
 
 # auto-translated
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Rediger sangnavn"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Gjeldende filnavn"
 
 # auto-translated
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Nytt filnavn"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
 msgstr "Automatisk formatering"
 
 # auto-translated
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Bytt artist/låtrekkefølge"
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Bytt artist/tittel"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Foreslå fra Last.fm"
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Foreslå fra iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes-søkeland"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Spare"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Kansellere"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Slett denne sangen"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Sortert alfabetisk"
-
-# auto-translated
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr ""
-"Sorter etter\n"
-"\t\t\tDato"
-
-# auto-translated
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Sortert etter dato"
-
-# auto-translated
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr ""
-"Sorter etter\n"
-"\t\t\tAlfabetisk"
-
-# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Rediger alle sangene"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Gi nytt navn"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Tilgjengelig på biblioteket"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Alle mapper"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Søk etter tittel, artist..."
+
+# auto-translated
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Klar"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Alle sanger"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Mapper"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Sorter alfabetisk"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Sorter etter dato"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Vil du slette denne oppføringen fra spilleloggen?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Ingenting er spilt ennå."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Spilt"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Hoppet over"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Spiller"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Alternativer"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Vis alle utøvere"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Skjul hoppet over"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Status"
+
+# auto-translated
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Legg til i kø"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Denne sangen er ikke lenger på biblioteket"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Slett oppføring"
 
 # auto-translated
 #. Message which shows in the "Now Playing" section when there is no song
@@ -797,58 +1047,63 @@ msgstr "Ingen sang står i kø."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
-"Er du sikker på at du vil hoppe over dette sporet? Hvis du ikke har lagt "
-"til denne sangen, spør om tillatelse først!"
+"Er du sikker på at du vil hoppe over dette sporet? Hvis du ikke har lagt til"
+" denne sangen, spør om tillatelse først!"
 
 # auto-translated
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Spiller nå"
 
 # auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Neste sang"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Spillerkontroll"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Start sangen på nytt"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Spill av/pause"
 
 # auto-translated
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Stopp gjeldende sang"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Endre nøkkel"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Endre"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Mikrofoner"
 
 # auto-translated
 #. Confirmation text whe the user selects quit.
@@ -883,25 +1138,60 @@ msgid ""
 "Are you sure you want to update yt-dlp right now? Current and pending "
 "downloads may fail."
 msgstr ""
-"Er du sikker på at du vil oppdatere yt-dlp akkurat nå? Gjeldende og "
-"ventende nedlastinger kan mislykkes."
+"Er du sikker på at du vil oppdatere yt-dlp akkurat nå? Gjeldende og ventende"
+" nedlastinger kan mislykkes."
 
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Ingen mikrofoner oppdaget. Koble til en USB- eller Bluetooth-mikrofon og "
+"klikk på Oppdater."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Skanner..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Forfriske"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Slett ALL spillehistorikk - hver økt og hver avspilling, for godt? Skriv "
+"\"ok\" for å fortsette."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Spilleloggen er slettet"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Biblioteksynkronisering fullført"
 
 # auto-translated
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informasjon"
 
 # auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL til %(site_title)s:"
@@ -909,244 +1199,362 @@ msgstr "URL til %(site_title)s:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Praktisk URL QR-kode for å dele med en venn:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Admin"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Skriv inn administratorpassordet"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Logg inn"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Sangbibliotek"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Bibliotek"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Sanger i biblioteket:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Synkroniser nå"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Avstemmer biblioteket med sangkatalogen i bakgrunnen."
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Gi nytt navn"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artist - Tittel"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Tittel - Artist"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Rekkefølge av iTunes foreslåtte sangnavn"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Tilbakestill all historikk"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr "Sletter hver økt og hver avspilling på plate. Dette kan ikke angres."
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Brukerinnstillinger"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Splash-skjerminnstillinger"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Deaktiver bakgrunnsvideo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Deaktiver bakgrunnsmusikk"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Deaktiver partiturskjermen etter hver sang"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Skjul varsler"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Vis sprutklokke"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Skjul URL-en og QR-koden"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Skjul logoen på velkomstskjermen"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Skjul øktnavnet på velkomstskjermen"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Skjul alle overlegg, inkludert nå som spilles, opp neste og QR-kode"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Standardvolum for videoene (min 0, maks 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volum på bakgrunnsmusikken (min 0, maks 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"Mengden hviletid i sekunder før skjermspareren aktiveres. Sett til 0 for "
-"å deaktivere den."
+"Mengden hviletid i sekunder før skjermspareren aktiveres. Sett til 0 for å "
+"deaktivere den."
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Forsinkelsen i sekunder før du starter neste sang"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Lyd"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "Mikrofoner oppdaget på serveren. Lyden rutes direkte til høyttalere."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latens"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Ekko kansellering"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Eksperimentell"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(reduserer tilbakemelding, legger til ventetid)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Mikrofonstøtte er ikke tilgjengelig. Nødvendige lydverktøy er ikke "
+"installert."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "På Linux / Raspberry Pi, installer den med:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "og start PiKaraoke på nytt."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Score setninger"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Legg til én setning per linje i hver boks og trykk på lagre."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "setninger med lav poengsum (score < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Kunne vært bedre..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID-poengsetninger (30 > score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Det var ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "HIGH Score-setninger (60 < poengsum)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Fantastisk..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Språkinnstillinger"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Foretrukket språk (krever omstart)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Serverinnstillinger"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normaliser lydvolumet"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Last ned videoer av høy kvalitet"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
-"Transkode video fullstendig før avspilling (bedre "
-"nettleserkompatibilitet, tregere start). Bufferstørrelse vil bli "
-"ignorert.*"
+"Transkode video fullstendig før avspilling (bedre nettleserkompatibilitet, "
+"tregere start). Bufferstørrelse vil bli ignorert.*"
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
 "Aktiver CDG-pikselskalering (klarere bilder for CDG-filer, kan øke CPU-"
 "bruken)"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Aktiver automatisk YouTube-tittelopprydding (fjerner støyord som \"Karaoke "
+"Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Aktiver mappesurfing (legger til en mappevisning på sangsiden når "
+"biblioteket har undermapper)"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1156,7 +1564,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Begrensning av sanger en individuell bruker kan legge til i køen (0 = "
@@ -1164,275 +1572,339 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "Aktiver rettferdig kø (round-robin-modus sikrer at brukerne bytter)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
-"Bufferstørrelse i kilobyte. Transkode denne mengden av videoen før du "
-"sender den til splash-skjermen."
+"Bufferstørrelse i kilobyte. Transkode denne mengden av videoen før du sender"
+" den til splash-skjermen."
+
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Standard sanger per side."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Hold serveren våken: utilgjengelig i en beholder. Deaktiver søvn på verten."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Hold serveren våken: trenger systemd-inhibit (Linux) eller koffein (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Hold serveren våken: støttes ikke på denne plattformen."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Hold serveren våken mens PiKaraoke kjører"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Tydelige preferanser"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Systemdata"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Systeminfo"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Plattform:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "OS-versjon:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp versjon:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg versjon:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versjon:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Systemstatistikk"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Laster inn..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Diskbruk:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Hukommelse:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Oppdateringer"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP-oppdatering"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Hvis nedlastinger eller søk sluttet å virke, vil oppdatering av youtube-"
-"dl sannsynligvis fikse det.<br/>\n"
-"\t\t\t\t\t\tDen nåværende installerte versjonen er: "
-"\"%(youtubedl_version)s\"."
+"Hvis nedlastinger eller søk sluttet å virke, vil oppdatering av youtube-dl sannsynligvis fikse det.<br/>\n"
+"\t\t\t\t\t\tDen nåværende installerte versjonen er: \"%(youtubedl_version)s\"."
 
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Oppdater yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"* Denne oppdateringslenken ovenfor kan mislykkes hvis du ikke har riktige"
-" filtillatelser.\n"
+"* Denne oppdateringslenken ovenfor kan mislykkes hvis du ikke har riktige filtillatelser.\n"
 "\t\t\t\t\t\t\tSjekk pikaraoke-loggen for feil."
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Annen"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Utvid Raspberry Pi-filsystemet"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Hvis du nettopp installerte det forhåndsbygde pikaraoke pi-bildet og SD-"
-"kortet ditt er større enn 4 GB,\n"
-"\t\t\t\t\t\t\tDet kan være lurt å utvide filsystemet for å utnytte den "
-"gjenværende plassen. Du trenger bare å gjøre dette én gang.\n"
+"Hvis du nettopp installerte det forhåndsbygde pikaraoke pi-bildet og SD-kortet ditt er større enn 4 GB,\n"
+"\t\t\t\t\t\t\tDet kan være lurt å utvide filsystemet for å utnytte den gjenværende plassen. Du trenger bare å gjøre dette én gang.\n"
 "\t\t\t\t\t\t\tDette vil starte systemet på nytt."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Klikk her for å logge ut fra admin-modus."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Logg ut"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Avslutning"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
 msgstr ""
-"Ikke bare trekk ut støpselet! Slå alltid av serveren på riktig måte for å"
-" unngå datakorrupsjon."
+"Ikke bare trekk ut støpselet! Slå alltid av serveren på riktig måte for å "
+"unngå datakorrupsjon."
 
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Avslutt Pikaraoke"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Start systemet på nytt"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Slå av systemet"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Alternativer"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Forrige side"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Neste side"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} av {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Per side"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Alle økter"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Venter på nedlastinger"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Prøver på nytt"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "I kø"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Last ned feil"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Mislyktes"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Prøv på nytt"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Avskjedige"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Dra for å omorganisere"
 
 # auto-translated
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "Køen er tom"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Spille"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1443,146 +1915,164 @@ msgstr ""
 "style=\"width: 42px\" /> tilfeldige sanger"
 
 # auto-translated
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Fjern alle"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Spill Neste"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Flytt til toppen"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Flytt opp"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Flytt ned"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Flytt til bunnen"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Gi nytt navn"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Fjern fra køen"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Start på nytt"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Hopp over"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Last ned kø"
 
 # auto-translated
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Tilgjengelige sanger i lokalbiblioteket"
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Vise"
 
 # auto-translated
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Søk / Legg til ny"
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Rang"
 
 # auto-translated
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Tilgjengelige sanger"
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Spiller"
 
 # auto-translated
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Legg til i kø"
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Topp sanger"
 
 # auto-translated
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Klar"
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Topp utøvere"
 
 # auto-translated
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Avansert"
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Ingen har sunget ennå."
 
 # auto-translated
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"- Skriv inn en sang (tittel/artist) for å søke\n"
-"\t\t\t\t\t\t\t\tde tilgjengelige sangene og klikk \"Legg til i kø\" for å"
-" legge den til i køen."
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Legger til ..."
 
 # auto-translated
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"- Hvis sangen ikke vises i\n"
-"\t\t\t\t\t\t\t\trullegardinmenyen \"Tilgjengelige sanger\", klikk på "
-"\"Søk\" for å finne den på Youtube"
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "På biblioteket"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Legg til nye sanger fra YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Søk på YouTube etter tittel, artist..."
+
+# auto-translated
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Søk"
 
 # auto-translated
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Inkluder ikke-karaoke-kamper"
 
 # auto-translated
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Avansert"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "YouTube-nettadresse for direkte nedlasting:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Lim inn en YouTube-nettadresse:"
 
 # auto-translated
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Legg til i køen når den er lastet ned"
-
-# auto-translated
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Last ned"
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Lagre til senere"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1593,7 +2083,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1603,56 +2093,230 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Forhåndsvisning er utilgjengelig for denne videoen. Bruk YouTube-lenken på "
+"resultatet for å se det."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Ingen aktiv økt"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Økt {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Gi denne økten et navn:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Navn å gjøre aktiv"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "Vil du slette {session} og alle avspillingene? Dette kan ikke angres."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Vil du slette hver avspilling som er tatt opp i {session}? Selve økten "
+"holdes. Dette kan ikke angres."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Ingen økter ennå."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Ingen har sunget i denne seansen."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"Vil du gjøre {session} til den aktive økten? Nye sanger vil bli spilt inn "
+"mot den."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Vis hvem som sang"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Vis disse skuespillene"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Nåværende økt"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Gi denne økten et navn..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Start økten"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Avslutt økten"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Sesjonshistorie"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Skjul autostartet"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sesjon"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Startet"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Gjør aktiv"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Eksporter CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Eksporter liste (tekst)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Tydelige skuespill"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Slett økten"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Forbindelsen mistet. Kjører serveren fortsatt?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "Denne nettleseren støttes ikke fullt ut. Du kan oppleve problemer med "
 "strømming. Bruk Chrome/Safari/Firefox/Edge for best resultat."
 
 # auto-translated
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Neste:"
 
 # auto-translated
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Neste sanger:"
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Poengsummen din"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "På grunn av begrensninger med nettlesertillatelser, må du samhandle\n"
-"      med siden én gang før den tillater autoavspilling av videoer. "
-"Pikaraoke vil ikke\n"
+"      med siden én gang før den tillater autoavspilling av videoer. Pikaraoke vil ikke\n"
 "      spille ellers. Klikk på knappen nedenfor for å\n"
 "      <a onClick=\"handleConfirmation()\">bekreft</a>."
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Bekrefte"
-

--- a/pikaraoke/translations/nl_NL/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/nl_NL/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-13 22:56-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: nl_NL <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponeren met %s halve tonen: %s"
@@ -29,110 +29,110 @@ msgstr "Transponeren met %s halve tonen: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
 # auto-translated
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Downloaden in wachtrij (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Downloaden begint: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Video downloaden: %s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Fout bij downloaden van nummer:"
 
 # auto-translated
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Gedownload en in de wachtrij geplaatst: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Gedownload: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Fout bij het in de wachtrij plaatsen van nummer:"
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Nummerbestand niet gevonden: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Stream kon niet worden afgespeeld! Spoor overslaan"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "Nummer eindigde abnormaal: %s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Overslaan: %s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Hervatten: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pauze: %s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Uw voorkeuren zijn succesvol gewijzigd"
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Er is iets misgegaan! Uw voorkeuren zijn niet gewijzigd"
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Uw voorkeuren zijn succesvol gewist"
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Er is iets misgegaan! Uw voorkeuren zijn niet gewist"
 
@@ -169,18 +169,18 @@ msgstr "Nummer toegevoegd aan de wachtrij: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Wachtrij wissen"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Fout bij het oplossen van bestand: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Kan stream niet voorbereiden"
 
@@ -292,65 +292,102 @@ msgid "Error: No filename parameters were specified!"
 msgstr "Fout: Er zijn geen bestandsnaamparameters opgegeven!"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr ""
 "Fout: Kan dit nummer niet bewerken omdat het in de huidige wachtrij staat:"
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 "Fout bij hernoemen van bestand: '%s' naar '%s', bestandsnaam bestaat al"
 
 # auto-translated
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Blader"
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Liedjes"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Je hebt geen toestemming om nummers te verwijderen"
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
 msgstr ""
-"Fout: Kan dit nummer niet verwijderen omdat het in de huidige wachtrij staat"
+"Fout: Kan dit nummer niet verwijderen omdat het in de wachtrij staat of "
+"wordt afgespeeld"
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Nummer verwijderd: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Je hebt geen toestemming om nummers te bewerken"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Je hebt geen toestemming om de naam van nummers te wijzigen"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Dit nummer wordt afgespeeld. Hernoem het wanneer het klaar is."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Voer een naam in voor dit nummer."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Dit nummer staat niet meer in de bibliotheek. Het is mogelijk hernoemd of "
+"verwijderd van een ander apparaat."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Fout bij hernoemen van bestand: '%s' naar '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "Er bestaat al een nummer met de naam '%s'."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Dit nummer begon te spelen terwijl je het aan het bewerken was. Hernoem het "
+"wanneer het klaar is."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Fout bij hernoemen van bestand: %s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Hernoemd bestand: %s naar %s"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Vraag naar CPU-gebruik wordt niet ondersteund"
 
@@ -446,6 +483,72 @@ msgid "Error deleting from queue"
 msgstr "Fout bij verwijderen uit wachtrij"
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Nieuw toevoegen"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "U heeft geen toestemming om deze pagina te bekijken"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Er is een naam vereist"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Er is een sessie nodig"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Speel niet gevonden"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Sessie niet gevonden"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Gespeeld bij"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Uitvoerder"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Liedje"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - Speelgeschiedenis"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Zing nooit meer... nooit meer."
@@ -526,60 +629,64 @@ msgid "Failed to stream subtitle: "
 msgstr "Kan ondertiteling niet streamen:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
-"show up on queued songs. Current: CURRENT_NAME"
+"show up on queued songs. Current: {name}"
 msgstr ""
 "Wilt u de naam wijzigen van de persoon die dit apparaat gebruikt? Dit wordt "
-"weergegeven bij nummers in de wachtrij. Huidig: CURRENT_NAME"
+"weergegeven bij nummers in de wachtrij. Huidig: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Weet u zeker dat u de HELE wachtrij wilt wissen? Typ ok om door te gaan"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Weet u zeker dat u SONG_TITLE uit de wachtrij wilt verwijderen?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Weet u zeker dat u {title} uit de wachtrij wilt verwijderen?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Weet je zeker dat je dit nummer uit de bibliotheek wilt verwijderen?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE halve tonen"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} halve tonen"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL
-#. is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Dit nummer transponeren: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Transponeer dit nummer: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Weet je zeker dat je dit nummer opnieuw wilt starten?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -591,7 +698,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -601,14 +708,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Fout"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -617,23 +724,50 @@ msgstr ""
 "apparaat in de wachtrij hebt geplaatst."
 
 # auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Huidige sessie: {name}"
+
+# auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Thuis"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Wachtrij"
 
 # auto-translated
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Zoekopdracht"
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Ranglijsten"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Speelgeschiedenis"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Sessies"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Instellingen"
 
 # auto-translated
 #. Message about the wait for loading the songs
@@ -673,7 +807,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Toon alle nummers"
 
@@ -684,99 +819,216 @@ msgid "Loading songs..."
 msgstr "Nummers laden..."
 
 # auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr ""
+"Klik op een suggestie om deze als de nieuwe bestandsnaam te gebruiken."
+
+# auto-translated
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Geen suggestie!"
 
 # auto-translated
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Nummer bewerken"
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Hernoem het nummer"
 
 # auto-translated
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Nummernaam bewerken"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Huidige bestandsnaam"
 
 # auto-translated
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Nieuwe bestandsnaam"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
 msgstr "Automatisch formatteren"
 
 # auto-translated
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Wissel de volgorde van artiest/nummer"
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Wissel artiest/titel om"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Suggestie van Last.fm"
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Suggestie van iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes-zoekland"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Redden"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Annuleren"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Verwijder dit nummer"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Alfabetisch gesorteerd"
+#. Button to open the batch song renamer page.
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Bulk hernoemen"
 
 # auto-translated
-#. Button which changes how the songs are sorted so they become sorted by
-#. date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr ""
-"Sorteer op\n"
-"\t\t\tDatum"
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Verkrijgbaar in de bibliotheek"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Gesorteerd op datum"
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Alle mappen"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Zoek op titel, artiest..."
+
+# auto-translated
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Duidelijk"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Alle liedjes"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Mappen"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr ""
-"Sorteer op\n"
-"\t\t\tAlfabetisch"
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Alfabetisch sorteren"
 
 # auto-translated
-#. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Bewerk alle nummers"
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Sorteer op datum"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Deze vermelding uit het afspeellogboek verwijderen?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Er is nog niets gespeeld."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Gespeeld"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Overgeslagen"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Spelen"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Opties"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Toon alle artiesten"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Verbergen overgeslagen"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Status"
+
+# auto-translated
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Toevoegen aan wachtrij"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Dit nummer staat niet meer in de bibliotheek"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Invoer verwijderen"
 
 # auto-translated
 #. Message which shows in the "Now Playing" section when there is no song
@@ -809,50 +1061,55 @@ msgstr ""
 
 # auto-translated
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Nu aan het spelen"
 
 # auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Volgend nummer"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Spelercontrole"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Start het nummer opnieuw"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Afspelen/pauzeren"
 
 # auto-translated
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Stop het huidige nummer"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Sleutel wijzigen"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Wijziging"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Microfoons"
 
 # auto-translated
 #. Confirmation text whe the user selects quit.
@@ -893,19 +1150,54 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Geen microfoons gedetecteerd. Sluit een USB- of Bluetooth-microfoon aan en "
+"klik op Vernieuwen."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Scannen..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Vernieuwen"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"ALLE speelgeschiedenis verwijderen - elke sessie en elk spel, voorgoed? Typ "
+"\"ok\" om door te gaan."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Speelgeschiedenis gewist"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Synchronisatie van bibliotheek voltooid"
 
 # auto-translated
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informatie"
 
 # auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL van %(site_title)s:"
@@ -913,129 +1205,181 @@ msgstr "URL van %(site_title)s:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Handige URL QR-code om te delen met een vriend:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Beheerder"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Voer het beheerderswachtwoord in"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Login"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Liedbibliotheek"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Bibliotheek"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Nummers in bibliotheek:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Synchroniseer nu"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Verzoent de bibliotheek met de songmap op de achtergrond."
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Hernoemen"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artiest - Titel"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Titel - Artiest"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Volgorde van door iTunes voorgestelde namen van nummers"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Reset de hele geschiedenis"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Verwijdert elke sessie en elk opgenomen spel. Dit kan niet ongedaan worden "
+"gemaakt."
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Gebruikersvoorkeuren"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Instellingen opstartscherm"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Schakel achtergrondvideo uit"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Schakel achtergrondmuziek uit"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Schakel het scorescherm na elk nummer uit"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Meldingen verbergen"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Laat de splashklok zien"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Verberg de URL en QR-code"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Verberg het logo op het startscherm"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Verberg de sessienaam op het startscherm"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Verberg alle overlays, inclusief nu spelen, volgende en QR-code"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Standaardvolume van de video's (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume van de achtergrondmuziek (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1045,91 +1389,142 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "De vertraging in seconden voordat het volgende nummer begint"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Audio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"Microfoons gedetecteerd op de server. Audio wordt rechtstreeks naar de "
+"luidsprekers geleid."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latentie"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Echo-annulering"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Experimenteel"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(vermindert feedback, voegt latentie toe)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Microfoonondersteuning is niet beschikbaar. Vereiste audiotools zijn niet "
+"geïnstalleerd."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "Op Linux / Raspberry Pi installeer je het met:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "en start PiKaraoke opnieuw."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Score-zinnen"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Voeg één zin per regel toe in elk vak en klik op Opslaan."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "LAGE scorezinnen (score < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Kan beter..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID-scorezinnen (30 > score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Dat was oké..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Zinnen met een HOGE Score (60 < score)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Geweldig..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Taalinstellingen"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Voorkeurstaal (herstart vereist)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Serverinstellingen"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normaliseer het audiovolume"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Download video's van hoge kwaliteit"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1140,7 +1535,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1149,8 +1544,28 @@ msgstr ""
 "CPU-gebruik verhogen)"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Schakel het automatisch opschonen van YouTube-titels in (verwijdert "
+"ruiswoorden zoals 'Karaoke-versie HD')"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Bladeren door mappen inschakelen (voegt een mappenweergave toe aan de pagina"
+" Nummers wanneer de bibliotheek submappen heeft)"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1160,7 +1575,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limiet van nummers die een individuele gebruiker aan de wachtrij kan "
@@ -1168,7 +1583,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Schakel eerlijke wachtrij in (round-robin-modus zorgt ervoor dat gebruikers "
@@ -1176,7 +1591,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1185,97 +1600,135 @@ msgstr ""
 " naar het startscherm verzendt."
 
 # auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Standaardnummers per pagina."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Houd de server wakker: niet beschikbaar in een container. Schakel slaap op "
+"de host uit."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Houd de server wakker: heeft systemd-inhibit (Linux) of caffeinate (macOS) "
+"nodig."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Houd de server wakker: wordt niet ondersteund op dit platform."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Houd de server wakker terwijl PiKaraoke actief is"
+
+# auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Duidelijke voorkeuren"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Systeemgegevens"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Systeeminfo"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Platform:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "OS-versie:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp-versie:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg-versie:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Picaraoke-versie:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Systeemstatistieken"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Laden..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Schijfgebruik:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Geheugen:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Updates"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP-update"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
@@ -1289,14 +1742,14 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Update yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1306,21 +1759,21 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Ander"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Vouw het Raspberry Pi-bestandssysteem uit"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1332,26 +1785,26 @@ msgstr ""
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Klik hier om uit te loggen uit de beheerdersmodus."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Uitloggen"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Afsluiten"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1362,74 +1815,111 @@ msgstr ""
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Stop met Picaraoke"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Start het systeem opnieuw op"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Systeem afsluiten"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Opties"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Vorige pagina"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Volgende pagina"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} van {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Per pagina"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Alle sessies"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Downloads in behandeling"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Opnieuw proberen"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "In de wachtrij"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Downloadfouten"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Mislukt"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Opnieuw proberen"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Afwijzen"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Sleep om de volgorde te wijzigen"
 
 # auto-translated
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "De wachtrij is leeg"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Toneelstuk"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pauze"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1440,142 +1930,164 @@ msgstr ""
 "style=\"width: 42px\" /> willekeurige nummers toe"
 
 # auto-translated
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Alles wissen"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Speel Volgende"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Verplaats naar boven"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Ga omhoog"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Ga naar beneden"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Verplaats naar beneden"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Hernoemen"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Verwijderen uit wachtrij"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Opnieuw opstarten"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Overslaan"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Wachtrij downloaden"
 
 # auto-translated
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Beschikbare nummers in de plaatselijke bibliotheek"
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Show"
 
 # auto-translated
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Zoeken / Nieuw toevoegen"
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Rang"
 
 # auto-translated
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Beschikbare nummers"
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Speelt"
 
 # auto-translated
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Toevoegen aan wachtrij"
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Topnummers"
 
 # auto-translated
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Duidelijk"
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Toppresteerders"
 
 # auto-translated
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Geavanceerd"
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Er heeft nog niemand gezongen."
 
 # auto-translated
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to the queue."
-msgstr ""
-"- Typ een nummer (titel/artiest) om te zoeken\n"
-"\t\t\t\t\t\t\t\tde beschikbare nummers en klik op 'Toevoegen aan wachtrij' om deze aan de wachtrij toe te voegen."
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Toevoegen..."
 
 # auto-translated
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find it on Youtube"
-msgstr ""
-"- Als het nummer niet verschijnt in\n"
-"\t\t\t\t\t\t\t\tin de vervolgkeuzelijst 'Beschikbare nummers' en klik op 'Zoeken' om het op YouTube te vinden"
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "In bibliotheek"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Voeg nieuwe nummers van YouTube toe"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Zoek op YouTube op titel, artiest..."
+
+# auto-translated
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Zoekopdracht"
 
 # auto-translated
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Inclusief niet-karaokewedstrijden"
 
 # auto-translated
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "Directe download YouTube-URL:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Plak een YouTube-URL:"
 
 # auto-translated
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Voeg toe aan de wachtrij zodra het is gedownload"
-
-# auto-translated
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Downloaden"
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Bewaar voor later"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1586,7 +2098,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1596,12 +2108,191 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Voorbeeld niet beschikbaar voor deze video. Gebruik de YouTube-link op het "
+"resultaat om het te bekijken."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Geen actieve sessie"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Sessie {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Geef deze sessie een naam:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Naam om actief te maken"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr ""
+"{session} en al zijn afspeelacties verwijderen? Dit kan niet ongedaan worden"
+" gemaakt."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Elke weergave verwijderen die is opgenomen in {session}? De sessie zelf "
+"wordt bewaard. Dit kan niet ongedaan worden gemaakt."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Nog geen sessies."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Niemand heeft gezongen tijdens deze sessie."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"{session} de actieve sessie maken? Er zullen nieuwe nummers tegen worden "
+"opgenomen."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Laat zien wie zong"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Laat deze toneelstukken zien"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Huidige sessie"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Noem deze sessie..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Sessie starten"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Sessie beëindigen"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Sessiegeschiedenis"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Automatisch gestart verbergen"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sessie"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Gestart"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Actief maken"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "CSV exporteren"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Lijst exporteren (tekst)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Duidelijke toneelstukken"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Sessie verwijderen"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Verbinding verbroken. Draait de server nog?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
 "This browser is not fully supported. You may experience streaming issues. "
 "Please use Chrome/Safari/Firefox/Edge for best results."
@@ -1612,25 +2303,25 @@ msgstr ""
 
 # auto-translated
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Volgende:"
 
 # auto-translated
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Volgende zanger:"
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Jouw score"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
 "      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
@@ -1644,6 +2335,6 @@ msgstr ""
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Bevestigen"

--- a/pikaraoke/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/pt_BR/LC_MESSAGES/messages.po
@@ -7,116 +7,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: mawkee@gmail.com\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2022-06-28 18:57-0300\n"
 "Last-Translator: FULL NAME <mawkee@gmail.com>\n"
-"Language: pt_BR\n"
 "Language-Team: pt_BR <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transpondo em %s semitons: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Música adicionada à fila (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Baixando vídeo: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Baixando vídeo: %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Erro ao baixar a música: "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Música adicionada à fila: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Baixada: %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Erro ao adicionar a música à fila: "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Arquivo de música não encontrado: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "A transmissão não estava reproduzível! Pular pista"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "A música terminou de forma anormal: %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Pulando: %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Retomando: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Pausa: %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Suas preferências foram alteradas com sucesso"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Algo deu errado! Suas preferências não foram alteradas"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Suas preferências foram limpas com sucesso"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Algo deu errado! Suas preferências não foram limpas"
 
@@ -147,18 +147,18 @@ msgid "Song added to the queue: %s"
 msgstr "Música adicionada à fila: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Fila limpa"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Erro ao resolver arquivo: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Falha ao preparar stream"
 
@@ -213,8 +213,8 @@ msgstr "Expandindo o sistema e reiniciando!"
 #: routes/admin.py:153
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
-"Não é possivel expandir o sistema de arquivos em dispositivos não-"
-"raspberry pi!"
+"Não é possivel expandir o sistema de arquivos em dispositivos não-raspberry "
+"pi!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
@@ -253,55 +253,95 @@ msgstr "Renomear músicas em lote"
 msgid "Error: No filename parameters were specified!"
 msgstr "Erro: Nenhum nome de arquivo foi especificado!"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "Erro: Nao é possivel editar essa musica porque ela está na fila: "
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "Erro ao renomear o arquivo: '%s' para '%s', Nome do arquivo já existe"
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Navegar"
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Músicas"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "Você não tem permissão para excluir músicas"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Erro: Nao é possivel deletar essa musica porque ela está na fila"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Erro: não é possível excluir esta música porque ela está na fila ou tocando"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Música removida: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "Você não tem permissão para editar músicas"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "Você não tem permissão para renomear músicas"
 
-#: routes/files.py:211
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Esta música está tocando. Renomeie-o quando terminar."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Digite um nome para esta música."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Esta música não está mais na biblioteca. Pode ter sido renomeado ou excluído"
+" de outro dispositivo."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Erro ao renomear o arquivo: '%s' para '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "Uma música chamada '%s' já existe."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Esta música começou a tocar enquanto você a editava. Renomeie-o quando "
+"terminar."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Erro ao renomear arquivo: %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Música renomeada: %s para %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Consulta de uso da CPU não suportada"
 
@@ -385,6 +425,72 @@ msgstr "Erro ao mover para baixo na fila"
 msgid "Error deleting from queue"
 msgstr "Erro ao remover da fila"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Adicionar novo"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "Você não tem permissão para visualizar esta página"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "É necessário um nome"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "É necessária uma sessão"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Jogo não encontrado"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Sessão não encontrada"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Jogado em"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Intérprete"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Canção"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraokê - Histórico de jogos"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Nunca mais cante... nunca."
@@ -403,7 +509,8 @@ msgstr "Passe o microfone para o próximo, por favor!"
 
 #: routes/splash.py:28
 msgid "Well, I'm sure you're very good at your day job."
-msgstr "Bem, tenho certeza de que você é muito bom no seu trabalho do dia a dia."
+msgstr ""
+"Bem, tenho certeza de que você é muito bom no seu trabalho do dia a dia."
 
 #: routes/splash.py:31
 msgid "I've seen better."
@@ -451,117 +558,148 @@ msgid "Failed to stream subtitle: "
 msgstr "Falha ao transmitir legenda:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
-"Deseja alterar o nome da pessoa que usa este dispositivo? Isso aparecerá "
-"nas músicas na fila. Atual: CURRENT_NAME"
+"Deseja alterar o nome da pessoa que usa este dispositivo? Isso aparecerá nas"
+" músicas na fila. Atual: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
-msgstr "Tem certeza de que deseja limpar TODA a fila? Digite ok para continuar"
+msgstr ""
+"Tem certeza de que deseja limpar TODA a fila? Digite ok para continuar"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Tem certeza de que deseja excluir SONG_TITLE da fila?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Tem certeza de que deseja excluir {title} da fila?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Tem certeza que quer excluir esta música da biblioteca?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE semitons"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} semitons"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Transpor esta música: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Transponha esta música: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Tem certeza de que deseja reiniciar esta faixa?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
-"Um semitom também é conhecido como meio tom. É o menor intervalo usado na"
-" música clássica ocidental, igual a um duodécimo de oitava ou meio tom."
+"Um semitom também é conhecido como meio tom. É o menor intervalo usado na "
+"música clássica ocidental, igual a um duodécimo de oitava ou meio tom."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"Tem certeza de que deseja expandir o sistema de arquivos? Isso irá "
-"reiniciar o seu Raspberry Pi."
+"Tem certeza de que deseja expandir o sistema de arquivos? Isso irá reiniciar"
+" o seu Raspberry Pi."
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Erro"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
-"Por favor digite seu nome. Irá aparecer ao lado das músicas em “a seguir”"
-" no dispositivo."
+"Por favor digite seu nome. Irá aparecer ao lado das músicas em “a seguir” no"
+" dispositivo."
+
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Sessão atual: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Home"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Fila"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Busca"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Classificações"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "Histórico de jogos"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Sessões"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Configurações"
 
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"O carregamento pode levar alguns segundos, pois os títulos das músicas "
-"são comparados online. O tempo de carregamento pode variar\n"
+"O carregamento pode levar alguns segundos, pois os títulos das músicas são comparados online. O tempo de carregamento pode variar\n"
 "\tde acordo com a sua conexão com a internet."
 
 #. Label which displays that all songs are being shown
@@ -588,7 +726,8 @@ msgstr ""
 "\tpara renomear"
 
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Mostrar todas as músicas"
 
@@ -598,82 +737,211 @@ msgstr "Mostrar todas as músicas"
 msgid "Loading songs..."
 msgstr "Carregando músicas..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "Clique em uma sugestão para usá-la como o novo nome de arquivo."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Sem sugestões!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Editar música"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "Editar nome da música"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Auto-formatar"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Inverter ordem de artista/música"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "Renomear música"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Sugestão da Last.fm"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Nome do arquivo atual"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Novo nome de arquivo"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Formatação automática"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Trocar Artista/Título"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Sugerir do iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "País de pesquisa do iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Salvar"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Apagar esta música"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Ordenado Alfabeticamente"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Ordenado por data"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Ordenado por data"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "Ordenar por Nome"
-
+# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Editar todas as músicas"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Renomear em massa"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Disponível na biblioteca"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Todas as pastas"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Pesquise por título, artista..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Limpar"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Todas as músicas"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Pastas"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Classificar em ordem alfabética"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Classificar por data"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Excluir esta entrada do registro de reprodução?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Nada foi jogado ainda."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Jogado"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Ignorado"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Jogando"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Opções"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Mostrar todos os artistas"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Ocultar ignorado"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Status"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Adicionar à fila"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Esta música não está mais na biblioteca"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Excluir entrada"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -694,50 +962,55 @@ msgstr "Nenhuma música na fila."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
-"Tem certeza que quer pular esta música? Se não foi você que adicionou, "
-"peça permissão primeiro!"
+"Tem certeza que quer pular esta música? Se não foi você que adicionou, peça "
+"permissão primeiro!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Tocando agora"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Próxima música"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Controles do Player"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Reiniciar Música"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Tocar/Pausar"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Parar música atual"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Mudar tom"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Alterar"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Microfones"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -773,214 +1046,352 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Nenhum microfone detectado. Conecte um microfone USB ou Bluetooth e clique "
+"em Atualizar."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Digitalizando..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Atualizar"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Excluir TODO o histórico de jogos - todas as sessões e todas as jogadas, "
+"para sempre? Digite \"ok\" para continuar."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "Histórico de jogo apagado"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Sincronização da biblioteca concluída"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Informação"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL do %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "QR code da URL para compartilhar com um amigo:"
 
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Administração"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Digite a senha de administrador"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Login"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Biblioteca de músicas"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Biblioteca"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Músicas na biblioteca:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Sincronizar agora"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Reconcilia a biblioteca com o diretório de músicas em segundo plano."
 
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Renomeando"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Artista - Título"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Título - Artista"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Ordem dos nomes das músicas sugeridas pelo iTunes"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Redefinir todo o histórico"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Exclui todas as sessões e todas as jogadas registradas. Isto não pode ser "
+"desfeito."
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Preferências de usuário"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Configurações da tela de apresentação"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Desativar vídeo de fundo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Desativar música de fundo"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Desativar tela de pontuaçãoa após cada música"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Ocultar notificações"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Mostrar relógio inicial"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Ocultar URL e QR code"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Ocultar o logotipo na tela inicial"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Oculte o nome da sessão na tela inicial"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
-"Ocultar todas as sobreposições, incluindo 'tocando agora', 'a seguir' e "
-"QR code"
+"Ocultar todas as sobreposições, incluindo 'tocando agora', 'a seguir' e QR "
+"code"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume padrão dos videos (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume da música de fundo (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"Tempo de inatividade em segundos antes de ativar a proteção de tela. "
-"Defina 0 para desabilitar."
+"Tempo de inatividade em segundos antes de ativar a proteção de tela. Defina "
+"0 para desabilitar."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Tempo de espera em segundos antes de iniciar a próxima música"
 
+# auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Áudio"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"Microfones detectados no servidor. O áudio é roteado diretamente para os "
+"alto-falantes."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Latência"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Cancelamento de eco"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Experimental"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(reduz feedback, adiciona latência)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"O suporte para microfone não está disponível. As ferramentas de áudio "
+"necessárias não estão instaladas."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "No Linux/Raspberry Pi, instale-o com:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "e reinicie o PiKaraoke."
+
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Frases das pontuações"
 
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Adicione uma frase por linha em cada caixa e clique em salvar."
 
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frases para notas BAIXAS (nota < 30)"
 
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Poderia ser melhor..."
 
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frases para notas MÉDIAS (30 > nota < 30)"
 
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Foi legalzinho..."
 
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frases para notas ALTAS (60 < score)"
 
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Maravilhoso..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Configurações de idioma"
 
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Idioma preferido (requer reinicialização)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Configurações do servidor"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Normalizar volume de audio"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Baixar videos em alta qualidade"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -990,274 +1401,360 @@ msgstr ""
 "será ignorado.*"
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
-"Ativar o dimensionamento de pixels CDG (visuais mais nítidos para "
-"arquivos CDG, pode aumentar o uso da CPU)"
+"Ativar o dimensionamento de pixels CDG (visuais mais nítidos para arquivos "
+"CDG, pode aumentar o uso da CPU)"
+
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Ative a limpeza automática de títulos do YouTube (remove palavras "
+"barulhentas como \"Karaokê Versão HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Ativar navegação em pastas (adiciona uma visualização de pastas à página "
+"Músicas quando a biblioteca tiver subpastas)"
 
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
-"Corrigir a sincronização de áudio e vídeo em segundos (negativo = adianta"
-" o áudio | positivo = atrasa o áudio)"
+"Corrigir a sincronização de áudio e vídeo em segundos (negativo = adianta o "
+"áudio | positivo = atrasa o áudio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "Limite de músicas para cada usuário na fila (0 = ilimitado)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
-"Habilitar fila justa (o modo round-robin garante que os usuários se "
-"revezem)"
+"Habilitar fila justa (o modo round-robin garante que os usuários se revezem)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
 "Tamanho do buffer em kilobytes. Transcodifique essa quantidade do vídeo "
 "antes de enviá-lo para a tela de abertura."
 
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Músicas padrão por página."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Mantenha o servidor ativo: indisponível em um contêiner. Desative a "
+"suspensão no host."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Mantenha o servidor ativo: precisa de inibição do systemd (Linux) ou cafeína"
+" (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Mantenha o servidor ativo: não é compatível com esta plataforma."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Mantenha o servidor ativo enquanto o PiKaraoke estiver em execução"
+
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Limpar preferências"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Status do Sistema"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Informação do Sistema"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Plataforma:"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Versão do sistem:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "Versão do yt-dlp:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "Versão do FFmpeg"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Versão do Pikaraoke:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Status do Sistema"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Carregando..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Uso de disco:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Memória:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Atualizações"
 
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "Atualização do YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
 "\n"
-"\t\t\t\t\t\tSe os downloads ou buscas pararem de funcionar, a atualização"
-" do yt-dlpprovavelmente irá consertá-lo.<br/>\n"
+"\t\t\t\t\t\tSe os downloads ou buscas pararem de funcionar, a atualização do yt-dlpprovavelmente irá consertá-lo.<br/>\n"
 "\t\t\t\t\t\tA versão instalada atual é: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Atualizar yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"* Este link de atualização acima pode falhar se você não tiver as devidas"
-" permissões de arquivo.\n"
+"* Este link de atualização acima pode falhar se você não tiver as devidas permissões de arquivo.\n"
 "\t\t\t\t\t\t\tVerifique se há erros no log do pikaraoke."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Outros"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Expandir sistema de arquivos do Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Se você acabou de instalar a imagem do pikaraoke pi pré-construído e seu "
-"cartão SD é maior que 4GB,\n"
-"\t\t\t\t\t\t\tvocê pode querer expandir o sistema de arquivos para "
-"utilizar o espaço restante. Você só precisa fazer isso uma vez.\n"
+"Se você acabou de instalar a imagem do pikaraoke pi pré-construído e seu cartão SD é maior que 4GB,\n"
+"\t\t\t\t\t\t\tvocê pode querer expandir o sistema de arquivos para utilizar o espaço restante. Você só precisa fazer isso uma vez.\n"
 "\t\t\t\t\t\t\tIsto reiniciará o sistema."
 
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Clique aqui para sair do modo de administração."
 
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Log out"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Desligar"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
 msgstr ""
-"Não puxe o plugue da tomada! Sempre desligue o servidor corretamente para"
-" evitar dados corrompidos."
+"Não puxe o plugue da tomada! Sempre desligue o servidor corretamente para "
+"evitar dados corrompidos."
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Sair do Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Reiniciar sistema"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Desligar sistema"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Opções"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Página anterior"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Próxima página"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} de {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "Por página"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Todas as sessões"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Downloads pendentes"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Tentando novamente"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "Na fila"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Erros de download"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Fracassado"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Tentar novamente"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Liberar"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "A fila está vazia"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Jogar"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Pausando"
 
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1267,131 +1764,160 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 40px\" /> músicas aleatórias"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Limpar todos"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Jogue a seguir"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Mover para o topo"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Subir"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Mover para baixo"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Mover para baixo"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Renomear"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Remover da fila"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Reiniciar"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Pular"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Fila de download"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Músicas disponíveis na biblioteca local"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Mostrar"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Procurar / Adicionar Novo"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Classificação"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Músicas disponíveis"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Peças"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Adicionar à fila"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Melhores músicas"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Limpar"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Melhores desempenhos"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Avançado"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Ninguém cantou ainda."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"- Digite uma música (título/artista) para procurar as músicas disponíveis"
-" e clique em 'Adicionar à fila' para adicioná-la à fila."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Adicionando..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Se a música não aparecer no menu suspenso \"Canções Disponíveis\", clique"
-" em \"Procurar\" para encontrá-la no Youtube"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "Na biblioteca"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Adicione novas músicas do YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Pesquise no YouTube por título, artista..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Busca"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Adicionar resultados não-karaoke"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Avançado"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "URL direta para baixar do YouTube:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Cole um URL do YouTube:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Adicionar na fila depois de baixar"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Baixar"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Salvar para mais tarde"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1400,7 +1926,7 @@ msgstr "Procurando no YouTube por <small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1410,51 +1936,224 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Visualização indisponível para este vídeo. Use o link do YouTube no "
+"resultado para assisti-lo."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Nenhuma sessão ativa"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Sessão {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Nomeie esta sessão:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Nome para tornar ativo"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "Excluir {session} e todas as suas peças? Isto não pode ser desfeito."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Excluir todas as jogadas gravadas em {session}? A sessão em si é mantida. "
+"Isto não pode ser desfeito."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Nenhuma sessão ainda."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "Ninguém cantou nesta sessão."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"Tornar {session} a sessão ativa? Novas músicas serão gravadas contra ele."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Mostre quem cantou"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Mostre essas peças"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Sessão Atual"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Dê um nome a esta sessão..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Iniciar sessão"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Encerrar sessão"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "Histórico da sessão"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Ocultar inicialização automática"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Sessão"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Iniciado"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Tornar ativo"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Exportar CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Lista de exportação (texto)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Jogadas claras"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Excluir sessão"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Conexão perdida. O servidor ainda está em execução?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
-"Este navegador não é totalmente compatível. Você pode enfrentar problemas"
-" de streaming. Use Chrome/Safari/Firefox/Edge para obter melhores "
-"resultados."
+"Este navegador não é totalmente compatível. Você pode enfrentar problemas de"
+" streaming. Use Chrome/Safari/Firefox/Edge para obter melhores resultados."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "A seguir:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Próximo cantor:"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Sua nota"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
-"Devido a limitações nas permissões do navegador, você deve interagir com "
-"a página uma vez antes que ela permita a reprodução automática de vídeos."
-" Pikaraokê não jogue de outra forma. Clique no botão abaixo para       <a"
-" onClick=\"handleConfirmation()\">confirmar</a> ."
+"Devido a limitações nas permissões do navegador, você deve interagir com a "
+"página uma vez antes que ela permita a reprodução automática de vídeos. "
+"Pikaraokê não jogue de outra forma. Clique no botão abaixo para       <a "
+"onClick=\"handleConfirmation()\">confirmar</a> ."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Confirmar"
-

--- a/pikaraoke/translations/ru_RU/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ru_RU/LC_MESSAGES/messages.po
@@ -7,117 +7,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-11-09 03:26+0300\n"
 "Last-Translator: \n"
-"Language: ru_RU\n"
 "Language-Team: ru_RU <LL@li.org>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Транспозиция на  %s полутонов: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "Громкость: %s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Скачано и помещено в очередь (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "Начинается загрузка: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Загрузка видео: %s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "Ошибка при скачивании песни: "
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Скачано и помещено в очередь: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Скачано: %s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "Ошибка помещения песни в очередь: "
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "Файл песни не найден: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "Стрим не воспроизводился! Пропуск трека"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "Песня завершилась ненормально: %s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "Пропустить: %s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "Возобновить: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "Пауза: %s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "Ваши настройки были успешно изменены"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Что-то пошло не так! Ваши настройки остались без изменений"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "Ваши настройки были успешно сброшены"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Что-то пошло не так! Ваши настройки не были сброшены"
 
@@ -148,18 +147,18 @@ msgid "Song added to the queue: %s"
 msgstr "Песня добавлена в очередь: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "Очистить очередь"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "Ошибка разрешения файла: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "Не удалось подготовить поток"
 
@@ -254,58 +253,98 @@ msgstr "Пакетное переименование песен"
 msgid "Error: No filename parameters were specified!"
 msgstr "Ошибка: Не указан параметр имя файла!"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr ""
 "Ошибка: Нельзя отредактировать песню,  поскольку она стоит в текущей "
 "очереди: "
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "Ошибка переименования файла из '%s' в '%s', Такое имя файла уже есть"
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "Просмотр"
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "Песни"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "У вас недостаточно прав для удаления песен"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "Ошибка: Нельзя удалить данную песню, потому что она  в текущей очереди"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Ошибка: невозможно удалить эту песню, поскольку она находится в очереди или "
+"воспроизводится."
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "Песня удалена: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "У вас недостаточно прав для редактирования песен."
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "У вас недостаточно прав для переименования песен."
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Эта песня играет. Переименуйте его, когда он закончится."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "Введите название этой песни."
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Этой песни больше нет в библиотеке. Возможно, он был переименован или удален"
+" с другого устройства."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "Ошибка переименования файла: с «%s» на «%s», %s."
+msgid "A song called '%s' already exists."
+msgstr "Песня под названием «%s» уже существует."
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr ""
+"Эта песня начала играть, пока вы ее редактировали. Переименуйте его, когда "
+"он закончится."
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "Ошибка переименования файла: %s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Файл переименован из  %s в %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "Запрос использования процессора не поддерживается"
 
@@ -389,6 +428,72 @@ msgstr "Ошибка перемещения в конец очереди"
 msgid "Error deleting from queue"
 msgstr "Ошибка удаления из очереди"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "Добавить новый"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "У вас нет разрешения на просмотр этой страницы"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "Укажите имя."
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "Требуется сеанс"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "Игра не найдена"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "Сессия не найдена"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "Играл в"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "Исполнитель"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "Песня"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - История воспроизведения"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "Никогда больше не пойте... никогда."
@@ -407,7 +512,8 @@ msgstr "Пожалуйста, передайте микрофон!"
 
 #: routes/splash.py:28
 msgid "Well, I'm sure you're very good at your day job."
-msgstr "Ладно, я уверен, что вы неплохо справляетесь со своей обычной работой."
+msgstr ""
+"Ладно, я уверен, что вы неплохо справляетесь со своей обычной работой."
 
 #: routes/splash.py:31
 msgid "I've seen better."
@@ -455,69 +561,74 @@ msgid "Failed to stream subtitle: "
 msgstr "Не удалось передать субтитры:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
 "Хотите изменить имя человека, использующего это устройство? Это будет "
-"отображаться в песнях в очереди. Текущее: CURRENT_NAME"
+"отображаться в песнях в очереди. Текущий: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
-msgstr "Вы уверены, что хотите очистить ВСЮ очередь? Введите ОК, чтобы продолжить"
+msgstr ""
+"Вы уверены, что хотите очистить ВСЮ очередь? Введите ОК, чтобы продолжить"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "Вы уверены, что хотите удалить SONG_TITLE из очереди?"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "Вы уверены, что хотите удалить {title} из очереди?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Вы уверены, что хотите удалить эту песню из библиотеки?"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE полутонов"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} полутонов"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "Транспонировать эту песню: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "Транспонировать эту песню: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "Вы уверены, что хотите перезапустить этот трек?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
-"Полутон также известен как полутон. Это наименьший интервал, используемый"
-" в классической западной музыке, равный двенадцатой октавы или полутона."
+"Полутон также известен как полутон. Это наименьший интервал, используемый в "
+"классической западной музыке, равный двенадцатой октавы или полутона."
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -527,46 +638,72 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "Ошибка"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr ""
-"Пожалуйста, введите имя. Оно будет показываться при показе следующих "
-"песен, которые были добавлены с этого устройства."
+"Пожалуйста, введите имя. Оно будет показываться при показе следующих песен, "
+"которые были добавлены с этого устройства."
+
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "Текущая сессия: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "Домой"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "Очередь"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "Поиск"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "Рейтинги"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "История игр"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "Сессии"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "Настройки"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"Процесс загрузки может занять несколько секунд, поскольку названия песен "
-"сравниваются онлайн. Время загрузки может варьироваться\n"
+"Процесс загрузки может занять несколько секунд, поскольку названия песен сравниваются онлайн. Время загрузки может варьироваться\n"
 "\tв зависимости от вашего интернет-соединения."
 
 # auto-translated
@@ -597,7 +734,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "Показать все песни"
 
@@ -606,82 +744,212 @@ msgstr "Показать все песни"
 msgid "Loading songs..."
 msgstr "Загрузка песен..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr ""
+"Щелкните предложение, чтобы использовать его в качестве нового имени файла."
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "Нет подходящих!"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "Редактировать песню"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
 msgstr "Переименовать песню"
 
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "Автоформат"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "Поменять порядок артист/песня"
+# auto-translated
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "Текущее имя файла"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "Предложить с Last.fm"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "Новое имя файла"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "Автоматическое форматирование"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "Поменять исполнителя/название"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "Предложить из iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "Страна поиска iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "Сохранить"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "Отмена"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "Удалить эту песню"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "Отсортировать по алфавиту"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "Отсортировано по дате"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "Отсортировано по дате"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "Отсортировано по алфавиту"
-
+# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "Редактировать все песни"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "Массовое переименование"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "Доступно в библиотеке"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "Все папки"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "Поиск по названию, исполнителю..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "Очистить"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "Все песни"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "Папки"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "Сортировать по алфавиту"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "Сортировать по дате"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "Удалить эту запись из журнала воспроизведения?"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "Еще ничего не сыграно."
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "Играл"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "Пропущено"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "Играя"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "Параметры"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "Показать всех исполнителей"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "Скрыть пропущенные"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "Статус"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "Добавить в очередь"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "Этой песни больше нет в библиотеке"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "Удалить запись"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -702,50 +970,55 @@ msgstr "В очереди нет песен."
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr ""
 "Вы точно хотите пропустить этот трек? Если это не вы добавили песню, "
 "предварительно будет запрошено разрешение на это!"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "Сейчас играет"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "Следующая песня"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "Управление плейером"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "Рестарт песни"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "Играть/пауза"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "Останов текущей песни"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "Поменять высоту"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "Поменять"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "Микрофоны"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -781,503 +1054,725 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr ""
+"Микрофоны не обнаружены. Подключите микрофон USB или Bluetooth и нажмите "
+"«Обновить»."
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "Сканирование..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "Обновить"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"Удалить ВСЮ историю игр — каждую сессию и каждую игру, навсегда? Введите "
+"«ОК», чтобы продолжить."
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "История игр удалена"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "Синхронизация библиотеки завершена"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "Информация"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "УРЛ  %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Простой УРЛ QR код чтобы поделиться с другими:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "Админ"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "Введите пароль администратора"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "Логин"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "Библиотека песен"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "Библиотека"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "Песни в библиотеке:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "Синхронизировать сейчас"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Согласовывает библиотеку с каталогом песен в фоновом режиме."
 
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "Переименование"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "Художник - Название"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "Название - Художник"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "Порядок предложенных iTunes названий песен"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "Сбросить всю историю"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr ""
+"Удаляет каждую сессию и каждое воспроизведение в записи. Это невозможно "
+"отменить."
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "Пользовательские настройки"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "Установки заставки"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "Отключить фоновое видео"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "Отключить фоновую музыку"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "Отключить экран набранных балов после каждой песни"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "Скрыть уведомления"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "Показать часы-заставку"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "Скрыть УРЛ и QR код"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "Скрыть логотип на заставке"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "Скрыть имя сеанса на заставке"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Скрыть все оверлеи, включая сейчас играет, следующая и QR код"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Громкость видео по уморчанию (мин 0, макс 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Громкость фоновой музыки (мин 0, макс 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
 "Период бездействия в секундах до того, как включится хранитель экрана. "
 "Поставьте 0, чтобы отключить его."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "Задержка в секундах перед стартом следующей песни"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "Аудио"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr ""
+"На сервере обнаружены микрофоны. Звук направляется непосредственно на "
+"динамики."
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "Задержка"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "Эхоподавление"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "Экспериментальный"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(уменьшает обратную связь, увеличивает задержку)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"Поддержка микрофона недоступна. Необходимые аудиоинструменты не установлены."
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "В Linux/Raspberry Pi установите его с помощью:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "и перезапустите ПиКараоке."
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "Оценка фраз"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
-"Добавьте по одной фразе в каждой строке в каждое поле и нажмите "
-"«Сохранить»."
+"Добавьте по одной фразе в каждой строке в каждое поле и нажмите «Сохранить»."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Фразы с НИЗКИМ баллом (балл < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "Могло бы быть лучше..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Фразы со средней оценкой (30 > оценка < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "Это было ок..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Фразы с высоким баллом (60 <балл)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "Замечательно..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "Языковые настройки"
 
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "Выбор языка (требуется рестарт)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "Настройки сервера"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "Нормализовать громкость звука"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "Скачивать видео высокого качества"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
 "Полностью транскодировать видео до того, как запустить проигрывание "
-"(улучшает совместимость с браузерами, замедляет старт). Размер буфера "
-"будет проигнорирован.*"
+"(улучшает совместимость с браузерами, замедляет старт). Размер буфера будет "
+"проигнорирован.*"
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
 "Включить CDG пиксельное масштабирование (улучшит внешний вид файлов CDG, "
 "может увеличить нагрузку на CPU)"
 
+# auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"Включить автоматическую очистку заголовков YouTube (удалять ненужные слова, "
+"например «Караоке-версия HD»)."
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"Включить просмотр папок (добавляет представление «Папки» на страницу "
+"«Песни», если в библиотеке есть подпапки)"
+
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
-"Исправить синхронизацию звука и видео в секундах (отрицательное = "
-"опережает звук, положительное = вперед видео)"
+"Исправить синхронизацию звука и видео в секундах (отрицательное = опережает "
+"звук, положительное = вперед видео)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
-"Предел количества песен от одного пользователя, которые  можно добавить в"
-" очередь (0 = анлим)"
+"Предел количества песен от одного пользователя, которые  можно добавить в "
+"очередь (0 = анлим)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
-"Включить честную очередь (циклический режим гарантирует, что пользователи"
-" работают по очереди)"
+"Включить честную очередь (циклический режим гарантирует, что пользователи "
+"работают по очереди)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
 "Размер буфера в килобайтах. Транскодирование использует его под видео, "
 "прежде чем отправить клиенту. "
 
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "Песни по умолчанию на странице."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"Не давать серверу спать: недоступен в контейнере. Отключите сон на хосте."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"Не позволяйте серверу спать: требуется блокировка systemd (Linux) или "
+"кофеинат (macOS)."
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "Не позволяйте серверу спать: не поддерживается на этой платформе."
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "Не позволяйте серверу спать во время работы PiKaraoke"
+
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "Сбросить настройки"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "Статистика системы"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "Информация о системе"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "Платформа:"
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "Версия ОС:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "Версия yt-dlp:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "Версия FFmpeg:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "Версия Pikaraoke:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "Статистика системы"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "ПРОЦЕССОР:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "Загрузка..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "Использование диска:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "Память:"
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "Обновление"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "Обновление YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
-"Если загрузка или поиск перестали работать, обновление yt-dlp возможно "
-"все исправит.\n"
+"Если загрузка или поиск перестали работать, обновление yt-dlp возможно все исправит.\n"
 "   Текущая установленная версия: \"%(youtubedl_version)s\""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "Обновить yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
-"Ссылка на обновления выше может не сработат, если не будет хватать прав "
-"на файлы.\n"
+"Ссылка на обновления выше может не сработат, если не будет хватать прав на файлы.\n"
 "    Смотрите ошибки в логах pikaraoke."
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "Иное"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Раскрыть файловую систему Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"Если вы установили предварительно сформированный образ pikaraoke pi  и "
-"ваша SD карта больше 4Гб,\n"
-"    то можете захотеть расширить файловую систему, чтобы использовать "
-"оставшееся место. Это необходимо сделать только один раз.\n"
+"Если вы установили предварительно сформированный образ pikaraoke pi  и ваша SD карта больше 4Гб,\n"
+"    то можете захотеть расширить файловую систему, чтобы использовать оставшееся место. Это необходимо сделать только один раз.\n"
 "    Система будет перезагружена."
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "Нажмите здесь, чтобы выйти из режима администратора."
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "Выйти"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "Выключить"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
 msgstr ""
-"Не выдергивай штепсель из розетки! Всегда корректно завершай работу "
-"сервера, дабы не потерять данные."
+"Не выдергивай штепсель из розетки! Всегда корректно завершай работу сервера,"
+" дабы не потерять данные."
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "Выход из Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "Перезагрузить систему"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "Выключить систему"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "Параметры"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "Предыдущая страница"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "Следующая страница"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} из {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "За страницу"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "Все сессии"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Ожидающие загрузки"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "Повторная попытка"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "В очереди"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "Ошибки загрузки"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "Неуспешный"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "Повторить попытку"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "Увольнять"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "Очередь пуста"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "Играть"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "Пауза"
 
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1287,135 +1782,160 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 40px\" /> случайных песни"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "Очистить все"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "Играть дальше"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "Перейти наверх"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "Двигаться вверх"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "Вниз"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "Переместиться вниз"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "Переименовать"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "Удалить из очереди"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "Перезапуск"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "Пропускать"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "Очередь загрузки"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "Песни из локальной библиотеки"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "Показывать"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "Поиск/добавить новую"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "Классифицировать"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "Доступные песни"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "Пьесы"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "Добавить в очередь"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "Лучшие песни"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "Очистить"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "Лучшие исполнители"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "Продвинутое"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "Никто еще не пел."
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"Набери песню\n"
-"          (название/артист) для поиска среди доступных песен и нажми "
-"'Добавить в очередь'\n"
-"          чтобы добавить ее в очередь."
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "Добавление..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"Если\n"
-"          песня не представлена в выпадающем списке доступных песен Нажми"
-"\n"
-"          'Поиск' чтобы поискать ее на Youtube"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "В библиотеке"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "Добавляйте новые песни с YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "Поиск на YouTube по названию, исполнителю..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "Поиск"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "Включить совпадения  не караоке"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "Продвинутое"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "Прямая ссылка на скачивание с YouTube:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "Вставьте URL-адрес YouTube:"
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "Добавить в очеред после загрузки"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "Загрузить"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "Сохранить на потом"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1426,7 +1946,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1436,52 +1956,224 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"Предварительный просмотр недоступен для этого видео. Используйте ссылку "
+"YouTube на результат, чтобы посмотреть его."
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "Нет активной сессии"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "Сеанс {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "Назовите этот сеанс:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "Имя, которое нужно сделать активным"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "Удалить {session} и все его пьесы? Это невозможно отменить."
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"Удалить каждое воспроизведение, записанное в {session}? Сама сессия "
+"сохраняется. Это невозможно отменить."
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "Сеансов пока нет."
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "На этом сеансе никто не пел."
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"Сделать {session} активным сеансом? На его фоне будут записаны новые песни."
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "Покажи, кто пел"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "Показать эти пьесы"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "Текущая сессия"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "Назовите эту сессию..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "Начать сеанс"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "Завершить сеанс"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "История сеансов"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "Скрыть автозапуск"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "Сессия"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "Началось"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "Сделать активным"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "Экспортировать CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "Экспортировать список (текст)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "Четкие пьесы"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "Удалить сеанс"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "Соединение потеряно. Сервер еще работает?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
-"Этот браузер не полностью поддерживается. У вас могут возникнуть проблемы"
-" с потоковой передачей. Для достижения наилучших результатов используйте "
+"Этот браузер не полностью поддерживается. У вас могут возникнуть проблемы с "
+"потоковой передачей. Для достижения наилучших результатов используйте "
 "Chrome/Safari/Firefox/Edge."
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "Следующая:"
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "Следующий певец:"
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "Ваши баллы"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "Из за ограничений браузера, вам придется единожды\n"
-"      провзаимодействовать с этой страницей, чтоб разрешить "
-"автоматическое проигрывание видео. Pikaraoke не будет играть их без "
-"этого. Щелкните по кнопке внизу\n"
+"      провзаимодействовать с этой страницей, чтоб разрешить автоматическое проигрывание видео. Pikaraoke не будет играть их без этого. Щелкните по кнопке внизу\n"
 "      <a onClick=\"handleConfirmation()\">разрешить</a> ."
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "Согласен"
-

--- a/pikaraoke/translations/th_TH/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/th_TH/LC_MESSAGES/messages.po
@@ -7,21 +7,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2025-01-14 10:20-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: th_TH\n"
 "Language-Team: th_TH <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: th_TH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.17.0\n"
 
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "ย้ายตาม %s ครึ่งเสียง: %s"
@@ -29,110 +29,110 @@ msgstr "ย้ายตาม %s ครึ่งเสียง: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "ระดับเสียง: %s"
 
 # auto-translated
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "ดาวน์โหลดอยู่ในคิว (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "เริ่มดาวน์โหลด: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "กำลังดาวน์โหลดวิดีโอ: %s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "เกิดข้อผิดพลาดในการดาวน์โหลดเพลง:"
 
 # auto-translated
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "ดาวน์โหลดและเข้าคิวแล้ว: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "ดาวน์โหลดแล้ว: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "เกิดข้อผิดพลาดในการเข้าคิวเพลง:"
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "ไม่พบไฟล์เพลง: %s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "ไม่สามารถเล่นสตรีมได้! ข้ามแทร็ก"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "เพลงจบลงอย่างผิดปกติ: %s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "ข้าม: %s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "ดำเนินการต่อ: %s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "หยุดชั่วคราว: %s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "การเปลี่ยนแปลงการตั้งค่าของคุณสำเร็จแล้ว"
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "มีบางอย่างผิดพลาด! การตั้งค่าของคุณไม่เปลี่ยนแปลง"
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "การตั้งค่าของคุณถูกล้างเรียบร้อยแล้ว"
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "มีบางอย่างผิดพลาด! การตั้งค่าของคุณไม่ได้รับการล้าง"
 
@@ -168,18 +168,18 @@ msgstr "เพิ่มเพลงในคิว: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "เคลียร์คิว"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "เกิดข้อผิดพลาดในการแก้ไขไฟล์: %s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "ไม่สามารถเตรียมสตรีมได้"
 
@@ -290,62 +290,95 @@ msgid "Error: No filename parameters were specified!"
 msgstr "ข้อผิดพลาด: ไม่ได้ระบุพารามิเตอร์ชื่อไฟล์!"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "ข้อผิดพลาด: ไม่สามารถแก้ไขเพลงนี้ได้เนื่องจากอยู่ในคิวปัจจุบัน:"
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "เกิดข้อผิดพลาดในการเปลี่ยนชื่อไฟล์: '%s' เป็น '%s' มีชื่อไฟล์อยู่แล้ว"
 
 # auto-translated
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "เรียกดู"
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "เพลง"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "คุณไม่ได้รับอนุญาตให้ลบเพลง"
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "ข้อผิดพลาด: ไม่สามารถลบเพลงนี้ได้เนื่องจากอยู่ในคิวปัจจุบัน"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "ข้อผิดพลาด: ไม่สามารถลบเพลงนี้ได้เนื่องจากอยู่ในคิวหรือเล่นอยู่"
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "เพลงที่ถูกลบ: %s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "คุณไม่ได้รับอนุญาตให้แก้ไขเพลง"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "คุณไม่ได้รับอนุญาตให้เปลี่ยนชื่อเพลง"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "เพลงนี้กำลังเล่นอยู่ เปลี่ยนชื่อเมื่อเสร็จสิ้น"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "ป้อนชื่อเพลงนี้"
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"เพลงนี้ไม่ได้อยู่ในห้องสมุดอีกต่อไป อาจถูกเปลี่ยนชื่อหรือลบออกจากอุปกรณ์อื่น"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "เกิดข้อผิดพลาดในการเปลี่ยนชื่อไฟล์: '%s' เป็น '%s', %s"
+msgid "A song called '%s' already exists."
+msgstr "มีเพลงชื่อ '%s' อยู่แล้ว"
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr "เพลงนี้เริ่มเล่นในขณะที่คุณกำลังตัดต่อ เปลี่ยนชื่อเมื่อเสร็จสิ้น"
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "เกิดข้อผิดพลาดในการเปลี่ยนชื่อไฟล์: %s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "เปลี่ยนชื่อไฟล์: %s เป็น %s"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "ไม่รองรับแบบสอบถามการใช้งาน CPU"
 
@@ -441,6 +474,72 @@ msgid "Error deleting from queue"
 msgstr "เกิดข้อผิดพลาดในการลบออกจากคิว"
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "เพิ่มใหม่"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "คุณไม่ได้รับอนุญาตให้ดูหน้านี้"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "จำเป็นต้องระบุชื่อ"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "จำเป็นต้องมีเซสชัน"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "ไม่พบการเล่น"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "ไม่พบเซสชัน"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "เล่นที่"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "นักแสดง"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "เพลง"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - เล่นประวัติ"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "อย่าร้องเพลงอีกเลย...เคย"
@@ -521,62 +620,66 @@ msgid "Failed to stream subtitle: "
 msgstr "ไม่สามารถสตรีมคำบรรยายได้:"
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
 msgstr ""
 "คุณต้องการเปลี่ยนชื่อบุคคลที่ใช้อุปกรณ์นี้หรือไม่? "
-"สิ่งนี้จะปรากฏในเพลงที่อยู่ในคิว ปัจจุบัน: CURRENT_NAME"
+"สิ่งนี้จะปรากฏในเพลงที่อยู่ในคิว ปัจจุบัน: {name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการล้างคิวทั้งหมด พิมพ์ตกลงเพื่อดำเนินการต่อ"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบ SONG_TITLE ออกจากคิว"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบ {title} ออกจากคิว"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบเพลงนี้ออกจากห้องสมุด"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE ครึ่งเสียง"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} ครึ่งเสียง"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "ย้ายเพลงนี้: SEMITONE_LABEL?"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "ย้ายเพลงนี้: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการรีสตาร์ทแทร็กนี้"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr ""
 "ครึ่งเสียงเรียกอีกอย่างว่าครึ่งก้าว "
 "เป็นช่วงที่เล็กที่สุดที่ใช้ในดนตรีตะวันตกคลาสสิก เท่ากับ 12 "
@@ -585,59 +688,82 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
-"คุณแน่ใจหรือไม่ว่าต้องการขยายระบบไฟล์ นี่จะเป็นการรีบูตราสเบอร์รี่ pi "
-"ของคุณ"
+"คุณแน่ใจหรือไม่ว่าต้องการขยายระบบไฟล์ นี่จะเป็นการรีบูตราสเบอร์รี่ pi ของคุณ"
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "ข้อผิดพลาด"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr "กรุณากรอกชื่อของคุณ ซึ่งจะแสดงถัดจากเพลงที่คุณจัดคิวจากอุปกรณ์นี้"
 
 # auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "เซสชันปัจจุบัน: {name}"
+
+# auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "บ้าน"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "คิว"
 
 # auto-translated
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "ค้นหา"
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "อันดับ"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "ประวัติการเล่น"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "เซสชัน"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "การตั้งค่า"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
-"กระบวนการโหลดอาจใช้เวลาสักครู่ "
-"เนื่องจากมีการเปรียบเทียบชื่อเพลงทางออนไลน์ เวลาในการโหลดอาจแตกต่างกันไป"
-"\n"
+"กระบวนการโหลดอาจใช้เวลาสักครู่ เนื่องจากมีการเปรียบเทียบชื่อเพลงทางออนไลน์ เวลาในการโหลดอาจแตกต่างกันไป\n"
 "\tขึ้นอยู่กับการเชื่อมต่ออินเทอร์เน็ตของคุณ"
 
 # auto-translated
@@ -668,7 +794,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "แสดงเพลงทั้งหมด"
 
@@ -679,97 +806,215 @@ msgid "Loading songs..."
 msgstr "กำลังโหลดเพลง..."
 
 # auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "คลิกคำแนะนำเพื่อใช้เป็นชื่อไฟล์ใหม่"
+
+# auto-translated
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "ไม่มีข้อเสนอแนะ!"
 
 # auto-translated
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "แก้ไขเพลง"
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "เปลี่ยนชื่อเพลง"
 
 # auto-translated
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "แก้ไขชื่อเพลง"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "ชื่อไฟล์ปัจจุบัน"
 
 # auto-translated
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "ชื่อไฟล์ใหม่"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
 msgstr "จัดรูปแบบอัตโนมัติ"
 
 # auto-translated
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "สลับลำดับศิลปิน/เพลง"
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "สลับศิลปิน/ชื่อเรื่อง"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "แนะนำจาก Last.fm"
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "แนะนำจาก iTunes"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "ประเทศค้นหา iTunes"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "บันทึก"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "ยกเลิก"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "ลบเพลงนี้"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "เรียงตามตัวอักษร"
+#. Button to open the batch song renamer page.
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "เปลี่ยนชื่อเป็นกลุ่ม"
 
 # auto-translated
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr ""
-"เรียงตาม\n"
-"\t\t\tวันที่"
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "มีจำหน่ายแล้วในห้องสมุด"
 
 # auto-translated
-#. Label which displays that the songs are currently sorted by
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "โฟลเดอร์ทั้งหมด"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "ค้นหาตามชื่อศิลปิน..."
+
+# auto-translated
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "ชัดเจน"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "ทุกเพลง"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "โฟลเดอร์"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "จัดเรียงตามตัวอักษร"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:98
-msgid "Sorted by date"
+#: templates/files.html:462
+msgid "Sort by Date"
 msgstr "เรียงตามวันที่"
 
 # auto-translated
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr ""
-"เรียงตาม\n"
-"\t\t\tตามตัวอักษร"
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "ลบรายการนี้ออกจากบันทึกการเล่นใช่ไหม"
 
 # auto-translated
-#. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "แก้ไขเพลงทั้งหมด"
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "ยังไม่ได้เล่นอะไรเลย"
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "เล่นแล้ว"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "ข้ามไป"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "กำลังเล่น"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "ตัวเลือก"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "แสดงนักแสดงทั้งหมด"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "ซ่อนข้ามไป"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "สถานะ"
+
+# auto-translated
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "เพิ่มเข้าคิว"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "เพลงนี้ไม่ได้อยู่ในห้องสมุดอีกต่อไป"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "ลบรายการ"
 
 # auto-translated
 #. Message which shows in the "Now Playing" section when there is no song
@@ -794,56 +1039,62 @@ msgstr "ไม่มีเพลงอยู่ในคิว"
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
-msgstr "คุณแน่ใจหรือไม่ว่าต้องการข้ามแทร็กนี้ ใครไม่ได้แอดเพลงนี้ต้องขออนุญาตก่อน!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
+msgstr ""
+"คุณแน่ใจหรือไม่ว่าต้องการข้ามแทร็กนี้ ใครไม่ได้แอดเพลงนี้ต้องขออนุญาตก่อน!"
 
 # auto-translated
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "กำลังเล่นอยู่"
 
 # auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "เพลงถัดไป"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "การควบคุมผู้เล่น"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "รีสตาร์ทเพลง"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "เล่น/หยุดชั่วคราว"
 
 # auto-translated
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "หยุดเพลงปัจจุบัน"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "เปลี่ยนคีย์"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "เปลี่ยน"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "ไมโครโฟน"
 
 # auto-translated
 #. Confirmation text whe the user selects quit.
@@ -884,19 +1135,52 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr "ไม่พบไมโครโฟน เชื่อมต่อไมโครโฟน USB หรือบลูทูธ แล้วคลิกรีเฟรช"
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "กำลังสแกน..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "รีเฟรช"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr ""
+"ลบประวัติการเล่นทั้งหมด - ทุกเซสชั่นและทุกการเล่น ดีไหม? พิมพ์ \"ตกลง\" "
+"เพื่อดำเนินการต่อ"
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "ลบประวัติการเล่นแล้ว"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "การซิงค์ไลบรารีเสร็จสมบูรณ์"
 
 # auto-translated
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "ข้อมูล"
 
 # auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL ของ %(site_title)s:"
@@ -904,370 +1188,524 @@ msgstr "URL ของ %(site_title)s:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "รหัส QR URL ที่มีประโยชน์เพื่อแบ่งปันกับเพื่อน:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "ผู้ดูแลระบบ"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "ป้อนรหัสผ่านผู้ดูแลระบบ"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "เข้าสู่ระบบ"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "ห้องสมุดเพลง"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "ห้องสมุด"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "เพลงในห้องสมุด:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "ซิงค์ทันที"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "กระทบยอดไลบรารีกับไดเร็กทอรีเพลงในเบื้องหลัง"
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "กำลังเปลี่ยนชื่อ"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "ศิลปิน - ชื่อเรื่อง"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "หัวเรื่อง - ศิลปิน"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "ลำดับของ iTunes แนะนำชื่อเพลง"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "รีเซ็ตประวัติทั้งหมด"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr "ลบทุกเซสชันและทุกการเล่นที่บันทึกไว้ สิ่งนี้ไม่สามารถยกเลิกได้"
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "การตั้งค่าผู้ใช้"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "การตั้งค่าหน้าจอสแปลช"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "ปิดการใช้งานวิดีโอพื้นหลัง"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "ปิดการใช้งานเพลงพื้นหลัง"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "ปิดการใช้งานหน้าจอคะแนนหลังจากแต่ละเพลง"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "ซ่อนการแจ้งเตือน"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "แสดงนาฬิกาสาด"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "ซ่อน URL และโค้ด QR"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "ซ่อนโลโก้บนหน้าจอสแปลช"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "ซ่อนชื่อเซสชันบนหน้าจอเริ่มต้น"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "ซ่อนโอเวอร์เลย์ทั้งหมด รวมถึงกำลังเล่น ถัดไป และโค้ด QR"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "ระดับเสียงเริ่มต้นของวิดีโอ (ขั้นต่ำ 0, สูงสุด 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "ระดับเสียงเพลงประกอบ (ต่ำสุด 0, สูงสุด 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr ""
-"จำนวนเวลาว่างในหน่วยวินาทีก่อนที่โปรแกรมรักษาหน้าจอจะเปิดใช้งาน "
-"ตั้งค่าเป็น 0 เพื่อปิดใช้งาน"
+"จำนวนเวลาว่างในหน่วยวินาทีก่อนที่โปรแกรมรักษาหน้าจอจะเปิดใช้งาน ตั้งค่าเป็น "
+"0 เพื่อปิดใช้งาน"
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "ดีเลย์เป็นวินาทีก่อนเริ่มเพลงถัดไป"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "เสียง"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "ตรวจพบไมโครโฟนบนเซิร์ฟเวอร์ เสียงจะถูกส่งไปยังลำโพงโดยตรง"
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "เวลาแฝง"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "การยกเลิกเสียงสะท้อน"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "การทดลอง"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "(ลดการตอบสนอง เพิ่มเวลาแฝง)"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr ""
+"การสนับสนุนไมโครโฟนไม่พร้อมใช้งาน ไม่ได้ติดตั้งเครื่องมือเสียงที่จำเป็น"
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "บน Linux / Raspberry Pi ให้ติดตั้งด้วย:"
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "และรีสตาร์ท PiKaraoke"
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "คะแนนวลี"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "เพิ่มหนึ่งวลีต่อบรรทัดในแต่ละช่องแล้วกดบันทึก"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "วลีคะแนนต่ำ (คะแนน < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "อาจจะดีกว่านี้..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "วลีคะแนน MID (30 > คะแนน < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "นั่นก็โอเค..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "วลีคะแนนสูง (60 < คะแนน)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "มหัศจรรย์..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "การตั้งค่าภาษา"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "ภาษาที่ต้องการ (ต้องรีสตาร์ท)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "การตั้งค่าเซิร์ฟเวอร์"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "ปรับระดับเสียงให้เป็นปกติ"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "ดาวน์โหลดวิดีโอคุณภาพสูง"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
-"แปลงรหัสวิดีโอให้สมบูรณ์ก่อนที่จะเล่น "
-"(ความเข้ากันได้ของเบราว์เซอร์ที่ดีขึ้น เริ่มช้าลง) "
-"ขนาดบัฟเฟอร์จะถูกละเว้น*"
+"แปลงรหัสวิดีโอให้สมบูรณ์ก่อนที่จะเล่น (ความเข้ากันได้ของเบราว์เซอร์ที่ดีขึ้น"
+" เริ่มช้าลง) ขนาดบัฟเฟอร์จะถูกละเว้น*"
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr ""
 "เปิดใช้งานการปรับขนาดพิกเซลของ CDG (ภาพที่คมชัดยิ่งขึ้นสำหรับไฟล์ CDG "
 "อาจเพิ่มการใช้งาน CPU)"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr ""
+"เปิดใช้งานการล้างชื่อ YouTube อัตโนมัติ (ตัดคำที่มีเสียงรบกวนเช่น \"Karaoke "
+"Version HD\")"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr ""
+"เปิดใช้งานการเรียกดูโฟลเดอร์ "
+"(เพิ่มมุมมองโฟลเดอร์ไปยังหน้าเพลงเมื่อไลบรารีมีโฟลเดอร์ย่อย)"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
-"แก้ไขการซิงโครไนซ์เสียงและวิดีโอในไม่กี่วินาที (ลบ = เสียงก้าวหน้า | บวก "
-"= เสียงล่าช้า)"
+"แก้ไขการซิงโครไนซ์เสียงและวิดีโอในไม่กี่วินาที (ลบ = เสียงก้าวหน้า | บวก = "
+"เสียงล่าช้า)"
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "ขีดจำกัดของเพลงที่ผู้ใช้แต่ละรายสามารถเพิ่มลงในคิวได้ (0 = ไม่จำกัด)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
-msgstr "เปิดใช้งานคิวที่ยุติธรรม (โหมด Round-Robin ช่วยให้มั่นใจว่าผู้ใช้ผลัดกัน)"
+msgstr ""
+"เปิดใช้งานคิวที่ยุติธรรม (โหมด Round-Robin ช่วยให้มั่นใจว่าผู้ใช้ผลัดกัน)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr ""
 "ขนาดบัฟเฟอร์เป็นกิโลไบต์ "
 "แปลงรหัสวิดีโอจำนวนเท่านี้ก่อนที่จะส่งไปที่หน้าจอเริ่มต้น"
 
 # auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "เพลงเริ่มต้นต่อหน้า"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr ""
+"ทำให้เซิร์ฟเวอร์ตื่นอยู่เสมอ: ไม่พร้อมใช้งานในคอนเทนเนอร์ "
+"ปิดการใช้งานโหมดสลีปบนโฮสต์"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr ""
+"ทำให้เซิร์ฟเวอร์ตื่นตัว: ต้องการ systemd-inhibit (Linux) หรือคาเฟอีน (macOS)"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "ทำให้เซิร์ฟเวอร์ตื่นอยู่เสมอ: ไม่รองรับบนแพลตฟอร์มนี้"
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "ให้เซิร์ฟเวอร์ตื่นตัวในขณะที่ PiKaraoke กำลังทำงานอยู่"
+
+# auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "ล้างค่ากำหนด"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "ข้อมูลระบบ"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "ข้อมูลระบบ"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "แพลตฟอร์ม:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "เวอร์ชันระบบปฏิบัติการ:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "เวอร์ชัน yt-dlp:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "เวอร์ชัน FFmpeg:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "เวอร์ชั่นปิคาราโอเกะ:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "สถิติของระบบ"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "ซีพียู:"
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "กำลังโหลด..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "การใช้ดิสก์:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "หน่วยความจำ:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "อัพเดท"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "อัปเดต YT-DLP"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
@@ -1277,17 +1715,16 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "อัพเดต yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
 "* ลิงก์อัปเดตด้านบนนี้อาจล้มเหลวหากคุณไม่มีสิทธิ์อนุญาตไฟล์ที่เหมาะสม\n"
@@ -1295,56 +1732,52 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "อื่น"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "ขยายระบบไฟล์ Raspberry Pi"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
-"หากคุณเพิ่งติดตั้งอิมเมจ pikaraoke pi ที่สร้างไว้ล่วงหน้าและการ์ด SD "
-"ของคุณมีขนาดใหญ่กว่า 4GB\n"
-"\t\t\t\t\t\t\tคุณอาจต้องการขยายระบบไฟล์เพื่อใช้พื้นที่ที่เหลืออยู่ "
-"คุณต้องทำสิ่งนี้เพียงครั้งเดียว\n"
+"หากคุณเพิ่งติดตั้งอิมเมจ pikaraoke pi ที่สร้างไว้ล่วงหน้าและการ์ด SD ของคุณมีขนาดใหญ่กว่า 4GB\n"
+"\t\t\t\t\t\t\tคุณอาจต้องการขยายระบบไฟล์เพื่อใช้พื้นที่ที่เหลืออยู่ คุณต้องทำสิ่งนี้เพียงครั้งเดียว\n"
 "\t\t\t\t\t\t\tนี่จะเป็นการรีบูตระบบ"
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "คลิกที่นี่เพื่อออกจากระบบโหมดผู้ดูแลระบบ"
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "ออกจากระบบ"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "ปิดเครื่อง"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1355,74 +1788,111 @@ msgstr ""
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "เลิกปิ๊กคาราโอเกะ"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "รีบูตระบบ"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "ระบบปิดเครื่อง"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "ตัวเลือก"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "หน้าก่อน"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "หน้าถัดไป"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} จาก {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "ต่อหน้า"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "เซสชันทั้งหมด"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "รอการดาวน์โหลด"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "กำลังลองอีกครั้ง"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "เข้าคิว"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "ดาวน์โหลดข้อผิดพลาด"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "ล้มเหลว"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "ลองอีกครั้ง"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "อนุญาตให้ออกไป"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "ลากเพื่อเรียงลำดับใหม่"
 
 # auto-translated
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "คิวว่างแล้ว"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "เล่น"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "หยุดชั่วคราว"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1433,145 +1903,164 @@ msgstr ""
 "style=\"width: 42px\" /> เพลงสุ่ม"
 
 # auto-translated
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "เคลียร์ทั้งหมด"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "เล่นถัดไป"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "ย้ายไปด้านบน"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "เลื่อนขึ้น"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "เลื่อนลง"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "ย้ายไปด้านล่าง"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "เปลี่ยนชื่อ"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "ลบออกจากคิว"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "รีสตาร์ท"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "ข้าม"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "คิวดาวน์โหลด"
 
 # auto-translated
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "เพลงที่มีอยู่ในห้องสมุดท้องถิ่น"
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "แสดง"
 
 # auto-translated
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "ค้นหา / เพิ่มใหม่"
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "อันดับ"
 
 # auto-translated
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "เพลงที่มีอยู่"
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "เล่น"
 
 # auto-translated
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "เพิ่มเข้าคิว"
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "เพลงยอดนิยม"
 
 # auto-translated
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "ชัดเจน"
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "นักแสดงชั้นนำ"
 
 # auto-translated
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "ขั้นสูง"
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "ยังไม่มีใครร้องเลย"
 
 # auto-translated
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"- พิมพ์เพลง (ชื่อเพลง/ศิลปิน) เพื่อค้นหา\n"
-"\t\t\t\t\t\t\t\tเพลงที่มีอยู่แล้วคลิก 'เพิ่มลงในคิว' เพื่อเพิ่มลงในคิว"
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "กำลังเพิ่ม..."
 
 # auto-translated
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"- หากเพลงไม่ปรากฏ\n"
-"\t\t\t\t\t\t\t\tเมนูแบบเลื่อนลง \"เพลงที่มีอยู่\" คลิก 'ค้นหา' "
-"เพื่อค้นหาบน Youtube"
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "ในห้องสมุด"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "เพิ่มเพลงใหม่จาก YouTube"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "ค้นหา YouTube ตามชื่อศิลปิน..."
+
+# auto-translated
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "ค้นหา"
 
 # auto-translated
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "รวมการแข่งขันที่ไม่ใช่คาราโอเกะ"
 
 # auto-translated
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "ขั้นสูง"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "ดาวน์โหลด URL YouTube โดยตรง:"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "วาง URL ของ YouTube:"
 
 # auto-translated
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "เพิ่มลงในคิวเมื่อดาวน์โหลดแล้ว"
-
-# auto-translated
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "ดาวน์โหลด"
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "เก็บไว้ดูทีหลัง"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1582,7 +2071,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1592,56 +2081,228 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr ""
+"ดูตัวอย่างไม่พร้อมใช้งานสำหรับวิดีโอนี้ ใช้ลิงก์ YouTube บนผลลัพธ์เพื่อดู"
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "ไม่มีเซสชันที่ใช้งานอยู่"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "เซสชัน {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "ตั้งชื่อเซสชันนี้:"
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "ชื่อที่จะเปิดใช้งาน"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "ลบ {session} และการเล่นทั้งหมดใช่ไหม สิ่งนี้ไม่สามารถยกเลิกได้"
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr ""
+"ลบทุกการเล่นที่บันทึกไว้ใน {session} หรือไม่ เซสชันนั้นจะถูกเก็บไว้ "
+"สิ่งนี้ไม่สามารถยกเลิกได้"
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "ยังไม่มีเซสชัน"
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "ไม่มีใครร้องเพลงในช่วงนี้"
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr ""
+"ทำให้ {session} เป็นเซสชันที่ใช้งานอยู่หรือไม่ เพลงใหม่จะถูกบันทึกต่อต้านมัน"
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "แสดงว่าใครร้อง."
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "แสดงละครเหล่านี้"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "เซสชันปัจจุบัน"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "ตั้งชื่อเซสชันนี้..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "เริ่มเซสชัน"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "สิ้นสุดเซสชัน"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "ประวัติเซสชัน"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "ซ่อนการเริ่มต้นอัตโนมัติ"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "การประชุม"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "เริ่ม"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "ทำให้มีความกระตือรือร้น"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "ส่งออก CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "รายการส่งออก (ข้อความ)"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "ละครชัดๆ"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "ลบเซสชัน"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "การเชื่อมต่อขาดหายไป เซิร์ฟเวอร์ยังคงทำงานอยู่หรือไม่?"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr ""
 "เบราว์เซอร์นี้ไม่รองรับอย่างสมบูรณ์ คุณอาจประสบปัญหาการสตรีม โปรดใช้ "
 "Chrome/Safari/Firefox/Edge เพื่อผลลัพธ์ที่ดีที่สุด"
 
 # auto-translated
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "ถัดไป:"
 
 # auto-translated
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "นักร้องคนต่อไป:"
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "คะแนนของคุณ"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
 "เนื่องจากข้อจำกัดในการอนุญาตเบราว์เซอร์ คุณต้องโต้ตอบ\n"
-"      ด้วยหน้าเว็บหนึ่งครั้งก่อนที่จะอนุญาตให้เล่นวิดีโออัตโนมัติ "
-"ปิคาราโอเกะจะไม่\n"
+"      ด้วยหน้าเว็บหนึ่งครั้งก่อนที่จะอนุญาตให้เล่นวิดีโออัตโนมัติ ปิคาราโอเกะจะไม่\n"
 "      เล่นเป็นอย่างอื่น คลิกปุ่มด้านล่างเพื่อ\n"
 "      <a onClick=\"handleConfirmation()\">ยืนยัน</a>"
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "ยืนยัน"
-

--- a/pikaraoke/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -5,23 +5,23 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version:  1.1.1\n"
+"Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2022-04-28 10:09-0400\n"
 "Last-Translator: \n"
-"Language: zh_CN\n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.17.0\n"
 
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "移调 %s 个半音：%s"
@@ -29,106 +29,106 @@ msgstr "移调 %s 个半音：%s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "音量：%s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "成功添加歌曲 (#%d)： %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "下载: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "正在下载视频：%s"
 
 # auto-translated
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "下载歌曲时出错："
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "成功添加歌曲： %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "下载: %s"
 
 # auto-translated
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "歌曲排队错误："
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "未找到歌曲文件：%s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "串流无法播放！跳过曲目"
 
 # auto-translated
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "歌曲异常结束：%s"
 
 # auto-translated
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "跳过：%s"
 
 # auto-translated
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "继续：%s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "暂停：%s"
 
 # auto-translated
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "您的偏好设置已成功更改"
 
 # auto-translated
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "出了问题！您的偏好没有改变"
 
 # auto-translated
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "您的偏好设置已成功清除"
 
 # auto-translated
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "出了问题！您的偏好未清除"
 
@@ -161,18 +161,18 @@ msgstr "成功添加歌曲：%s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "清除队列"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "解析文件时出错：%s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "准备流失败"
 
@@ -278,61 +278,94 @@ msgid "Error: No filename parameters were specified!"
 msgstr "错误：未指定文件名参数！"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "错误：无法编辑这首歌曲，因为它位于当前队列中："
 
 # auto-translated
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "将文件 '%s' 重命名为 '%s' 时出错，文件名已存在"
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "浏览"
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "歌曲"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "您无权删除歌曲"
 
 # auto-translated
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "错误：无法删除这首歌曲，因为它位于当前队列中"
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "错误：无法删除这首歌曲，因为它正在排队或正在播放"
 
 # auto-translated
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "已删除歌曲：%s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "您没有编辑歌曲的权限"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "您无权重命名歌曲"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "正在播放这首歌。完成后重命名。"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "输入这首歌的名称。"
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "这首歌已经不在图书馆里了。它可能已被重命名或从其他设备中删除。"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "将文件 '%s' 重命名为 '%s' 时出错，%s"
+msgid "A song called '%s' already exists."
+msgstr "一首名为“%s”的歌曲已经存在。"
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr "这首歌在您编辑时开始播放。完成后重命名。"
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "重命名文件时出错：%s"
 
 # auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "已重命名文件：%s 为 %s"
 
 # auto-translated
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "不支持CPU使用率查询"
 
@@ -427,6 +460,72 @@ msgid "Error deleting from queue"
 msgstr "从队列中删除时出错"
 
 # auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "添加新内容"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "您没有权限查看此页面"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "需要提供姓名"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "需要一个会话"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "找不到播放"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "未找到会话"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "玩过"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "演员"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "歌曲"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - 播放历史"
+
+# auto-translated
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "永远不要再唱歌了……永远。"
@@ -507,65 +606,69 @@ msgid "Failed to stream subtitle: "
 msgstr "无法传输字幕："
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
-msgstr "您想更改使用此设备的人的姓名吗？这将显示在排队的歌曲上。当前：CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
+msgstr "您想更改使用此设备的人的姓名吗？这将显示在排队的歌曲上。当前：{name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "您确定要清除整个队列吗？输入“确定”继续"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "您确定要从队列中删除 SONG_TITLE 吗？"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "您确定要从队列中删除 {title} 吗？"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "确认即将把此歌曲从音乐库里删除？"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE 半音"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} 半音"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "转调这首歌：SEMITONE_LABEL？"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "转置这首歌：{label}？"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "您确定要重新开始该曲目吗？"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr "半音也称为半音。它是西方古典音乐中使用的最小音程，等于十二个八度或半个音。"
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -573,40 +676,67 @@ msgstr "您确定要扩展文件系统吗？这将重新启动您的树莓派。
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "错误"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr "演唱者（我）的名字是："
 
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "当前会话：{name}"
+
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "主页"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "列表"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "搜索"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "排行榜"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "播放历史"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "会议"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "设置"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
 "由于歌曲名称是在线比较的，加载过程可能需要几秒钟。加载时间可能会有所不同\n"
@@ -640,7 +770,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "显示所有歌曲"
 
@@ -650,82 +781,211 @@ msgstr "显示所有歌曲"
 msgid "Loading songs..."
 msgstr "正在加载歌曲..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "单击建议以将其用作新文件名。"
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "没有搜索建议！"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "修改歌曲"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "修改歌曲名称"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "自动整理"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "切换歌手/歌曲顺序"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "重命名歌曲"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "来自 Last.fm 的建议"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "当前文件名"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "新文件名"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "自动格式化"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "交换艺术家/标题"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "来自 iTunes 的建议"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes 搜索国家/地区"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "保存"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "取消"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "删除此曲"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "现在歌曲正在按字母排序"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "现在歌曲正在按日期排序"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "现在歌曲正在按日期排序"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "用字母排序"
-
+# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "編輯所有歌曲"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "批量重命名"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "在图书馆可以找到"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "所有文件夹"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "按标题、艺术家搜索..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "清除所有"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "所有歌曲"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "文件夹"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "按字母顺序排序"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "按日期排序"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "从播放日志中删除此条目吗？"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "还没有播放任何内容。"
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "玩过"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "跳过"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "演奏"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "选项"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "显示所有表演者"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "隐藏跳过的"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "地位"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "添加至播放列表"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "这首歌已经不在库里了"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "删除条目"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -746,48 +1006,53 @@ msgstr "没有下一首歌"
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr "你确定要跳过这首歌？"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "正在播放曲目"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "下一首歌"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "播放器"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "重新开始"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "播放/暂停"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "停止并跳到下一首歌"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "升降调"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "确认更改声调"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "麦克风"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -822,236 +1087,364 @@ msgstr "确定升级yt-dlp？会终止正在下载的音乐"
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr "未检测到麦克风。连接 USB 或蓝牙麦克风，然后单击“刷新”。"
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "扫描..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "刷新"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr "永久删除所有游戏历史记录 - 每个会话和每个游戏？输入“确定”继续。"
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "播放历史记录已删除"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "库同步完成"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "信息"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s 的网址"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "快捷QR码（用于分享给朋友）"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "行政"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "输入管理员密码"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "登录"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "歌库"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "图书馆"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "库里的歌曲："
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "立即同步"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "在后台协调库与歌曲目录。"
 
 # auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "重命名"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "艺术家 - 头衔"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "头衔 - 艺术家"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "iTunes 建议歌曲名称的顺序"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "重置所有历史记录"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr "删除记录中的每个会话和每个播放。此操作无法撤消。"
+
+# auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "用户偏好"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "启动画面设置"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "禁用背景视频"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "禁用背景音乐"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "每首歌曲后禁用乐谱屏幕"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "隐藏通知"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "显示启动时钟"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "隐藏网址和二维码"
 
 # auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "隐藏启动屏幕上的徽标"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "在启动屏幕上隐藏会话名称"
+
+# auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "隐藏所有叠加层，包括正在播放、下一个和二维码"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "视频的默认音量（最小 0，最大 100）"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "背景音乐音量（最小 0，最大 100）"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr "屏幕保护程序激活之前的空闲时间（以秒为单位）。设置为 0 以禁用它。"
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "开始下一首歌曲之前的延迟（以秒为单位）"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "声音的"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "在服务器上检测到麦克风。音频直接传送至扬声器。"
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "延迟"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "回声消除"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "实验性的"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "（减少反馈，增加延迟）"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr "麦克风支持不可用。未安装所需的音频工具。"
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "在 Linux / Raspberry Pi 上，安装它："
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "并重新启动 PiKaraoke。"
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "给短语评分"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "在每个框中每行添加一个短语，然后点击“保存”。"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "低分短语（分数 < 30）"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "可能会更好..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID 得分短语 (30 > 得分 < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "那就可以了..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "高分短语（60 < 分数）"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "精彩..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "语言设置"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "首选语言（需要重新启动）"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "服务器设置"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "标准化音量"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "下载高质量视频"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1059,15 +1452,31 @@ msgstr "在播放前对视频进行完全转码（浏览器兼容性更好，启
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr "启用 CDG 像素缩放（CDG 文件的视觉效果更清晰，可能会增加 CPU 使用率）"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr "启用自动 YouTube 标题清​​理（删除“卡拉 OK 版本高清”等干扰词）"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr "启用文件夹浏览（当库有子文件夹时，将文件夹视图添加到歌曲页面）"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1075,114 +1484,147 @@ msgstr "在几秒钟内修复音频和视频同步（负=提前音频|正=延迟
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "单个用户可以添加到队列中的歌曲数量限制（0 = 无限制）"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "启用公平队列（循环模式确保用户轮流）"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr "缓冲区大小（以千字节为单位）。在将视频发送到启动屏幕之前对其进行转码。"
 
 # auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "每页默认歌曲。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr "保持服务器唤醒：在容器中不可用。禁用主机上的睡眠。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr "保持服务器唤醒：需要 systemd-inhibit (Linux) 或 caffeinate (macOS)。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "保持服务器唤醒：此平台不支持。"
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "PiKaraoke 运行时保持服务器处于唤醒状态"
+
+# auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "明确的偏好"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "系统信息"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "系统信息"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "平台："
 
 # auto-translated
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "操作系统版本："
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp 版本:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg 版本："
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "卡拉OK派 版本:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "系统信息"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "中央处理器："
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "加载中..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "磁盘使用情况："
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "记忆："
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "更新"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP 更新"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
@@ -1191,40 +1633,37 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "更新 yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
 "以上的链接有可能失败，如果你没有相应的权限的话.\n"
 "    查看卡拉OK派的错误日志以检查错误"
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "其他"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "拓展Raspberry Pi文件系统"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
 "如果你刚刚安装预设卡拉OK派图片而且你的SD卡超过4GB,\n"
@@ -1233,25 +1672,25 @@ msgstr ""
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "单击此处从管理模式注销。"
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "退出"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "关闭"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1259,201 +1698,271 @@ msgstr "不要只是拔掉插头！始终正确关闭服务器以避免数据损
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "退出卡拉OK派"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "重启系统"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "关机"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "选项"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "上一页"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "下一页"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} 共 {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "每页"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "所有会议"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "待下载"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "重试"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "排队"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "下载错误"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "失败的"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "重试"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "解雇"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "拖动以重新排序"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "播放列表是空的"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "玩"
 
 # auto-translated
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "暂停"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> random songs"
 msgstr ""
-"添加 <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
-"pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
-"style=\"width: 42px\" /> 随机歌曲"
+"添加 <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" pattern=\"\\d*\""
+" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" /> "
+"随机歌曲"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "清除所有"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "播放下一个"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "移至顶部"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "向上移动"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "下移"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "移至底部"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "重命名"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "从队列中删除"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "重新启动"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "跳过"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "下载队列"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "本地曲库"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "展示"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "搜索 / 添加新歌"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "秩"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "已有歌曲"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "戏剧"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "添加至播放列表"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "热门歌曲"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "清除所有"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "表现最佳者"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "高级设置"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "还没有人唱歌。"
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr "输入想唱的歌的名字，点击旁边的“添加至播放列表”按键以添加歌曲"
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "添加..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr "如果曲目不在“已有歌曲”列表中，点击”搜索“转跳到YouTube上搜索"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "在图书馆"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "添加来自 YouTube 的新歌曲"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "按标题、艺术家搜索 YouTube..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "搜索"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "搜索包含原唱版本（非伴奏）"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "高级设置"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "通过YouTube url网址直接下载"
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "粘贴 YouTube 网址："
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr "下载完毕后自动添加曲目到播放列表"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "下载"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "保存以供稍后使用"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1462,7 +1971,7 @@ msgstr "在YouTube上搜索<small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1472,40 +1981,210 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr "该视频无法预览。使用结果上的 YouTube 链接进行观看。"
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "没有活动会话"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "会话 {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "将此会话命名为："
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "要激活的名称"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "删除 {session} 及其所有戏剧？此操作无法撤消。"
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr "删除 {session} 中录制的所有播放内容吗？会话本身被保留。此操作无法撤消。"
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "还没有会议。"
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "没有人在这届会议上唱歌。"
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr "使 {session} 成为活动会话？新歌曲将根据它录制。"
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "显示谁唱的"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "展示这些剧目"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "当前会话"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "将此会话命名..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "开始会话"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "结束会话"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "会话历史记录"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "隐藏自动启动"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "会议"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "开始"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "激活"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "导出 CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "导出列表（文本）"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "清晰的戏剧"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "删除会话"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "连接丢失。服务器还在运行吗？"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr "该浏览器不完全支持。您可能会遇到流媒体问题。请使用 Chrome/Safari/Firefox/Edge 以获得最佳效果。"
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "下一首歌："
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "下一个歌手："
 
 # auto-translated
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "你的分数"
 
 # auto-translated
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
@@ -1516,7 +2195,6 @@ msgstr ""
 
 # auto-translated
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "确认"
-

--- a/pikaraoke/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -4,118 +4,118 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version:  1.1.1\n"
+"Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-03-20 08:10+1100\n"
+"POT-Creation-Date: 2026-08-19 09:35+1000\n"
 "PO-Revision-Date: 2024-08-28 10:09-0400\n"
 "Last-Translator: \n"
-"Language: zh_TW\n"
 "Language-Team: zh_hant_TW <LL@li.org>\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Generated-By: Babel 2.17.0\n"
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:453
+#: karaoke.py:557
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "調整音調 %s 個半音：%s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:469
+#: karaoke.py:571
 #, python-format
 msgid "Volume: %s"
 msgstr "音量：%s"
 
-#: lib/download_manager.py:130
+#: lib/download_manager.py:184
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "成功添加歌曲 (#%d)：%s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:134
+#: lib/download_manager.py:188
 #, python-format
 msgid "Download starting: %s"
 msgstr "開始下載：%s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:222
+#: lib/download_manager.py:344
 #, python-format
 msgid "Downloading video: %s"
 msgstr "正在下載影片：%s"
 
-#: lib/download_manager.py:280
+#: lib/download_manager.py:370
 msgid "Error downloading song: "
 msgstr "下載歌曲時出錯："
 
-#: lib/download_manager.py:300
+#: lib/download_manager.py:390
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "成功添加歌曲：%s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:304
+#: lib/download_manager.py:394
 #, python-format
 msgid "Downloaded: %s"
 msgstr "下載：%s"
 
-#: lib/download_manager.py:327
+#: lib/download_manager.py:418
 msgid "Error queueing song: "
 msgstr "添加歌曲到播放列表時出錯："
 
 # auto-translated
-#: lib/playback_controller.py:89
+#: lib/playback_controller.py:91
 #, python-format
 msgid "Song file not found: %s"
 msgstr "未找到歌曲檔案：%s"
 
 # auto-translated
-#: lib/playback_controller.py:120
+#: lib/playback_controller.py:125
 msgid "Stream was not playable! Skipping track"
 msgstr "串流無法播放！跳過曲目"
 
 #. Message shown when the song ends abnormally
-#: lib/playback_controller.py:149
+#: lib/playback_controller.py:163
 #, python-format
 msgid "Song ended abnormally: %s"
 msgstr "歌曲異常結束：%s"
 
 #. Message shown after the song is skipped, will be followed by song name
-#: lib/playback_controller.py:173
+#: lib/playback_controller.py:191
 #, python-format
 msgid "Skip: %s"
 msgstr "跳過：%s"
 
 #. Message shown after the song is resumed, will be followed by song name
-#: lib/playback_controller.py:189
+#: lib/playback_controller.py:207
 #, python-format
 msgid "Resume: %s"
 msgstr "繼續播放：%s"
 
 # auto-translated
 #. Message shown after the song is paused, will be followed by song name
-#: lib/playback_controller.py:192
+#: lib/playback_controller.py:210
 #, python-format
 msgid "Pause: %s"
 msgstr "暫停：%s"
 
-#: lib/preference_manager.py:133
+#: lib/preference_manager.py:142
 msgid "Your preferences were changed successfully"
 msgstr "您的偏好設定已成功更改"
 
-#: lib/preference_manager.py:136 templates/info.html:19
+#: lib/preference_manager.py:145 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "發生錯誤！您的偏好設定未被更改"
 
-#: lib/preference_manager.py:153
+#: lib/preference_manager.py:162
 msgid "Your preferences were cleared successfully"
 msgstr "您的偏好設定已成功清除"
 
-#: lib/preference_manager.py:156
+#: lib/preference_manager.py:165
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "發生錯誤！您的偏好設定未被清除"
 
@@ -146,18 +146,18 @@ msgid "Song added to the queue: %s"
 msgstr "成功添加歌曲到播放列表：%s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:194
+#: lib/queue_manager.py:210
 msgid "Clear queue"
 msgstr "清空播放列表"
 
 # auto-translated
-#: lib/stream_manager.py:112
+#: lib/stream_manager.py:124
 #, python-format
 msgid "Error resolving file: %s"
 msgstr "解析檔案時發生錯誤：%s"
 
 # auto-translated
-#: lib/stream_manager.py:148
+#: lib/stream_manager.py:160
 msgid "Failed to prepare stream"
 msgstr "準備流失敗"
 
@@ -252,56 +252,90 @@ msgstr "大量歌曲重命名器"
 msgid "Error: No filename parameters were specified!"
 msgstr "錯誤：未指定檔案名參數！"
 
-#: routes/batch_song_renamer.py:245 routes/files.py:160 routes/files.py:191
+#: routes/batch_song_renamer.py:245
 msgid "Error: Can't edit this song because it is in the current queue: "
 msgstr "錯誤：無法編輯此歌曲，因為它在當前播放列表中："
 
-#. Message shown after trying to rename a file to a name that already exists.
-#: routes/batch_song_renamer.py:259 routes/files.py:201
+#: routes/batch_song_renamer.py:259
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "重命名檔案時出錯：'%s' 到 '%s'，檔案名已存在"
 
-#. Title of the files page.
-#. Navigation link for the page where the user can add existing songs to the
-#. queue.
-#: routes/files.py:111 templates/base.html:226
-msgid "Browse"
-msgstr "瀏覽"
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+msgid "Songs"
+msgstr "歌曲"
 
 # auto-translated
-#: routes/files.py:126
+#: routes/files.py:216
 msgid "You don't have permission to delete songs"
 msgstr "您無權刪除歌曲"
 
-#. Message shown after trying to delete a song that is in the queue.
-#: routes/files.py:131
-msgid "Error: Can't delete this song because it is in the current queue"
-msgstr "錯誤：無法刪除此歌曲，因為它在當前播放列表中"
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:221
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "錯誤：無法刪除這首歌曲，因為它正在排隊或正在播放"
 
-#: routes/files.py:140
+#: routes/files.py:228
 #, python-format
 msgid "Song deleted: %s"
 msgstr "歌曲已刪除：%s"
 
 # auto-translated
-#: routes/files.py:155 routes/files.py:184
-msgid "You don't have permission to edit songs"
-msgstr "您沒有編輯歌曲的權限"
+#: routes/files.py:260 routes/files.py:283
+msgid "You don't have permission to rename songs"
+msgstr "您無權重命名歌曲"
 
 # auto-translated
-#: routes/files.py:211
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:264
+msgid "This song is playing. Rename it when it finishes."
+msgstr "正在播放這首歌。完成後重命名。"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:288
+msgid "Enter a name for this song."
+msgstr "輸入這首歌的名稱。"
+
+# auto-translated
+#: routes/files.py:294
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "這首歌已經不在圖書館了。它可能已被重新命名或從其他裝置中刪除。"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:306
 #, python-format
-msgid "Error renaming file: '%s' to '%s', %s"
-msgstr "將檔案 '%s' 重新命名為 '%s' 時出錯，%s"
+msgid "A song called '%s' already exists."
+msgstr "一首名為「%s」的歌曲已經存在。"
+
+# auto-translated
+#: routes/files.py:314
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr "這首歌在您編輯時開始播放。完成後重命名。"
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/files.py:320
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "重新命名檔案時發生錯誤：%s"
 
 #. Message shown after renaming a file.
-#: routes/files.py:217
+#: routes/files.py:325
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "已重命名檔案：%s 到 %s"
 
-#: routes/info.py:100
+#: routes/info.py:116
 msgid "CPU usage query unsupported"
 msgstr "不支援 CPU 使用率查詢"
 
@@ -385,6 +419,72 @@ msgstr "在播放列表中下移時出錯"
 msgid "Error deleting from queue"
 msgstr "從播放列表中刪除時出錯"
 
+# auto-translated
+#. Title of the page used to get new songs into the library.
+#. Navigation link for the page used to get new songs into the library.
+#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+msgid "Add New"
+msgstr "新增內容"
+
+# auto-translated
+#. Message shown when a non-admin tries to open a host-only history page
+#: routes/sessions.py:63
+msgid "You don't have permission to view this page"
+msgstr "您沒有權限查看此頁面"
+
+# auto-translated
+#. Error when starting a session without supplying a name
+#. Error when renaming a session without supplying a name
+#: routes/sessions_api.py:105 routes/sessions_api.py:160
+msgid "A name is required"
+msgstr "需要提供姓名"
+
+# auto-translated
+#. Error when resetting one session's plays without saying which session
+#: routes/sessions_api.py:135
+msgid "A session is required"
+msgstr "需要一個會話"
+
+# auto-translated
+#: routes/sessions_api.py:209
+msgid "Play not found"
+msgstr "找不到播放"
+
+# auto-translated
+#: routes/sessions_api.py:250 routes/sessions_api.py:254
+#: routes/sessions_api.py:277 routes/sessions_api.py:286
+#: routes/sessions_api.py:343
+msgid "Session not found"
+msgstr "未找到會話"
+
+# auto-translated
+#: routes/sessions_api.py:312
+msgid "Played At"
+msgstr "玩過"
+
+# auto-translated
+#. Label before the name of the singer the play log is filtered to.
+#. Play log column header for who sang the song.
+#. Ranking table column header for the person who sang.
+#: routes/sessions_api.py:312 templates/history.html:412
+#: templates/history.html:469 templates/rankings.html:185
+msgid "Performer"
+msgstr "演員"
+
+# auto-translated
+#. Label before the name of the song the play log is filtered to.
+#. Play log column header for the song that was sung.
+#. Ranking table column header for the song that was sung.
+#: routes/sessions_api.py:312 templates/history.html:432
+#: templates/history.html:473 templates/rankings.html:138
+msgid "Song"
+msgstr "歌曲"
+
+# auto-translated
+#: routes/sessions_api.py:324
+msgid "PiKaraoke - Play History"
+msgstr "PiKaraoke - 播放歷史"
+
 #: routes/splash.py:24
 msgid "Never sing again... ever."
 msgstr "永遠不要再唱歌了...永遠不要。"
@@ -451,65 +551,69 @@ msgid "Failed to stream subtitle: "
 msgstr "無法傳輸字幕："
 
 # auto-translated
-#. Prompt to change the username displayed next to queued songs. CURRENT_NAME
-#. is replaced with the name
-#: templates/base.html:25
+#. Prompt to change the username displayed next to queued songs. {name} is
+#. replaced with the name
+#: templates/base.html:33
+#, python-brace-format
 msgid ""
-"Do you want to change the name of the person using this device? This will"
-" show up on queued songs. Current: CURRENT_NAME"
-msgstr "您要更改使用此設備的人的姓名嗎？這將顯示在排隊的歌曲上。目前：CURRENT_NAME"
+"Do you want to change the name of the person using this device? This will "
+"show up on queued songs. Current: {name}"
+msgstr "您要更改使用此設備的人的姓名嗎？這將顯示在排隊的歌曲上。目前：{name}"
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:27
+#: templates/base.html:35
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "您確定要清除整個佇列嗎？輸入“確定”繼續"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. SONG_TITLE is
-#. replaced with the title
-#: templates/base.html:29
-msgid "Are you sure you want to delete SONG_TITLE from the queue?"
-msgstr "您確定要從佇列中刪除 SONG_TITLE 嗎？"
+#. Confirmation dialog when removing a song from the queue. {title} is
+#. replaced
+#. with the title
+#: templates/base.html:37
+#, python-brace-format
+msgid "Are you sure you want to delete {title} from the queue?"
+msgstr "您確定要從佇列中刪除 {title} 嗎？"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:31
+#: templates/base.html:39
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "您確定要從音樂庫中刪除此歌曲嗎？"
 
 # auto-translated
-#. Label showing the number of semitones for pitch shift. SEMITONE_VALUE is
-#. replaced with a number like +3 or -2.
-#: templates/base.html:33
-msgid "SEMITONE_VALUE semitones"
-msgstr "SEMITONE_VALUE 半音"
+#. Label showing the number of semitones for pitch shift. {value} is replaced
+#. with a number like +3 or -2.
+#: templates/base.html:41
+#, python-brace-format
+msgid "{value} semitones"
+msgstr "{value} 半音"
 
 # auto-translated
-#. Confirmation dialog when changing the key/pitch of a song. SEMITONE_LABEL is
+#. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:35
-msgid "Transpose this song: SEMITONE_LABEL?"
-msgstr "轉調這首歌：SEMITONE_LABEL？"
+#: templates/base.html:43
+#, python-brace-format
+msgid "Transpose this song: {label}?"
+msgstr "轉置這首歌：{label}？"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:37
+#: templates/base.html:45
 msgid "Are you sure you want to restart this track?"
 msgstr "您確定要重新開始該曲目嗎？"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:39
+#: templates/base.html:47
 msgid ""
-"A semitone is also known as a half-step. It is the smallest interval used"
-" in classical Western music, equal to a twelfth of an octave or half a "
-"tone."
+"A semitone is also known as a half-step. It is the smallest interval used in"
+" classical Western music, equal to a twelfth of an octave or half a tone."
 msgstr "半音也稱為半音。它是西方古典音樂中使用的最小音程，等於十二個八度或半個音。"
 
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:41
+#: templates/base.html:49
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -517,40 +621,67 @@ msgstr "您確定要擴充檔案系統嗎？這將重新啟動您的樹莓派。
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:43
+#: templates/base.html:51
 msgid "Error"
 msgstr "錯誤"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:96
+#: templates/base.html:116
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
 msgstr "請輸入您的名字。這將顯示在您從此設備添加的歌曲旁邊。"
 
+# auto-translated
+#. Accessible label for the banner naming the karaoke session in progress.
+#. {name} is replaced with the session's name.
+#: templates/base.html:144 templates/base.html:413
+#, python-brace-format
+msgid "Current session: {name}"
+msgstr "目前會話：{name}"
+
 #. Navigation link for the home page.
-#: templates/base.html:210
+#: templates/base.html:330
 msgid "Home"
 msgstr "首頁"
 
 #. Navigation link for the queue page.
-#: templates/base.html:216 templates/queue.html:492
+#: templates/base.html:336 templates/queue.html:509
 msgid "Queue"
 msgstr "播放列表"
 
-#. Navigation link for the search page add songs to the queue.
-#. Submit button on the search form for searching YouTube.
-#: templates/base.html:221 templates/search.html:589
-msgid "Search"
-msgstr "搜尋"
+# auto-translated
+#. Dropdown link to the most-played songs and most active singers.
+#: templates/base.html:380
+msgid "Rankings"
+msgstr "排行榜"
+
+# auto-translated
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: templates/base.html:385 templates/info.html:432
+msgid "Play History"
+msgstr "播放歷史"
+
+# auto-translated
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: templates/base.html:392
+msgid "Sessions"
+msgstr "會議"
+
+# auto-translated
+#. Dropdown link to the settings and system information page.
+#: templates/base.html:398
+msgid "Settings"
+msgstr "設定"
 
 # auto-translated
 #. Message about the wait for loading the songs
 #: templates/batch-song-renamer.html:136
 msgid ""
-"The loading process may take a few seconds, as the song titles are "
-"compared online. Loading time may vary\n"
+"The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
 msgstr ""
 "由於歌曲名稱是在線比較的，加載過程可能需要幾秒鐘。載入時間可能會有所不同\n"
@@ -584,7 +715,8 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show all songs
-#: templates/batch-song-renamer.html:150
+#. Button which stops filtering the play log to one song.
+#: templates/batch-song-renamer.html:150 templates/history.html:438
 msgid "Show all songs"
 msgstr "顯示所有歌曲"
 
@@ -594,82 +726,211 @@ msgstr "顯示所有歌曲"
 msgid "Loading songs..."
 msgstr "正在加載歌曲..."
 
+# auto-translated
+#. Help text explaining that clicking a suggestion copies it to the filename
+#. input.
+#: templates/edit.html:46
+msgid "Click a suggestion to use it as the new filename."
+msgstr "按一下建議以將其用作新檔案名稱。"
+
 #. Warning when no suggested tracks are found for a search.
-#: templates/edit.html:30
+#: templates/edit.html:49
 msgid "No suggestion!"
 msgstr "沒有建議！"
 
-#. Page title for the page where a song can be edited.
-#: templates/edit.html:55
-msgid "Edit Song"
-msgstr "編輯歌曲"
-
-#. Label on the control to edit the song's name
-#: templates/edit.html:69
-msgid "Edit Song Name"
-msgstr "編輯歌曲名稱"
-
-#. Label on button which auto formats the song's title.
-#: templates/edit.html:76
-msgid "Auto-format"
-msgstr "自動格式化"
-
-#. Label on button which swaps the order of the artist and song in the title.
-#: templates/edit.html:78
-msgid "Swap artist/song order"
-msgstr "交換歌手/歌曲順序"
+# auto-translated
+#. Page title for the page where a song can be renamed.
+#: templates/edit.html:99
+msgid "Rename Song"
+msgstr "重命名歌曲"
 
 # auto-translated
-#. Label on button which suggests song titles from the website Last.fm.
-#: templates/edit.html:81
-msgid "Suggest from Last.fm"
-msgstr "來自 Last.fm 的建議"
+#. Label showing the original filename on disk before editing.
+#: templates/edit.html:108
+msgid "Current filename"
+msgstr "目前檔案名稱"
+
+# auto-translated
+#. Label for the input where the user types the new filename.
+#: templates/edit.html:127
+msgid "New filename"
+msgstr "新檔案名稱"
+
+# auto-translated
+#. Label on button which applies automatic formatting to tidy the filename.
+#: templates/edit.html:138
+msgid "Auto Format"
+msgstr "自動格式化"
+
+# auto-translated
+#. Label on button which swaps the artist and title around the dash separator.
+#: templates/edit.html:143
+msgid "Swap Artist/Title"
+msgstr "交換藝術家/標題"
+
+# auto-translated
+#. Label on button which searches for track name suggestions from iTunes.
+#: templates/edit.html:150
+msgid "Suggest from iTunes"
+msgstr "來自 iTunes 的建議"
+
+# auto-translated
+#. Label for iTunes search country dropdown
+#: templates/edit.html:155 templates/info.html:416
+msgid "iTunes search country"
+msgstr "iTunes 搜尋國家/地區"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:90
+#: templates/edit.html:169
 msgid "Save"
 msgstr "儲存"
 
 # auto-translated
-#: templates/edit.html:95
+#: templates/edit.html:174
 msgid "Cancel"
 msgstr "取消"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:106
+#: templates/edit.html:183
 msgid "Delete this song"
 msgstr "刪除此歌曲"
 
-#. Label which displays that the songs are currently sorted by
-#. alphabetical order.
-#: templates/files.html:92
-msgid "Sorted Alphabetically"
-msgstr "按字母順序排序"
-
-#. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:94
-msgid ""
-"Sort by\n"
-"\t\t\tDate"
-msgstr "按日期排序"
-
-#. Label which displays that the songs are currently sorted by
-#. date.
-#: templates/files.html:98
-msgid "Sorted by date"
-msgstr "按日期排序"
-
-#. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:100
-msgid ""
-"Sort by\n"
-"\t\t\tAlphabetical"
-msgstr "按字母順序排序"
-
+# auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:107
-msgid "Edit all songs"
-msgstr "編輯所有歌曲"
+#: templates/files.html:218
+msgid "Bulk rename"
+msgstr "批次重命名"
+
+# auto-translated
+#. Subtitle under the Songs heading, explaining that this page lists songs
+#. already downloaded.
+#: templates/files.html:224
+msgid "Available in the library"
+msgstr "在圖書館可以找到"
+
+# auto-translated
+#. Breadcrumb link back to the top level of the folder view.
+#: templates/files.html:353
+msgid "All folders"
+msgstr "所有資料夾"
+
+# auto-translated
+#. Placeholder in the box that filters the songs already on this machine.
+#: templates/files.html:377
+msgid "Search by title, artist..."
+msgstr "按標題、藝術家搜尋..."
+
+#. Button which empties the filter box and shows every song again.
+#. Link which clears the text from the search box.
+#: templates/files.html:383 templates/search.html:552
+msgid "Clear"
+msgstr "清除"
+
+# auto-translated
+#. Button which lists every song at once, ignoring the folders they are stored
+#. in.
+#: templates/files.html:441
+msgid "All songs"
+msgstr "所有歌曲"
+
+# auto-translated
+#. Button which groups the songs by the folder they are stored in.
+#: templates/files.html:446
+msgid "Folders"
+msgstr "資料夾"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. name.
+#: templates/files.html:457
+msgid "Sort Alphabetically"
+msgstr "按字母順序排序"
+
+# auto-translated
+#. Button which changes how the songs are sorted so they become sorted by
+#. date.
+#: templates/files.html:462
+msgid "Sort by Date"
+msgstr "按日期排序"
+
+# auto-translated
+#. Confirmation before deleting one entry from the play log.
+#: templates/history.html:40
+msgid "Delete this entry from the play log?"
+msgstr "從播放日誌中刪除此條目嗎？"
+
+# auto-translated
+#. Shown when the play log has no entries yet.
+#. Shown on the rankings page when no songs have been played yet.
+#: templates/history.html:42 templates/rankings.html:172
+msgid "Nothing has been played yet."
+msgstr "還沒有播放任何內容。"
+
+# auto-translated
+#. Status of a song that was sung all the way through.
+#. Play log column header for when the song was played.
+#: templates/history.html:44 templates/history.html:465
+msgid "Played"
+msgstr "玩過"
+
+# auto-translated
+#. Status of a song that was skipped before it finished.
+#: templates/history.html:46
+msgid "Skipped"
+msgstr "跳過"
+
+# auto-translated
+#. Status of the song that is playing right now, which has not finished yet.
+#: templates/history.html:48
+msgid "Playing"
+msgstr "演奏"
+
+# auto-translated
+#: templates/history.html:182 templates/queue.html:164
+#: templates/queue.html:326 templates/sessions.html:153
+msgid "Options"
+msgstr "選項"
+
+# auto-translated
+#. Button which stops filtering the play log to one singer.
+#: templates/history.html:421
+msgid "Show all performers"
+msgstr "顯示所有表演者"
+
+# auto-translated
+#. Checkbox which hides songs that were skipped before they finished.
+#: templates/history.html:447
+msgid "Hide skipped"
+msgstr "隱藏跳過的"
+
+# auto-translated
+#. Play log column header for whether the song was played through, skipped, or
+#. is still playing.
+#: templates/history.html:476
+msgid "Status"
+msgstr "地位"
+
+#. Menu item which adds the song from this play log entry to the queue.
+#. Button which adds an already-downloaded song to the queue.
+#. Button which downloads a song and puts it straight in the queue.
+#: templates/history.html:496 templates/rankings.html:151
+#: templates/search.html:369 templates/search.html:577
+#: templates/search.html:644 templates/search.html:654
+msgid "Add to queue"
+msgstr "添加到播放列表"
+
+# auto-translated
+#. Shown in place of "add to queue" when the song has since been removed from
+#. the library.
+#: templates/history.html:501
+msgid "This song is no longer in the library"
+msgstr "這首歌已經不在柯瑞了"
+
+# auto-translated
+#. Menu item which removes this entry from the play log.
+#: templates/history.html:506
+msgid "Delete entry"
+msgstr "刪除條目"
 
 #. Message which shows in the "Now Playing" section when there is no song
 #. currently playing
@@ -690,48 +951,53 @@ msgstr "沒有排隊的歌曲。"
 #. Confirmation message when clicking a button to skip a track.
 #: templates/home.html:134
 msgid ""
-"Are you sure you want to skip this track? If you didn't add this song, "
-"ask permission first!"
+"Are you sure you want to skip this track? If you didn't add this song, ask "
+"permission first!"
 msgstr "您確定要跳過這首歌嗎？如果您不是添加這首歌的人，請先徵求許可！"
 
 #. Header showing the currently playing song.
-#: templates/home.html:181
+#: templates/home.html:235
 msgid "Now Playing"
 msgstr "正在播放"
 
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:194
+#: templates/home.html:248
 msgid "Next Song"
 msgstr "下一首歌"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:201
+#: templates/home.html:255
 msgid "Player Control"
 msgstr "播放器控制"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:205
+#: templates/home.html:259
 msgid "Restart Song"
 msgstr "重新開始歌曲"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:207
+#: templates/home.html:261
 msgid "Play/Pause"
 msgstr "播放/暫停"
 
-#: templates/home.html:209
+#: templates/home.html:263
 msgid "Stop Current Song"
 msgstr "停止當前歌曲"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:231
+#: templates/home.html:285
 msgid "Change Key"
 msgstr "更改音調"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:251
+#: templates/home.html:305
 msgid "Change"
 msgstr "更改"
+
+# auto-translated
+#: templates/home.html:315 templates/info.html:553
+msgid "Microphones"
+msgstr "麥克風"
 
 #. Confirmation text whe the user selects quit.
 #: templates/info.html:67
@@ -765,219 +1031,347 @@ msgstr "您確定要立即更新 yt-dlp 嗎？當前和待處理的下載可能�
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:179
+#: templates/info.html:166 templates/info.html:558
+msgid ""
+"No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
+msgstr "未偵測到麥克風。連接 USB 或藍牙麥克風，然後按一下「刷新」。"
+
+# auto-translated
+#: templates/info.html:232
+msgid "Scanning..."
+msgstr "掃描..."
+
+# auto-translated
+#: templates/info.html:234 templates/info.html:579
+msgid "Refresh"
+msgstr "重新整理"
+
+# auto-translated
+#. Confirmation before deleting the entire play history. The host must type ok
+#. to proceed.
+#: templates/info.html:280
+msgid ""
+"Delete ALL play history - every session and every play, for good? Type "
+"\"ok\" to continue."
+msgstr "永久刪除所有遊戲歷史記錄 - 每個會話和每個遊戲？輸入“確定”繼續。"
+
+# auto-translated
+#. Notification shown once the play history has been erased.
+#: templates/info.html:287
+msgid "Play history erased"
+msgstr "播放記錄已刪除"
+
+# auto-translated
+#: templates/info.html:300
 msgid "Library sync complete"
 msgstr "庫同步完成"
 
 #. Title of the information page.
-#: templates/info.html:189
+#: templates/info.html:310
 msgid "Information"
 msgstr "資訊"
 
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:201
+#: templates/info.html:322
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s 的網址："
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:207
+#: templates/info.html:328
 msgid "Handy URL QR code to share with a pal:"
 msgstr "方便分享給朋友的網址 QR 碼："
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:215 templates/info.html:578
+#: templates/info.html:336 templates/info.html:860
 msgid "Admin"
 msgstr "行政"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:221
+#: templates/info.html:342
 msgid "Enter the administrator password"
 msgstr "輸入管理員密碼"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:230
+#: templates/info.html:351
 msgid "Login"
 msgstr "登入"
 
 # auto-translated
 #. Title of the song library section.
-#: templates/info.html:242
+#: templates/info.html:363
 msgid "Song Library"
 msgstr "歌庫"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:247
+#: templates/info.html:368
 msgid "Library"
 msgstr "圖書館"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:253
+#: templates/info.html:374
 msgid "Songs in library:"
 msgstr "庫裡的歌曲："
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:257
+#: templates/info.html:378
 msgid "Sync Now"
 msgstr "立即同步"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:261
+#: templates/info.html:382
 msgid "Reconciles the library with the song directory in the background."
 msgstr "在後台協調庫與歌曲目錄。"
 
+# auto-translated
+#. Header of the song renaming settings section.
+#: templates/info.html:391
+msgid "Renaming"
+msgstr "重新命名"
+
+# auto-translated
+#. Option for naming songs artist first, e.g. "Abba - Waterloo".
+#: templates/info.html:399
+msgid "Artist - Title"
+msgstr "藝術家 - 頭銜"
+
+# auto-translated
+#. Option for naming songs title first, e.g. "Waterloo - Abba".
+#: templates/info.html:401
+msgid "Title - Artist"
+msgstr "頭銜 - 藝術家"
+
+# auto-translated
+#. Label for the suggestion name order dropdown
+#: templates/info.html:404
+msgid "Order of iTunes suggested song names"
+msgstr "iTunes 建議歌曲名稱的順序"
+
+# auto-translated
+#. Button which deletes the entire play history, every session and every play.
+#: templates/info.html:438
+msgid "Reset all history"
+msgstr "重置所有歷史記錄"
+
+# auto-translated
+#. Help text explaining what Reset all history does.
+#: templates/info.html:442
+msgid "Deletes every session and every play on record. This cannot be undone."
+msgstr "刪除記錄中的每個會話和每個播放。此操作無法撤銷。"
+
 #. Title of the user preferences section.
-#: templates/info.html:268
+#: templates/info.html:449
 msgid "User Preferences"
 msgstr "使用者偏好設定"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:274
+#: templates/info.html:455
 msgid "Splash screen settings"
 msgstr "啟動畫面設定"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:282
+#: templates/info.html:463
 msgid "Disable background video"
 msgstr "停用背景影片"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:288
+#: templates/info.html:469
 msgid "Disable background music"
 msgstr "停用背景音樂"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:294
+#: templates/info.html:475
 msgid "Disable the score screen after each song"
 msgstr "停用每首歌曲後的分數畫面"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:300
+#: templates/info.html:481
 msgid "Hide notifications"
 msgstr "隱藏通知"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:306
+#: templates/info.html:487
 msgid "Show splash clock"
 msgstr "顯示啟動時鐘"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:311
+#: templates/info.html:492
 msgid "Hide the URL and QR code"
 msgstr "隱藏網址和 QR 碼"
 
+# auto-translated
+#. Checkbox label which enables/disables the logo in the middle of the splash
+#. screen
+#: templates/info.html:498
+msgid "Hide the logo on the splash screen"
+msgstr "隱藏啟動畫面上的標誌"
+
+# auto-translated
+#. Checkbox label which enables/disables the karaoke session name shown under
+#. the logo on the splash screen
+#: templates/info.html:504
+msgid "Hide the session name on the splash screen"
+msgstr "在啟動畫面上隱藏會話名稱"
+
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:317
+#: templates/info.html:510
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "隱藏所有覆蓋層，包括正在播放、即將播放和 QR 碼"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:323
+#: templates/info.html:516
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "影片的預設音量（最小 0，最大 100）"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:329
+#: templates/info.html:522
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "背景音樂的音量（最小 0，最大 100）"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:336
+#: templates/info.html:529
 msgid ""
-"The amount of idle time in seconds before the screen saver activates. Set"
-" to 0 to disable it."
+"The amount of idle time in seconds before the screen saver activates. Set to"
+" 0 to disable it."
 msgstr "螢幕保護程式啟動前的閒置時間（秒）。設為 0 可停用。"
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:343
+#: templates/info.html:536
 msgid "The delay in seconds before starting the next song"
 msgstr "開始下一首歌曲前的延遲時間（秒）"
 
 # auto-translated
+#: templates/info.html:547
+msgid "Audio"
+msgstr "聲音的"
+
+# auto-translated
+#: templates/info.html:555
+msgid ""
+"Microphones detected on the server. Audio is routed directly to speakers."
+msgstr "在伺服器上偵測到麥克風。音訊直接傳送至揚聲器。"
+
+# auto-translated
+#: templates/info.html:563
+msgid "Latency"
+msgstr "延遲"
+
+# auto-translated
+#: templates/info.html:571
+msgid "Echo cancellation"
+msgstr "迴聲消除"
+
+# auto-translated
+#: templates/info.html:573
+msgid "Experimental"
+msgstr "實驗性的"
+
+# auto-translated
+#: templates/info.html:574
+msgid "(reduces feedback, adds latency)"
+msgstr "（減少回饋，增加延遲）"
+
+# auto-translated
+#: templates/info.html:582
+msgid ""
+"Microphone support is unavailable. Required audio tools are not installed."
+msgstr "麥克風支援不可用。未安裝所需的音訊工具。"
+
+# auto-translated
+#: templates/info.html:585
+msgid "On Linux / Raspberry Pi, install it with:"
+msgstr "在 Linux / Raspberry Pi 上，安裝它："
+
+# auto-translated
+#: templates/info.html:587
+msgid "and restart PiKaraoke."
+msgstr "並重新啟動 PiKaraoke。"
+
+# auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:354
+#: templates/info.html:599
 msgid "Score phrases"
 msgstr "給短語評分"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:361
+#: templates/info.html:606
 msgid "Add one phrase per line in each box and hit save."
 msgstr "在每個框中每行新增一個短語，然後點擊「儲存」。"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:363
+#: templates/info.html:608
 msgid "LOW Score Phrases (score < 30)"
 msgstr "低分短語（分數 < 30）"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:365
+#: templates/info.html:610
 msgid "Could be better..."
 msgstr "可能會更好..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:368
+#: templates/info.html:613
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID 得分短語 (30 > 分數 < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:370
+#: templates/info.html:615
 msgid "That was ok..."
 msgstr "那就可以了..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:373
+#: templates/info.html:618
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "高分短語（60 < 分數）"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:375
+#: templates/info.html:620
 msgid "Wonderfull..."
 msgstr "精彩..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:383
+#: templates/info.html:628
 msgid "Language settings"
 msgstr "語言設定"
 
 #. Label for language selection dropdown
-#: templates/info.html:396
+#: templates/info.html:641
 msgid "Preferred language (requires restart)"
 msgstr "首選語言（需要重啟"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:405
+#: templates/info.html:650
 msgid "Server settings"
 msgstr "伺服器設定"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:412
+#: templates/info.html:657
 msgid "Normalize audio volume"
 msgstr "標準化音訊音量"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:418
+#: templates/info.html:663
 msgid "Download high quality videos"
 msgstr "下載高品質影片"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:424
+#: templates/info.html:669
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -985,124 +1379,173 @@ msgstr "在播放前完全轉碼影片（更好的瀏覽器相容性，較慢的
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:430
+#: templates/info.html:675
 msgid ""
-"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
-" usage)"
+"Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
+"usage)"
 msgstr "啟用 CDG 像素縮放（CDG 檔案的視覺效果更清晰，可能會增加 CPU 使用率）"
 
 # auto-translated
+#. Checkbox label which enables automatic cleanup of YouTube song titles
+#: templates/info.html:681
+msgid ""
+"Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
+"Version HD\")"
+msgstr "啟用自動 YouTube 標題處理（刪除“卡拉 OK 版本高清”等乾擾詞）"
+
+# auto-translated
+#. Checkbox label which enables browsing the song library by folder
+#: templates/info.html:687
+msgid ""
+"Enable folder browsing (adds a Folders view to the Songs page when the "
+"library has subfolders)"
+msgstr "啟用資料夾瀏覽（當庫有子資料夾時，將資料夾視圖新增至歌曲頁面）"
+
+# auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:437
+#: templates/info.html:694
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr "在幾秒鐘內修復音訊和視訊同步（負=提前音訊|正=延遲音訊）"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:444
+#: templates/info.html:701
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "個別使用者可以添加到播放列表的歌曲數量限制（0 = 無限制）"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:450
+#: templates/info.html:707
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "啟用公平隊列（循環模式確保用戶輪流）"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:457
+#: templates/info.html:714
 msgid ""
-"Buffer size in kilobytes. Transcode this amount of the video before "
-"sending it to the splash screen. "
+"Buffer size in kilobytes. Transcode this amount of the video before sending "
+"it to the splash screen. "
 msgstr "緩衝區大小（KB）。在將影片發送到啟動畫面之前，轉碼這個數量的影片。"
 
+# auto-translated
+#. Label for the dropdown choosing how many songs are shown per page on the
+#. Songs page.
+#: templates/info.html:727
+msgid "Default songs per page."
+msgstr "每頁預設歌曲。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when running in a container.
+#: templates/info.html:734
+msgid ""
+"Keep the server awake: unavailable in a container. Disable sleep on the "
+"host."
+msgstr "保持伺服器喚醒：在容器中不可用。禁用主機上的睡眠。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox when the required tool is missing.
+#: templates/info.html:736
+msgid ""
+"Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
+msgstr "保持伺服器喚醒：需要 systemd-inhibit (Linux) 或 caffeinate (macOS)。"
+
+# auto-translated
+#. Shown instead of the keep-awake checkbox on platforms without a wake lock.
+#: templates/info.html:738
+msgid "Keep the server awake: not supported on this platform."
+msgstr "保持伺服器喚醒：此平台不支援。"
+
+# auto-translated
+#. Checkbox label which stops the server machine from sleeping
+#: templates/info.html:744
+msgid "Keep the server awake while PiKaraoke is running"
+msgstr "PiKaraoke 運行時保持伺服器處於喚醒狀態"
+
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:470
+#: templates/info.html:751
 msgid "Clear preferences"
 msgstr "清除偏好設定"
 
 #. Title of the system data section.
-#: templates/info.html:478
+#: templates/info.html:759
 msgid "System Data"
 msgstr "系統統計"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:483
+#: templates/info.html:764
 msgid "System Info"
 msgstr "系統資訊"
 
 #. The hardware platform
-#: templates/info.html:489
+#: templates/info.html:770
 msgid "Platform:"
 msgstr "平台："
 
 #. The os version
-#: templates/info.html:491
+#: templates/info.html:772
 msgid "OS Version:"
 msgstr "作業系統版本："
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:493
+#: templates/info.html:774
 msgid "yt-dlp version:"
 msgstr "yt-dlp 版本："
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:495
+#: templates/info.html:776
 msgid "FFmpeg version:"
 msgstr "FFmpeg 版本："
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:497
+#: templates/info.html:778
 msgid "Pikaraoke version:"
 msgstr "卡拉OK派版本："
 
 #. Header of the information section about the System stats.
-#: templates/info.html:503
+#: templates/info.html:784
 msgid "System stats"
 msgstr "系統統計"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:509
+#: templates/info.html:790
 msgid "CPU:"
 msgstr "中央處理器："
 
 # auto-translated
-#: templates/info.html:509 templates/info.html:511 templates/info.html:513
+#: templates/info.html:790 templates/info.html:792 templates/info.html:794
 msgid "Loading..."
 msgstr "載入中..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:511
+#: templates/info.html:792
 msgid "Disk Usage:"
 msgstr "磁碟使用情況："
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:513
+#: templates/info.html:794
 msgid "Memory:"
 msgstr "記憶："
 
 #. Title of the updates section.
-#: templates/info.html:520
+#: templates/info.html:801
 msgid "Updates"
 msgstr "更新"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:525
+#: templates/info.html:806
 msgid "YT-DLP update"
 msgstr "YT-DLP 更新"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:530
+#: templates/info.html:811
 #, python-format
 msgid ""
 "\n"
-"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp "
-"will probably fix it.<br/>\n"
+"\t\t\t\t\t\tIf downloads or searches stopped working, updating yt-dlp will probably fix it.<br/>\n"
 "\t\t\t\t\t\tThe current installed version is: \"%(youtubedl_version)s\".\n"
 "\t\t\t\t\t"
 msgstr ""
@@ -1111,40 +1554,37 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:536
+#: templates/info.html:817
 msgid "Update yt-dlp"
 msgstr "更新 yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:540
+#: templates/info.html:821
 msgid ""
-"* This update link above may fail if you don't have proper file "
-"permissions.\n"
+"* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
 msgstr ""
 "如果您沒有適當的檔案權限，上面的更新連結可能會失敗。\n"
 "    檢查卡拉OK派日誌以查看錯誤。"
 
 #. Title of the updates section.
-#: templates/info.html:552
+#: templates/info.html:834
 msgid "Other"
 msgstr "其他"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:557 templates/info.html:569
+#: templates/info.html:839 templates/info.html:851
 msgid "Expand Raspberry Pi filesystem"
 msgstr "擴展樹莓派檔案系統"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:562
+#: templates/info.html:844
 msgid ""
-"If you just installed the pre-built pikaraoke pi image and your SD card "
-"is larger than 4GB,\n"
-"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the "
-"remaining space. You only need to do this once.\n"
+"If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
+"\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
 "如果您剛剛安裝了預建的卡拉OK派樹莓派映像，且您的 SD 卡大於 4GB，\n"
@@ -1153,24 +1593,24 @@ msgstr ""
 
 # auto-translated
 #. Message for the log out user from admin mode button.
-#: templates/info.html:584
+#: templates/info.html:866
 msgid "Click here to logout from admin mode."
 msgstr "按一下此處從管理模式登出。"
 
 # auto-translated
 #. Link which will log out the user from admin mode.
-#: templates/info.html:586
+#: templates/info.html:868
 msgid "Log out"
 msgstr "退出"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:593
+#: templates/info.html:875
 msgid "Shutdown"
 msgstr "關機"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:600
+#: templates/info.html:882
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1178,208 +1618,270 @@ msgstr "不要直接拔掉電源！始終正確關閉您的伺服器，以避免
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:607
+#: templates/info.html:889
 msgid "Quit Pikaraoke"
 msgstr "退出卡拉OK派"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:610
+#: templates/info.html:893
 msgid "Reboot System"
 msgstr "重新啟動系統"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:613
+#: templates/info.html:896
 msgid "Shutdown System"
 msgstr "關閉系統"
 
 # auto-translated
-#: templates/queue.html:164 templates/queue.html:313
-msgid "Options"
-msgstr "選項"
+#. Tooltip on the button showing the previous page of a table.
+#: templates/partials/pager.html:32 templates/partials/pager.html:63
+msgid "Previous page"
+msgstr "上一頁"
 
 # auto-translated
-#: templates/queue.html:213
+#. Tooltip on the button showing the next page of a table.
+#: templates/partials/pager.html:34 templates/partials/pager.html:67
+msgid "Next page"
+msgstr "下一頁"
+
+# auto-translated
+#. Pagination summary. {start}, {end} and {total} are replaced with numbers,
+#. reading for example "1-100 of 2000".
+#: templates/partials/pager.html:39 templates/partials/pager.html:82
+#, python-brace-format
+msgid "{start}-{end} of {total}"
+msgstr "{start}-{end} 共 {total}"
+
+# auto-translated
+#. Label before the dropdown choosing how many rows to list per page.
+#: templates/partials/pager.html:44
+msgid "Per page"
+msgstr "每頁"
+
+# auto-translated
+#. Dropdown option covering every karaoke session ever recorded.
+#: templates/partials/session_filter.html:18
+msgid "All sessions"
+msgstr "所有會議"
+
+# auto-translated
+#: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "待下載"
 
 # auto-translated
 #: templates/queue.html:218
+msgid "Retrying"
+msgstr "重試"
+
+# auto-translated
+#: templates/queue.html:219
 msgid "Queued"
 msgstr "排隊"
 
 # auto-translated
-#: templates/queue.html:226
+#: templates/queue.html:231
 msgid "Download Errors"
 msgstr "下載錯誤"
 
 # auto-translated
-#: templates/queue.html:235
+#: templates/queue.html:240
 msgid "Failed"
 msgstr "失敗的"
 
 # auto-translated
-#: templates/queue.html:236
+#: templates/queue.html:241
+msgid "Retry"
+msgstr "重試"
+
+# auto-translated
+#: templates/queue.html:242
 msgid "Dismiss"
 msgstr "解僱"
 
 # auto-translated
-#: templates/queue.html:298
+#: templates/queue.html:311
 msgid "Drag to reorder"
 msgstr "拖曳以重新排序"
 
-#: templates/queue.html:338
+#: templates/queue.html:351
 msgid "The queue is empty"
 msgstr "播放列表是空的"
 
 # auto-translated
-#: templates/queue.html:432
+#: templates/queue.html:449
 msgid "Play"
 msgstr "玩"
 
-#: templates/queue.html:434 templates/queue.html:559
+#: templates/queue.html:451 templates/queue.html:580
 msgid "Pause"
 msgstr "暫停"
 
 # auto-translated
-#: templates/queue.html:505
+#: templates/queue.html:522
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> random songs"
 msgstr ""
-"加 <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
-"pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
-"style=\"width: 42px\" /> 隨機歌曲"
+"加 <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" pattern=\"\\d*\" "
+"maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" /> "
+"隨機歌曲"
 
-#: templates/queue.html:509
+#: templates/queue.html:526
 msgid "Clear all"
 msgstr "清除全部"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Play Next"
 msgstr "播放下一個"
 
 # auto-translated
-#: templates/queue.html:523
+#: templates/queue.html:540
 msgid "Move to Top"
 msgstr "移至頂部"
 
 # auto-translated
-#: templates/queue.html:527
+#: templates/queue.html:544
 msgid "Move Up"
 msgstr "向上移動"
 
 # auto-translated
-#: templates/queue.html:531
+#: templates/queue.html:548
 msgid "Move Down"
 msgstr "下移"
 
 # auto-translated
-#: templates/queue.html:535
+#: templates/queue.html:552
 msgid "Move to Bottom"
 msgstr "移至底部"
 
 # auto-translated
-#: templates/queue.html:539
+#. Menu item which changes the name of a session that already has one.
+#. Button which changes the name of the session that is currently running.
+#: templates/queue.html:556 templates/sessions.html:43
+#: templates/sessions.html:651
+msgid "Rename"
+msgstr "重新命名"
+
+# auto-translated
+#: templates/queue.html:560
 msgid "Remove from Queue"
 msgstr "從佇列中刪除"
 
 # auto-translated
-#: templates/queue.html:555
+#: templates/queue.html:576
 msgid "Restart"
 msgstr "重新啟動"
 
 # auto-translated
-#: templates/queue.html:563
+#: templates/queue.html:584
 msgid "Skip"
 msgstr "跳過"
 
 # auto-translated
-#: templates/queue.html:571
+#: templates/queue.html:592
 msgid "Download queue"
 msgstr "下載隊列"
 
-#: templates/search.html:242
-msgid "Available songs in local library"
-msgstr "本地音樂庫中的可用歌曲"
+# auto-translated
+#. Label before the dropdown choosing how many ranked rows to show.
+#: templates/rankings.html:39
+msgid "Show"
+msgstr "展示"
 
-#. Title for the search page.
-#: templates/search.html:574
-msgid "Search / Add New"
-msgstr "搜尋 / 添加新歌"
+# auto-translated
+#. Ranking table column header for a row's position in the chart.
+#: templates/rankings.html:55
+msgid "Rank"
+msgstr "秩"
 
-#: templates/search.html:584
-msgid "Available Songs"
-msgstr "可用歌曲"
+# auto-translated
+#. Ranking table column header for how many times something was played.
+#. Session list column header for how many songs were played.
+#: templates/rankings.html:58 templates/sessions.html:689
+msgid "Plays"
+msgstr "戲劇"
 
-#. Submit button on the search form when selecting a locally downloaded song.
-#. The button adds it to                                         the queue.
-#: templates/search.html:592
-msgid "Add to queue"
-msgstr "添加到播放列表"
+# auto-translated
+#. Heading for the list of songs that have been sung the most times.
+#: templates/rankings.html:129
+msgid "Top songs"
+msgstr "熱門歌曲"
 
-#. Link which clears the text from the search box.
-#: templates/search.html:598
-msgid "Clear"
-msgstr "清除"
+# auto-translated
+#. Heading for the list of people who have sung the most songs.
+#: templates/rankings.html:176
+msgid "Top performers"
+msgstr "表現最佳者"
 
-#. Checkbox label which enables more options when searching.
-#: templates/search.html:602
-msgid "Advanced"
-msgstr "進階"
+# auto-translated
+#. Shown on the rankings page when nobody has sung anything yet.
+#: templates/rankings.html:203
+msgid "Nobody has sung yet."
+msgstr "還沒有人唱歌。"
 
-#. Help text below the search bar.
-#: templates/search.html:617
-msgid ""
-"- Type a song (title/artist) to search\n"
-"\t\t\t\t\t\t\t\tthe available songs and click 'Add to queue' to add it to"
-" the queue."
-msgstr ""
-"輸入歌曲\n"
-"          （標題/歌手）以搜尋可用歌曲，並點擊「添加到播放列表」\n"
-"          將其添加到播放列表。"
+# auto-translated
+#. Status shown on a search result that has been requested but has not arrived
+#. yet.
+#: templates/search.html:348
+msgid "Adding..."
+msgstr "新增..."
 
-#. Additonal help text below the search bar.
-#: templates/search.html:621
-msgid ""
-"- If the song doesn't appear in\n"
-"\t\t\t\t\t\t\t\tthe \"Available Songs\" dropdown, click 'Search' to find "
-"it on Youtube"
-msgstr ""
-"如果\n"
-"          歌曲未出現在「可用歌曲」下拉選單中，點擊\n"
-"          「搜尋」在 Youtube 上尋找"
+# auto-translated
+#. Badge on a YouTube search result marking a song that is already downloaded.
+#: templates/search.html:375 templates/search.html:624
+msgid "In library"
+msgstr "在圖書館"
+
+# auto-translated
+#. Subtitle under the Add New heading, explaining that this page gets songs
+#. the
+#. machine does not have.
+#: templates/search.html:519
+msgid "Add new songs from YouTube"
+msgstr "新增 YouTube 的新歌曲"
+
+# auto-translated
+#. Placeholder in the box used to search YouTube for a song to download.
+#: templates/search.html:532
+msgid "Search YouTube by title, artist..."
+msgstr "按標題、藝術家搜尋 YouTube..."
+
+#. Submit button on the search form for searching YouTube.
+#: templates/search.html:538
+msgid "Search"
+msgstr "搜尋"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
-#. (i.e. the songs still                                         have a singer
-#. and are not just instrumentals.)
-#: templates/search.html:637
+#. (i.e. the songs still                                 have a singer and are
+#. not just instrumentals.)
+#: templates/search.html:548
 msgid "Include non-karaoke matches"
 msgstr "包含非卡拉OK版本"
 
+#. Link which reveals the direct-URL download form.
+#: templates/search.html:554
+msgid "Advanced"
+msgstr "進階"
+
+# auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:643
-msgid "Direct download YouTube url:"
-msgstr "直接下載 YouTube 網址："
+#: templates/search.html:562
+msgid "Paste a YouTube url:"
+msgstr "貼上 YouTube 網址："
 
-#. Checkbox label which marks the song to be added to the queue after it
-#. finishes downloading.
-#: templates/search.html:657 templates/search.html:700
-msgid "Add to queue once downloaded"
-msgstr ""
-"下載完成後\n"
-"          添加到播放列表"
-
-#. Button label for the direct download form's submit button.
-#: templates/search.html:662
-msgid "Download"
-msgstr "下載"
+# auto-translated
+#. Button which downloads a song into the library without queuing it.
+#: templates/search.html:582 templates/search.html:659
+msgid "Save for later"
+msgstr "儲存以供稍後使用"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:684
+#: templates/search.html:601
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1390,7 +1892,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:691
+#: templates/search.html:608
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1400,38 +1902,208 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/splash.html:23
+#: templates/search.html:673
+msgid ""
+"Preview unavailable for this video. Use the YouTube link on the result to "
+"watch it."
+msgstr "該影片無法預覽。使用結果上的 YouTube 連結進行觀看。"
+
+# auto-translated
+#. Shown on the sessions page when no session is currently running.
+#: templates/sessions.html:35
+msgid "No active session"
+msgstr "沒有活動會話"
+
+# auto-translated
+#. Label for a session the host never named. {number} is replaced with a
+#. number.
+#: templates/partials/session_filter.html:22 templates/sessions.html:37
+#, python-brace-format
+msgid "Session {number}"
+msgstr "會話 {number}"
+
+# auto-translated
+#. Prompt asking the host to name a session.
+#: templates/sessions.html:39
+msgid "Name this session:"
+msgstr "將此會話命名為："
+
+# auto-translated
+#. Menu item which names the auto-started session that is recording now,
+#. making
+#. it the active session everyone sees.
+#: templates/sessions.html:41
+msgid "Name to make active"
+msgstr "要啟動的名稱"
+
+# auto-translated
+#. Confirmation before deleting a session and every play recorded in it.
+#. {session} is replaced with its name.
+#: templates/sessions.html:45
+#, python-brace-format
+msgid "Delete {session} and all of its plays? This cannot be undone."
+msgstr "刪除 {session} 及其所有戲劇？此操作無法撤銷。"
+
+# auto-translated
+#. Confirmation before deleting every play in a session while keeping the
+#. session. {session} is replaced with its name.
+#: templates/sessions.html:47
+#, python-brace-format
+msgid ""
+"Delete every play recorded in {session}? The session itself is kept. This "
+"cannot be undone."
+msgstr "刪除 {session} 中錄製的所有播放內容嗎？會話本身被保留。此操作無法撤銷。"
+
+# auto-translated
+#. Shown when no sessions have been recorded yet.
+#: templates/sessions.html:49
+msgid "No sessions yet."
+msgstr "還沒有會議。"
+
+# auto-translated
+#. Shown when a session has no plays, so nobody has sung in it.
+#: templates/sessions.html:51
+msgid "Nobody has sung in this session."
+msgstr "沒有人在這屆會議上唱歌。"
+
+# auto-translated
+#. Confirmation before making an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:53
+#, python-brace-format
+msgid ""
+"Make {session} the active session? New songs will be recorded against it."
+msgstr "使 {session} 成為活動會話？新歌曲將根據它錄製。"
+
+# auto-translated
+#. Tooltip on the arrow which expands a session to list who sang in it.
+#: templates/sessions.html:144
+msgid "Show who sang"
+msgstr "顯示誰唱的"
+
+# auto-translated
+#. Link inside an expanded session which opens the play log filtered to it.
+#: templates/sessions.html:163
+msgid "Show these plays"
+msgstr "展示這些劇目"
+
+# auto-translated
+#. Heading for the section showing the session currently being recorded.
+#: templates/sessions.html:625
+msgid "Current Session"
+msgstr "目前會話"
+
+# auto-translated
+#. Placeholder inside the box naming a session as it is started.
+#: templates/sessions.html:642
+msgid "Name this session..."
+msgstr "將此會話命名..."
+
+# auto-translated
+#. Button which starts a new play history session.
+#: templates/sessions.html:648
+msgid "Start session"
+msgstr "開始會話"
+
+# auto-translated
+#. Button which closes the session that is currently running.
+#. Menu item which closes the session that is currently running.
+#: templates/sessions.html:654 templates/sessions.html:714
+msgid "End session"
+msgstr "結束會話"
+
+# auto-translated
+#. Heading for the list of past karaoke sessions.
+#: templates/sessions.html:660
+msgid "Session History"
+msgstr "會話歷史記錄"
+
+# auto-translated
+#. Checkbox which hides the sessions PiKaraoke started on its own, which the
+#. host never named.
+#: templates/sessions.html:669
+msgid "Hide auto-started"
+msgstr "隱藏自動啟動"
+
+# auto-translated
+#. Session list column header for the session name.
+#. Label before the dropdown choosing which karaoke session a page reports on.
+#: templates/partials/session_filter.html:14 templates/sessions.html:685
+msgid "Session"
+msgstr "會議"
+
+# auto-translated
+#. Session list column header for when the session started.
+#: templates/sessions.html:687
+msgid "Started"
+msgstr "開始"
+
+# auto-translated
+#. Menu item which makes an old session the one new songs are recorded
+#. against.
+#: templates/sessions.html:709
+msgid "Make active"
+msgstr "啟用設定"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a CSV file for
+#. spreadsheets.
+#: templates/sessions.html:719
+msgid "Export CSV"
+msgstr "匯出 CSV"
+
+# auto-translated
+#. Menu item which downloads the session's play log as a plain-text,
+#. human-readable set list.
+#: templates/sessions.html:724
+msgid "Export list (text)"
+msgstr "匯出清單（文字）"
+
+# auto-translated
+#. Menu item which deletes every play in the session but keeps the session
+#. itself.
+#: templates/sessions.html:735
+msgid "Clear plays"
+msgstr "清晰的戲劇"
+
+# auto-translated
+#. Menu item which deletes the session and every play recorded in it.
+#: templates/sessions.html:740
+msgid "Delete session"
+msgstr "刪除會話"
+
+# auto-translated
+#: templates/splash.html:24
 msgid "Connection lost. Is the server still running?"
 msgstr "連線遺失。伺服器還在運作嗎？"
 
 # auto-translated
-#: templates/splash.html:24
+#: templates/splash.html:25
 msgid ""
-"This browser is not fully supported. You may experience streaming issues."
-" Please use Chrome/Safari/Firefox/Edge for best results."
+"This browser is not fully supported. You may experience streaming issues. "
+"Please use Chrome/Safari/Firefox/Edge for best results."
 msgstr "該瀏覽器不完全支援。您可能會遇到串流媒體問題。請使用 Chrome/Safari/Firefox/Edge 以獲得最佳效果。"
 
 #. Label for the next song to be played in the queue.
-#: templates/splash.html:89
+#: templates/splash.html:94
 msgid "Up next:"
 msgstr "即將播放："
 
 #. Label for the next singer in the queue.
-#: templates/splash.html:96
+#: templates/splash.html:101
 msgid "Next singer:"
 msgstr "下一位歌手："
 
 #. The title of the score screen, telling the user their singing score
-#: templates/splash.html:118
+#: templates/splash.html:123
 msgid "Your Score"
 msgstr "您的分數"
 
 #. Prompt for interaction in order to enable video autoplay.
-#: templates/splash.html:132
+#: templates/splash.html:137
 msgid ""
 "Due to limitations with browser permissions, you must interact\n"
-"      with the page once before it allows autoplay of videos. Pikaraoke "
-"will not\n"
+"      with the page once before it allows autoplay of videos. Pikaraoke will not\n"
 "      play otherwise. Click the button below to\n"
 "      <a onClick=\"handleConfirmation()\">confirm</a>."
 msgstr ""
@@ -1441,7 +2113,6 @@ msgstr ""
 "      <a onClick=\"handleConfirmation()\">確認</a>。"
 
 #. Button to confirm to enable video autoplay.
-#: templates/splash.html:145
+#: templates/splash.html:150
 msgid "Confirm"
 msgstr "確認"
-

--- a/tests/unit/test_template_i18n.py
+++ b/tests/unit/test_template_i18n.py
@@ -6,6 +6,10 @@ terminates the JS string literal it is interpolated into, raising a SyntaxError 
 kills the entire inline <script> for that locale. Every gettext call inside a <script>
 must therefore be escaped by hand: |tojson to emit a JS value, or |forceescape when JS
 builds the translation into an HTML string.
+
+It also guards the placeholder convention. A token that a call site fills in with
+replace() must be braced, like {name}: a bare English word is translated along with the
+sentence around it, so the replace() matches nothing and the token reaches the screen.
 """
 
 import json
@@ -28,6 +32,15 @@ SCRIPT_BLOCK = re.compile(r"<script\b[^>]*>(.*?)</script>", re.DOTALL | re.IGNOR
 JINJA_EXPRESSION = re.compile(r"\{\{.*?\}\}", re.DOTALL)
 GETTEXT_CALL = re.compile(r"\b(_|gettext|ngettext)\s*\(")
 ESCAPING_FILTER = re.compile(r"\|\s*(tojson|forceescape)\b")
+
+GETTEXT_STRING = re.compile(r"\b(?:_|gettext|ngettext)\s*\(\s*(['\"])(.*?)\1")
+REPLACE_TARGET = re.compile(r"\breplace\(\s*(['\"])(.*?)\1")
+BARE_TOKEN = re.compile(r"\b[A-Z][A-Z0-9_]{2,}\b")
+
+# Minified bundles substitute uppercase strings of their own, which would read as offenders.
+OWN_SOURCES = sorted(TEMPLATES.glob("**/*.html")) + sorted(
+    path for path in (PIKARAOKE / "static").glob("*.js") if not path.name.endswith(".min.js")
+)
 
 
 @pytest.fixture(scope="module")
@@ -67,3 +80,26 @@ def test_gettext_in_script_blocks_is_escaped(template):
     ]
 
     assert not offenders, "Unescaped gettext in inline JS:\n" + "\n".join(offenders)
+
+
+def test_substituted_tokens_in_translated_strings_are_braced():
+    """Flag an uppercase word that is both inside a msgid and a target of replace().
+
+    Cross-file by necessity: base.html holds the msgid whose token spa-navigation.js
+    substitutes. Words that are merely uppercase (CDG, ENTIRE) are never replace() targets,
+    so no vocabulary list is needed to tell a placeholder from emphasis.
+    """
+    sources = {path: path.read_text(encoding="utf-8") for path in OWN_SOURCES}
+    substituted = {
+        match.group(2) for text in sources.values() for match in REPLACE_TARGET.finditer(text)
+    }
+
+    offenders = [
+        f"{path.name}: {token} in {call.group(2)[:60]!r}"
+        for path, text in sources.items()
+        for call in GETTEXT_STRING.finditer(text)
+        for token in BARE_TOKEN.findall(call.group(2))
+        if token in substituted
+    ]
+
+    assert not offenders, "Substituted tokens must be braced, like {name}:\n" + "\n".join(offenders)

--- a/tests/unit/test_update_translations.py
+++ b/tests/unit/test_update_translations.py
@@ -1,14 +1,43 @@
-"""Unit tests for placeholder protection in update_translations."""
+"""Unit tests for placeholder protection and retry in update_translations."""
 
 import pytest
 
 pytest.importorskip("polib", reason="polib is only in the 'translations' dependency group")
 
+import polib
+from deep_translator.exceptions import (
+    LanguageNotSupportedException,
+    TranslationNotFound,
+)
+
 from build_scripts.update_translations import (
     _protect_placeholders,
     _restore_placeholders,
+    _translate_once,
     _validate_placeholders,
+    translate_entry,
 )
+
+
+class FakeTranslator:
+    """Fails its first `failures` calls with `error`, then succeeds."""
+
+    def __init__(self, failures: int = 0, error: type[Exception] = TranslationNotFound):
+        self.calls = 0
+        self.failures = failures
+        self.error = error
+
+    def translate(self, text: str) -> str:
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise self.error("translator unavailable")
+        return f"translated {text}"
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Skip the rate-limit and retry delays so the suite stays fast."""
+    monkeypatch.setattr("build_scripts.update_translations.time.sleep", lambda _: None)
 
 
 class TestProtectPlaceholders:
@@ -182,3 +211,42 @@ class TestBraceTokens:
     def test_uppercase_word_is_not_a_token(self):
         """ENTIRE is emphasis, not a placeholder, so the translator should see it."""
         assert _protect_placeholders("clear the ENTIRE queue")[1] == []
+
+
+class TestTranslateOnce:
+    def test_succeeds_first_try(self):
+        translator = FakeTranslator()
+        assert _translate_once("hello", translator) == "translated hello"
+        assert translator.calls == 1
+
+    def test_retries_transient_error(self):
+        translator = FakeTranslator(failures=1)
+        assert _translate_once("hello", translator) == "translated hello"
+        assert translator.calls == 2
+
+    def test_gives_up_after_one_retry(self):
+        translator = FakeTranslator(failures=2)
+        with pytest.raises(TranslationNotFound):
+            _translate_once("hello", translator)
+        assert translator.calls == 2
+
+    def test_permanent_error_is_not_retried(self):
+        translator = FakeTranslator(failures=1, error=LanguageNotSupportedException)
+        with pytest.raises(LanguageNotSupportedException):
+            _translate_once("hello", translator)
+        assert translator.calls == 1
+
+
+class TestTranslateEntry:
+    def test_recovers_from_transient_error(self):
+        entry = polib.POEntry(msgid="Session {number}")
+        assert translate_entry(entry, FakeTranslator(failures=1)) == "translated Session {number}"
+
+    def test_returns_none_when_translation_fails(self):
+        entry = polib.POEntry(msgid="Session {number}")
+        assert translate_entry(entry, FakeTranslator(failures=2)) is None
+
+    def test_skips_blank_msgid(self):
+        translator = FakeTranslator()
+        assert translate_entry(polib.POEntry(msgid="   "), translator) is None
+        assert translator.calls == 0

--- a/tests/unit/test_update_translations.py
+++ b/tests/unit/test_update_translations.py
@@ -159,3 +159,26 @@ class TestValidatePlaceholders:
         source = "Error renaming file: '%s' to '%s', %s"
         translated = "Fehler beim Umbenennen: '%s' nach '%s'"
         assert not _validate_placeholders(source, translated)
+
+
+class TestBraceTokens:
+    """Tokens the call site fills in with replace() must survive translation verbatim."""
+
+    def test_protected(self):
+        protected, tokens = _protect_placeholders("{start}-{end} of {total}")
+        assert tokens == ["{start}", "{end}", "{total}"]
+        assert protected == "<x0>-<x1> of <x2>"
+
+    def test_roundtrip(self):
+        text = "Current session: {name}"
+        assert _restore_placeholders(*_protect_placeholders(text)) == text
+
+    def test_translated_token_rejected(self):
+        assert not _validate_placeholders("{start}-{end} of {total}", "ANFANG-ENDE von GESAMT")
+
+    def test_preserved_token_accepted(self):
+        assert _validate_placeholders("{start}-{end} of {total}", "{start}-{end} von {total}")
+
+    def test_uppercase_word_is_not_a_token(self):
+        """ENTIRE is emphasis, not a placeholder, so the translator should see it."""
+        assert _protect_placeholders("clear the ENTIRE queue")[1] == []


### PR DESCRIPTION
Updates the translation catalogs for all the UI merged since the last release — sessions, play history, rankings, folder browsing, microphone settings and the rename dialog. This is the PR that ties those recent PRs together, so a release can go out.

The catalog grows from 253 to 355 strings across 15 locales.

Two fixes to the translation workflow came out of the run:

- **Braced placeholders.** Tokens substituted into translated strings were bare words like `SESSION` and `TOTAL`. Google Translate translates those along with the sentence, which silently breaks the `replace()` that fills them in. They are now `{session}` and `{total}`, which the extractor protects automatically, and a test keeps new tokens braced.
- **Retry on transient failures.** Roughly one request in twenty came back empty, leaving a string in English in a single locale. One retry took the failure rate to zero.
