### PR TITLE
fix: session times display in UTC under docker

### DIFF
--- a/build_scripts/docker/Dockerfile
+++ b/build_scripts/docker/Dockerfile
@@ -10,7 +10,8 @@ ENV UV_BREAK_SYSTEM_PACKAGES=1
 # Copy static ffmpeg binaries. 7.0 is a bit old, but significantly smaller while supporting librubberband
 COPY --from=mwader/static-ffmpeg:7.0 /ffprobe /ffmpeg /usr/local/bin/
 
-RUN apk add --no-cache python3 deno curl
+# tzdata: without the zoneinfo files, musl ignores a TZ zone name and stays on UTC
+RUN apk add --no-cache python3 deno curl tzdata
 
 # Copy dependency and metadata files first for better caching
 COPY pyproject.toml uv.lock ./

--- a/build_scripts/docker/docker-compose.yml.example
+++ b/build_scripts/docker/docker-compose.yml.example
@@ -21,6 +21,12 @@ services:
     command: >
       -u http://<YOUR_LAN_IP>:5555
 
+    # --- TIMEZONE ---
+    # Set this to your own zone, from the "TZ identifier" column of
+    # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    environment:
+      - TZ=Europe/London
+
     # --- VOLUMES ---
     # The <local_directory>:<container_directory> format is used.
     # You should only need to change <local_directory>

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,11 +108,14 @@ Run PiKaraoke in Docker using the command below. Note the requirements for port 
 
 ```sh
 docker run -p 5555:5555 \
+  -e TZ=Europe/London \
   -v ~/pikaraoke-songs:/app/pikaraoke-songs \
   -v ~/.pikaraoke:/home/pikaraoke/.pikaraoke \
   vicwomg/pikaraoke:latest \
   -u http://<YOUR_LAN_IP>:5555
 ```
+
+Set `TZ` to your own timezone, taken from the "TZ identifier" column of the [tz database list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 For more information and a configurable docker-compose example, [see official Dockerhub repo](https://hub.docker.com/r/vicwomg/pikaraoke)
 


### PR DESCRIPTION
I promise this is the last one!!

Session and play times showed UTC in the Docker image rather than local time.

Timestamps are stored UTC and converted on read by SQLite's `localtime` modifier, which follows the *container's* timezone — and the container had none set, so it stayed on UTC. Setting `TZ` alone would not have been enough either: the image is Alpine, and musl resolves zone names from `/usr/share/zoneinfo`, silently falling back to UTC when the `tzdata` package is missing.

Both halves are needed:

- `tzdata` added to the Dockerfile's `apk add`
- `TZ` set in the docker-compose example and in the `docker run` example in the README, with a pointer to the tz database list

Stored rows are unaffected, so sessions recorded before this change render at the right hour once the container has a timezone. No backfill.

## Test plan

- [x] Build the image and run with `TZ=Europe/London`; `docker compose exec pikaraoke date` reports local time, not UTC
- [x] Sing a song, then check the Sessions and Play History pages show the current wall-clock time
- [x] Restart with `TZ` unset; times fall back to UTC, confirming the variable is what does the work
- [x] Confirm sessions recorded before the fix now display at the correct hour
