### PR TITLE
fix: queue a song once from the rankings page

### DIFF
--- a/pikaraoke/templates/rankings.html
+++ b/pikaraoke/templates/rankings.html
@@ -14,18 +14,8 @@
 		window.location.href = "{{ url_for('sessions.rankings') }}?" + params;
 	}
 
-	$(function () {
-		// The same endpoint and response shape the browse page uses: the href
-		// already carries the song and ends at "user=", which is resolved at click
-		// time rather than rendered, since it comes from this device's cookie.
-		$(".add-song-link").on("click", function (e) {
-			e.preventDefault();
-			$.get(this.href + encodeURIComponent(resolveSinger()), function (data) {
-				var result = JSON.parse(data).success;
-				showNotification(result[1], result[0] ? "is-success" : "is-danger");
-			});
-		});
-	});
+	// The add links need no handler here: base.html delegates add-song-link
+	// clicks from the document, and a second binding would queue the song twice.
 </script>
 {% endblock %}
 


### PR DESCRIPTION
Found while investigating #877, which turned out to be a Greasemonkey userscript on the reporter's machine rather than a PiKaraoke bug. The double-add below is a separate defect that reproduces with no extension involved.

The rankings page bound its own click handler to `.add-song-link`, on top of the delegated handler `base.html` already binds on the document for every page that renders those links. One click therefore fired both, sending two `GET /queue/enqueue` requests for the same song: the first added it, the second answered `Song is already in the queue: <title>`. Both responses write the same toast element, and the red one arrives last, so that is the message left on screen.

Removed the page's handler and left a note saying where the binding lives. The search page carries the same note already, and the browse page renders only the delegated handler.

Verified in a browser against both versions of the page: one click sends two `/queue/enqueue` requests before this change and one after. The Songs and Add New pages send one per click either way, including across SPA navigation between them.

## Test plan

- [x] Rankings page: click the `+` beside a song not in the queue. One green `<name> added to the queue: <title>` toast, no red one, and one row added to the queue.
- [x] Click the same `+` again. The red `Song is already in the queue: <title>` toast appears, and the queue still holds one row.
- [x] The `Show N` selectors above each chart still reload the page with the chosen row counts, and keep the other selector's value.
- [x] Songs and Add New pages: adding a song still shows the green toast.


