### PR TITLE
fix: queue songs with a POST rather than a GET link

### DIFF
--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -24,7 +24,9 @@
       cookiePath: "{{ cookie_path }}",
       socketioPath: "{{ socketio_path }}",
       // Empty on the chromeless splash page, which has no singer field.
-      singersUrl: "{% if not blank_page %}{{ url_for('sessions_api.get_singers') }}{% endif %}"
+      singersUrl: "{% if not blank_page %}{{ url_for('sessions_api.get_singers') }}{% endif %}",
+      // Likewise: the splash page renders no add links.
+      enqueueUrl: "{% if not blank_page %}{{ url_for('queue.enqueue_form') }}{% endif %}"
     };
     // Translations for JS (static JS cannot use Jinja2 directly).
     // Gettext output is Markup, so Jinja never autoescapes it. Inside a <script> a
@@ -278,7 +280,18 @@
       $(document).off("click", "a.add-song-link");
       $(document).on("click", "a.add-song-link", function (e) {
         e.preventDefault();
-        $.get(this.href + encodeURIComponent(resolveSinger()), function (data) {
+        // The song rides in data-song and goes back as a POST. A link that
+        // queues a song on GET is queued by anything that fetches it without a
+        // click -- a prefetcher, a link preview, a proxy retry, a userscript.
+        // The attribute holds the percent-encoded path the href used to carry,
+        // and the body is assembled by hand to pass it through untouched: a
+        // filename that is not valid UTF-8 cannot survive a decode here.
+        var body =
+          "song_to_add=" +
+          this.getAttribute("data-song") +
+          "&song_added_by=" +
+          encodeURIComponent(resolveSinger());
+        $.post(window.pikaraokeConfig.enqueueUrl, body, function (data) {
           var obj = JSON.parse(data);
           // {# MSG: Notification shown after trying to add a song to the queue. The song name comes after this string. #}
           showNotification(obj.success[1], obj.success[0] ? "is-success" : "is-danger");

--- a/pikaraoke/templates/history.html
+++ b/pikaraoke/templates/history.html
@@ -217,7 +217,7 @@
 	function addToQueue(path) {
 		// The same endpoint and response shape the browse page uses: `success` is
 		// [ok, message], the message being what to show either way.
-		$.get("{{ url_for('queue.enqueue') }}", { song: path, user: resolveSinger() }, function (data) {
+		$.post("{{ url_for('queue.enqueue_form') }}", { song_to_add: path, song_added_by: resolveSinger() }, function (data) {
 			var result = JSON.parse(data).success;
 			showNotification(result[1], result[0] ? "is-success" : "is-danger");
 		});

--- a/pikaraoke/templates/partials/browse_results.html
+++ b/pikaraoke/templates/partials/browse_results.html
@@ -15,7 +15,8 @@
 			<a
 				class="add-song-link has-text-weight-bold has-text-success"
 				title="Add '{{display_name}}' to queue"
-				href="{{url_for('queue.enqueue')}}?song={{url_escape(song.encode('utf-8','surrogateescape'))}}&user="
+				href="#"
+				data-song="{{url_escape(song.encode('utf-8','surrogateescape'))}}"
 				><i class="icon icon-list-add"></i>
 			</a>
 		</td>

--- a/pikaraoke/templates/rankings.html
+++ b/pikaraoke/templates/rankings.html
@@ -139,7 +139,8 @@
 				   the title, and .icon is a 1.5rem flex box that would ride above it. #}
 				<a class="add-song-link has-text-success"
 					title="{{ _('Add to queue') | forceescape }}"
-					href="{{ url_for('queue.enqueue') }}?song={{ url_escape(song.file_path.encode('utf-8','surrogateescape')) }}&user="
+					href="#"
+					data-song="{{ url_escape(song.file_path.encode('utf-8','surrogateescape')) }}"
 					><i class="icon-list-add"></i
 				></a>
 				{% endif %}

--- a/pikaraoke/templates/rankings.html
+++ b/pikaraoke/templates/rankings.html
@@ -14,18 +14,8 @@
 		window.location.href = "{{ url_for('sessions.rankings') }}?" + params;
 	}
 
-	$(function () {
-		// The same endpoint and response shape the browse page uses: the href
-		// already carries the song and ends at "user=", which is resolved at click
-		// time rather than rendered, since it comes from this device's cookie.
-		$(".add-song-link").on("click", function (e) {
-			e.preventDefault();
-			$.get(this.href + encodeURIComponent(resolveSinger()), function (data) {
-				var result = JSON.parse(data).success;
-				showNotification(result[1], result[0] ? "is-success" : "is-danger");
-			});
-		});
-	});
+	// The add links need no handler here: base.html delegates add-song-link
+	// clicks from the document, and a second binding would queue the song twice.
 </script>
 {% endblock %}
 

--- a/pikaraoke/templates/search.html
+++ b/pikaraoke/templates/search.html
@@ -361,11 +361,10 @@
 
 		// Rewrites a row into the state the server renders for a song it already
 		// holds. The anchor needs no binding of its own: base.html delegates
-		// add-song-link clicks from the document.
+		// add-song-link clicks from the document and reads the path from data-song.
 		function showInLibrary($row, path) {
-			const href = "{{ url_for('queue.enqueue') }}?song=" + encodeURIComponent(path) + "&user=";
 			$row.find(".search_result_items_actions").html(
-				'<a class="button is-info add-song-link" href="' + href + '">' +
+				'<a class="button is-info add-song-link" href="#" data-song="' + encodeURIComponent(path) + '">' +
 					'<span class="icon"><i class="icon-list-add"></i></span>' +
 					// {# MSG: Button which adds an already-downloaded song to the queue. #}
 					'<span>{{ _("Add to queue") | forceescape }}</span>' +
@@ -640,7 +639,8 @@
 						{# Already downloaded, so queue it rather than fetching a second copy. #}
 						<a
 							class="button is-info add-song-link"
-							href="{{url_for('queue.enqueue')}}?song={{url_escape(local_path.encode('utf-8','surrogateescape'))}}&user="
+							href="#"
+							data-song="{{url_escape(local_path.encode('utf-8','surrogateescape'))}}"
 						>
 							<span class="icon"><i class="icon-list-add"></i></span>
 							{# MSG: Button which adds an already-downloaded song to the queue. #}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ _BASE_TEMPLATE_ENDPOINTS = [
     ("/history", "sessions.history"),
     ("/sessions", "sessions.sessions"),
     ("/api/sessions/singers", "sessions_api.get_singers"),
+    ("/enqueue", "queue.enqueue_form"),
 ]
 
 

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -27,7 +27,6 @@ def app():
         [
             ("/", "home.home"),
             ("/queue", "queue.queue"),
-            ("/queue/enqueue", "queue.enqueue"),
             ("/search", "search.search"),
             ("/info", "info.info"),
             ("/batch", "batch_song_renamer.browse"),

--- a/tests/unit/test_search_routes.py
+++ b/tests/unit/test_search_routes.py
@@ -30,7 +30,6 @@ def app():
         [
             ("/", "home.home"),
             ("/queue", "queue.queue"),
-            ("/queue/enqueue", "queue.enqueue"),
             ("/browse", "files.browse"),
             ("/info", "info.info"),
         ],
@@ -66,7 +65,9 @@ class TestAcquisitionOnly:
         body = response.data.decode()
         assert response.status_code == 200
         assert "selectize" not in body
-        assert "song_to_add" not in body
+        # The removed dropdown was the only element naming this field; the shared
+        # queueing script in base.html posts it, so the bare name now matches that.
+        assert 'id="song_to_add"' not in body
         assert "search_string_input" in body
 
     def test_autocomplete_endpoint_is_gone(self, client):


### PR DESCRIPTION
Supersedes #878, whose commit is included here as the first of the two.

## Queue a song once from the rankings page

The rankings page bound its own click handler to `.add-song-link`, on top of the delegated handler `base.html` already binds on the document for every page that renders those links. One click fired both, sending two requests for the same song: the first added it, the second answered `Song is already in the queue: <title>`, and since both write the same toast element the red one is what stays on screen.

## Queue with a POST rather than a GET link

The add controls carried the entire request in an `href`, so anything that fetched the link without a click queued the song — a prefetcher, a macOS link preview, a proxy retry, or a browser extension. The click that followed then reported the song as already queued. That is what #877 turned out to be: a Greasemonkey userscript on the reporter's machine, fetching the links it found.

The song now rides in `data-song` and the shared handler posts it to `enqueue_form`, the endpoint the search page has always used. No route or schema changes: both verbs already share `_do_enqueue` and return identical JSON.

The attribute keeps the same percent-encoded path the href carried, and the request body is assembled by hand rather than by jQuery so that value reaches the server byte for byte. That is deliberate — a filename that is not valid UTF-8 cannot survive `decodeURIComponent`, and encoding it afresh would double-encode it. The server therefore sees exactly the string the query parameter used to deliver.

The GET route stays for the documented API.

## Verification

Driven in a real browser against every page that renders these links, counting requests per click:

| Page | Requests per click | Method |
| --- | --- | --- |
| Songs | 1 | POST |
| Rankings (before the first commit) | 2 | GET |
| Rankings (after) | 1 | POST |
| Songs -> Rankings -> Songs by SPA navigation | 1 each | POST |

And the case this is all for: a script that fetches every `a.add-song-link` href on the Songs page now issues **zero** enqueue requests and leaves the queue empty. Previously it queued every song on the page.

