### PR TITLE
chore: update translations

### DIFF
--- a/pikaraoke/messages.pot
+++ b/pikaraoke/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,14 +19,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr ""
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr ""
@@ -116,33 +116,33 @@ msgstr ""
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr ""
 
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr ""
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr ""
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr ""
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr ""
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr ""
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr ""
 
@@ -255,7 +255,7 @@ msgstr ""
 
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr ""
 
@@ -435,7 +435,7 @@ msgstr ""
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgstr ""
 
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will"
@@ -525,43 +525,43 @@ msgid ""
 msgstr ""
 
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 
 #. Confirmation dialog when removing a song from the queue. {title} is replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr ""
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr ""
 
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr ""
 
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr ""
 
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr ""
 
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used"
 " in classical Western music, equal to a twelfth of an octave or half a "
@@ -570,20 +570,20 @@ msgstr ""
 
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
 
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr ""
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -591,40 +591,40 @@ msgstr ""
 
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr ""
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr ""
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr ""
 
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr ""
 
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr ""
 
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr ""
 
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr ""
 
@@ -727,50 +727,50 @@ msgid "Delete this song"
 msgstr ""
 
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr ""
 
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr ""
 
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr ""
 
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr ""
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr ""
 
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr ""
 
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr ""
 
 #. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr ""
 
 #. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr ""
 
@@ -825,9 +825,9 @@ msgstr ""
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr ""
 
@@ -1507,6 +1507,23 @@ msgstr ""
 msgid "All sessions"
 msgstr ""
 
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr ""
+
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr ""
+
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr ""
+
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr ""
@@ -1606,89 +1623,89 @@ msgid "Download queue"
 msgstr ""
 
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr ""
 
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr ""
 
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr ""
 
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr ""
 
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr ""
 
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr ""
 
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr ""
 
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr ""
 
 #. Subtitle under the Add New heading, explaining that this page gets songs the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr ""
 
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr ""
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr ""
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr ""
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr ""
 
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr ""
 
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr ""
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1696,14 +1713,14 @@ msgid ""
 msgstr ""
 
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 msgstr ""
 
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to"
 " watch it."

--- a/pikaraoke/translations/de_DE/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/de_DE/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-13 22:53-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: de_DE <LL@li.org>\n"
@@ -20,14 +20,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponieren um %s Halbtöne: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Lautstärke: %s"
@@ -122,34 +122,34 @@ msgstr ""
 "Etwas ist schiefgelaufen! Die Einstellungen wurden nicht zurückgesetzt"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Song befindet sich bereits in der Warteschlange: %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr ""
 "Das Limit von %s Lied(er) per Benutzer in der Warteschlange ist erreicht!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s wurde an die Spitze der Warteschlange hinzugefügt: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s wurde der Warteschlange hinzugefügt: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Lied wurde der Warteschlange hinzugefügt: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Warteschlange leeren"
 
@@ -271,7 +271,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Lieder"
 
@@ -435,7 +435,7 @@ msgstr "Fehler beim Entfernen aus der Warteschlange"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Neu hinzufügen"
 
@@ -480,7 +480,7 @@ msgstr "Gespielt bei"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Künstler"
 
@@ -489,7 +489,7 @@ msgstr "Künstler"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Lied"
 
@@ -566,7 +566,7 @@ msgstr "Untertitel konnte nicht gestreamt werden:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -577,7 +577,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Sind Sie sicher, dass Sie die GESAMTE Warteschlange löschen möchten? Geben "
@@ -587,21 +587,21 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr ""
 "Sind Sie sicher, dass Sie {title} aus der Warteschlange löschen möchten?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Dieses Lied wirklich aus der Bibliothek löschen?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} Halbtöne"
@@ -609,20 +609,20 @@ msgstr "{value} Halbtöne"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Dieses Lied transponieren: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Möchten Sie diesen Titel wirklich neu starten?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -634,7 +634,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -644,13 +644,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Fehler"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -661,44 +661,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Aktuelle Sitzung: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Startseite"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Warteschlange"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Ranglisten"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Spielverlauf"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Sitzungen"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -822,59 +822,59 @@ msgstr "Dieses Lied löschen"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Massenumbenennung"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Verfügbar in der Bibliothek"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Alle Ordner"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Suche nach Titel, Künstler..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Löschen"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Alle Lieder"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Ordner"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Alphabetisch sortieren"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Nach Datum sortieren"
 
@@ -887,7 +887,7 @@ msgstr "Diesen Eintrag aus dem Spielprotokoll löschen?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Es wurde noch nichts gespielt."
 
@@ -938,9 +938,9 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Zur Warteschlange hinzufügen"
 
@@ -1736,6 +1736,26 @@ msgid "All sessions"
 msgstr "Alle Sitzungen"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Warteschlange für Sänger"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Name des Sängers"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Starten Sie eine Sitzung, um sich für Sänger anzumelden"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Ausstehende Downloads"
@@ -1858,51 +1878,51 @@ msgstr "Download-Warteschlange"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Zeigen"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Rang"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Spielt"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Top-Songs"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Top-Performer"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Bisher hat niemand gesungen."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Hinzufügen..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "In der Bibliothek"
 
@@ -1910,49 +1930,49 @@ msgstr "In der Bibliothek"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Fügen Sie neue Songs von YouTube hinzu"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Durchsuchen Sie YouTube nach Titel, Künstler ..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Suche"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Nicht-Karaoke-Treffer einbeziehen"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Erweitert"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Fügen Sie eine YouTube-URL ein:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Für später speichern"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1961,7 +1981,7 @@ msgstr "Suche auf Youtube nach <small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1971,7 +1991,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/es_VE/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/es_VE/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: frederick.chang@hotmail.com\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-07-19 03:30-0400\n"
 "Last-Translator: FREDERICK CHANG <frederick.chang@hotmail.com>\n"
 "Language-Team: \n"
@@ -20,14 +20,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Cambiando a %s semitonos: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volumen: %s"
@@ -121,33 +121,33 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Algo ha ocurrido. Tus preferencias no se han borrado"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "La canción ya está en la cola: %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Haz alcanzado el limite de %s canción(es) de un usuario en cola!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s añadido al principio de la cola: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s agregada a la cola: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Canción agregada a la cola: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Borrar cola"
 
@@ -267,7 +267,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Canciones"
 
@@ -431,7 +431,7 @@ msgstr "Error al eliminar de la cola"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Agregar nuevo"
 
@@ -476,7 +476,7 @@ msgstr "Jugado en"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Ejecutante"
 
@@ -485,7 +485,7 @@ msgstr "Ejecutante"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Canción"
 
@@ -562,7 +562,7 @@ msgstr "No se pudo transmitir el subtítulo:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -573,7 +573,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "¿Está seguro de que desea borrar TODA la cola? Escribe ok para continuar"
@@ -582,20 +582,20 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "¿Está seguro de que desea eliminar {title} de la cola?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Estas seguro que quieres eliminar esta canción de la librería?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} semitonos"
@@ -603,20 +603,20 @@ msgstr "{value} semitonos"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponer esta canción: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "¿Estás seguro de que quieres reiniciar esta pista?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -628,7 +628,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -638,13 +638,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Error"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -655,44 +655,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sesión actual: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Inicio"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Lista de Espera o Cola"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Clasificaciones"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Historial de juego"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Sesiones"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Ajustes"
 
@@ -815,59 +815,59 @@ msgstr "Borrar esta canción"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "cambio de nombre masivo"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Disponible en la biblioteca"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Todas las carpetas"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Buscar por título, artista..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Borrar"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Todas las canciones"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Carpetas"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Ordenar alfabéticamente"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Ordenar por fecha"
 
@@ -880,7 +880,7 @@ msgstr "¿Eliminar esta entrada del registro de reproducción?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Aún no se ha jugado nada."
 
@@ -931,9 +931,9 @@ msgstr "Estado"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Añadir a la cola"
 
@@ -1724,6 +1724,26 @@ msgid "All sessions"
 msgstr "Todas las sesiones"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Cola para cantante"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "nombre del cantante"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Iniciar una sesión para hacer cola para cantantes."
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Descargas pendientes"
@@ -1846,51 +1866,51 @@ msgstr "Cola de descarga"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Espectáculo"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Rango"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "juega"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Canciones más populares"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Mejores artistas"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Nadie ha cantado todavía."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Añadiendo..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "en la biblioteca"
 
@@ -1898,49 +1918,49 @@ msgstr "en la biblioteca"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Agregar nuevas canciones de YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Busca en YouTube por título, artista..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Buscador"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Incluir videos que no sean de karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Avanzado"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Pega una URL de YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Guardar para más tarde"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1951,7 +1971,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1961,7 +1981,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/fi_FI/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/fi_FI/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: minna.soudunsaari@gmail.com\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2024-05-08 18:57-0300\n"
 "Last-Translator: FULL NAME <minna.soudunsaari@gmail.com>\n"
 "Language-Team: fi_FI <LL@li.org>\n"
@@ -21,14 +21,14 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponoidaan %s puolisävelellä: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Ääni kovemmalle: %s"
@@ -132,35 +132,35 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Jotain meni pieleen! Asetuksiasi ei tyhjennetty"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Kappale on jo jonossa: %s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Saavutit %s kappaleen enimmäismäärän jonossa olevalta käyttäjältä!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s Jonoon lisätty kappale: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s Jonoon lisätty kappale: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Jonoon lisätty kappale: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Tyhjennä jono"
 
@@ -293,7 +293,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Songs"
 
@@ -468,7 +468,7 @@ msgstr "Virhe poistettaessa jonosta"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Lisää Uusi"
 
@@ -513,7 +513,7 @@ msgstr "Pelasi klo"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Esiintyjä"
 
@@ -522,7 +522,7 @@ msgstr "Esiintyjä"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Song"
 
@@ -614,7 +614,7 @@ msgstr "Tekstityksen suoratoisto epäonnistui:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -625,7 +625,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Haluatko varmasti tyhjentää KOKO jonon? Kirjoita ok jatkaaksesi"
 
@@ -633,20 +633,20 @@ msgstr "Haluatko varmasti tyhjentää KOKO jonon? Kirjoita ok jatkaaksesi"
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Haluatko varmasti poistaa kohteen {title} jonosta?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Oletko varma että haluat poistaa tämän kappaleen karaokelaitteelta?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} puolisävelet"
@@ -654,20 +654,20 @@ msgstr "{value} puolisävelet"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponoi tämä kappale: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Oletko varma, että haluat aloittaa tämän kappaleen uudelleen?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -679,7 +679,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -689,13 +689,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Virhe"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -706,44 +706,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Nykyinen istunto: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Kotisivu"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Jono"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Rankingit"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Pelihistoria"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Istunnot"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Asetukset"
 
@@ -867,59 +867,59 @@ msgstr "Poista tämä kappale"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Joukkonimeä uudelleen"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Saatavilla kirjastossa"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Kaikki kansiot"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Hae nimen, esittäjän mukaan..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Tyhjennä"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Kaikki kappaleet"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Kansiot"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Lajittele aakkosjärjestyksessä"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Lajittele päivämäärän mukaan"
 
@@ -932,7 +932,7 @@ msgstr "Poistetaanko tämä merkintä soittolokista?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Mitään ei ole vielä pelattu."
 
@@ -983,9 +983,9 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Lisää Jonoon"
 
@@ -1799,6 +1799,26 @@ msgid "All sessions"
 msgstr "Kaikki istunnot"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Jono laulajalle"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Laulajan nimi"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Aloita istunto asettaaksesi jonoon laulajia"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Odottavat lataukset"
@@ -1922,51 +1942,51 @@ msgstr "Latausjono"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Show"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Sijoitus"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Toistetaan"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Huippukappaleita"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Huippusuorittajat"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Kukaan ei ole vielä laulanut."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Lisätään..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "Kirjastossa"
 
@@ -1974,49 +1994,49 @@ msgstr "Kirjastossa"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Lisää uusia kappaleita YouTubesta"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Hae YouTubesta nimen, esittäjän mukaan..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Etsi"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Sisällytä myös ei-karaoke versiot."
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Tarkemmat hakuvaihtoehdot"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Liitä YouTube-URL-osoite:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Säästä myöhempää käyttöä varten"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2025,7 +2045,7 @@ msgstr "Etsi Youtubesta <small><i>’%(search_term)s’</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2035,7 +2055,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/fr_FR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-13 22:52-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: fr_FR <LL@li.org>\n"
@@ -20,14 +20,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transposition par %s demi-tons : %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume : %s"
@@ -121,35 +121,35 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Il y a eu un problème ! Vos préférences n'ont pas été effacées"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "La chanson est déjà dans la file d'attente : %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr ""
 "Vous avez atteint la limite de %s chanson(s) par utilisateur dans la file "
 "d'attente !"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s ajouté au sommet de la file d'attente : %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s ajouté à la file d'attente : %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Chanson ajoutée à la file d'attente : %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Effacer la file d'attente"
 
@@ -274,7 +274,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Chansons"
 
@@ -438,7 +438,7 @@ msgstr "Erreur lors de la suppression de la file d'attente"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Ajouter un nouveau"
 
@@ -483,7 +483,7 @@ msgstr "Joué à"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Interprète"
 
@@ -492,7 +492,7 @@ msgstr "Interprète"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Chanson"
 
@@ -569,7 +569,7 @@ msgstr "Échec de la diffusion du sous-titre :"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -580,7 +580,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Êtes-vous sûr de vouloir effacer la file d'attente ENTIÈRE ? Tapez ok pour "
@@ -590,20 +590,20 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Êtes-vous sûr de vouloir supprimer {title} de la file d'attente ?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette chanson de la bibliothèque ?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} demi-tons"
@@ -611,20 +611,20 @@ msgstr "{value} demi-tons"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transposer cette chanson : {label} ?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Êtes-vous sûr de vouloir redémarrer cette piste ?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -636,7 +636,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -646,13 +646,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Erreur"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -663,44 +663,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Session en cours : {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Accueil"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "File d'attente"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Classements"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Historique de lecture"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Séances"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Paramètres"
 
@@ -825,59 +825,59 @@ msgstr "Supprimer cette musique"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Renommer en masse"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Disponible à la bibliothèque"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Tous les dossiers"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Recherche par titre, artiste..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Effacer"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Toutes les chansons"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Dossiers"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Trier par ordre alphabétique"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Trier par date"
 
@@ -890,7 +890,7 @@ msgstr "Supprimer cette entrée du journal de lecture ?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Rien n'a encore été joué."
 
@@ -941,9 +941,9 @@ msgstr "Statut"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Ajouter à la file d'attente"
 
@@ -1738,6 +1738,26 @@ msgid "All sessions"
 msgstr "Toutes les séances"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "File d'attente pour le chanteur"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Nom du chanteur"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Démarrer une session pour faire la queue pour les chanteurs"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Téléchargements en attente"
@@ -1860,51 +1880,51 @@ msgstr "File d'attente de téléchargement"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Montrer"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Rang"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Pièces"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Meilleures chansons"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Les plus performants"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Personne n'a encore chanté."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Ajout..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "En bibliothèque"
 
@@ -1912,49 +1932,49 @@ msgstr "En bibliothèque"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Ajouter de nouvelles chansons de YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Recherchez YouTube par titre, artiste..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Recherche"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Inclure les résultats non-karaoké"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Avancés"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Collez une URL YouTube :"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Enregistrer pour plus tard"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1965,7 +1985,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1975,7 +1995,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/id_ID/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/id_ID/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2026-02-13 11:48+0700\n"
 "Last-Translator: birudanoranye@gmail.com\n"
 "Language-Team: Indonesian <LL@li.org>\n"
@@ -19,14 +19,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Menggeser nada %s setengah nada: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
@@ -120,33 +120,33 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Terjadi kesalahan! Pengaturan tidak berhasil dihapus"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Lagu sudah ada dalam antrian: %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Anda sudah mencapai batas %s lagu per pengguna dalam antrian!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s ditambahkan ke posisi teratas antrian: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s ditambahkan ke antrian: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Lagu berhasil ditambahkan ke antrian: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Kosongkan antrian"
 
@@ -261,7 +261,7 @@ msgstr "Gagal mengganti nama: '%s' → '%s', nama file sudah ada"
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Lagu"
 
@@ -422,7 +422,7 @@ msgstr "Gagal menghapus dari antrian"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Tambahkan Baru"
 
@@ -467,7 +467,7 @@ msgstr "Dimainkan Pada"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Pemain"
 
@@ -476,7 +476,7 @@ msgstr "Pemain"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Lagu"
 
@@ -552,7 +552,7 @@ msgstr "Gagal memutar subtitle: "
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -562,7 +562,7 @@ msgstr ""
 "akan muncul pada lagu yang antri. Saat ini: {name}"
 
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Yakin ingin mengosongkan SELURUH antrian? Ketik ok untuk melanjutkan"
 
@@ -570,20 +570,20 @@ msgstr "Yakin ingin mengosongkan SELURUH antrian? Ketik ok untuk melanjutkan"
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Apakah Anda yakin ingin menghapus {title} dari antrean?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Yakin ingin menghapus lagu ini dari pustaka?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} seminada"
@@ -591,20 +591,20 @@ msgstr "{value} seminada"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Ubah urutan lagu ini: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Apakah Anda yakin ingin memulai ulang trek ini?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -616,7 +616,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -626,13 +626,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Kesalahan"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -643,44 +643,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sesi saat ini: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Beranda"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Antrian"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Peringkat"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Mainkan Sejarah"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Sesi"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Pengaturan"
 
@@ -801,59 +801,59 @@ msgstr "Hapus lagu ini"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Ganti nama secara massal"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Tersedia di perpustakaan"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Semua folder"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Cari berdasarkan judul, artis..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Hapus"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Semua lagu"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Folder"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Urutkan Berdasarkan Abjad"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Urutkan berdasarkan Tanggal"
 
@@ -866,7 +866,7 @@ msgstr "Hapus entri ini dari log pemutaran?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Belum ada yang dimainkan."
 
@@ -916,9 +916,9 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Tambah ke antrian"
 
@@ -1684,6 +1684,26 @@ msgstr "Per halaman"
 msgid "All sessions"
 msgstr "Semua sesi"
 
+# auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Antrian untuk penyanyi"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Nama penyanyinya"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Mulailah sesi untuk mengantri penyanyi"
+
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Download tertunda"
@@ -1790,51 +1810,51 @@ msgstr "Antrian download"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Menunjukkan"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Pangkat"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Dimainkan"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Lagu teratas"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Berkinerja terbaik"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Belum ada yang bernyanyi."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Menambahkan..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "Di perpustakaan"
 
@@ -1842,50 +1862,50 @@ msgstr "Di perpustakaan"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Tambahkan lagu baru dari YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Cari YouTube berdasarkan judul, artis..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Cari"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Sertakan hasil yang bukan versi karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Lanjutan"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Tempelkan url YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Simpan untuk nanti"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1896,7 +1916,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1906,7 +1926,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/it_IT/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/it_IT/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2024-10-30 14:44-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: it_IT <LL@li.org>\n"
@@ -20,14 +20,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Trasposizione di %s semitoni: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
@@ -121,33 +121,33 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Qualcosa è andato storto! Le tue preferenze non sono state cancellate"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Il brano è già in coda: %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Hai raggiunto il limite di %s brani da un utente in coda!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s aggiunto in cima alla coda: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s aggiunto alla coda: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Brano aggiunto alla coda: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Coda ripulita"
 
@@ -269,7 +269,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Canzoni"
 
@@ -433,7 +433,7 @@ msgstr "Errore durante l'eliminazione dalla coda"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Aggiungi nuovo"
 
@@ -478,7 +478,7 @@ msgstr "Giocato a"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Esecutore"
 
@@ -487,7 +487,7 @@ msgstr "Esecutore"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Canzone"
 
@@ -564,7 +564,7 @@ msgstr "Impossibile eseguire lo streaming dei sottotitoli:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -575,7 +575,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Sei sicuro di voler cancellare l'INTERA coda? Digita ok per continuare"
@@ -584,20 +584,20 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Sei sicuro di voler eliminare {title} dalla coda?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Vuoi davvero eliminare questa canzone dalla libreria?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} semitoni"
@@ -605,20 +605,20 @@ msgstr "{value} semitoni"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Trasponi questa canzone: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Sei sicuro di voler riavviare questa traccia?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -630,7 +630,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -640,13 +640,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Errore"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -657,44 +657,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sessione corrente: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Home"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Coda"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Classifiche"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Gioca alla storia"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Sessioni"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -818,59 +818,59 @@ msgstr "Elimina questa canzone"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Rinominazione in blocco"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Disponibile in biblioteca"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Tutte le cartelle"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Cerca per titolo, artista..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Pulisci"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Tutte le canzoni"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Cartelle"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Ordina in ordine alfabetico"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Ordina per data"
 
@@ -883,7 +883,7 @@ msgstr "Eliminare questa voce dal registro di gioco?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Non è stato ancora giocato nulla."
 
@@ -934,9 +934,9 @@ msgstr "Stato"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Aggiungi alla coda"
 
@@ -1729,6 +1729,26 @@ msgid "All sessions"
 msgstr "Tutte le sessioni"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Coda per il cantante"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Nome del cantante"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Inizia una sessione per mettere in coda i cantanti"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Download in sospeso"
@@ -1851,51 +1871,51 @@ msgstr "Coda di download"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Spettacolo"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Rango"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Gioca"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Canzoni migliori"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Migliori interpreti"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Nessuno ha ancora cantato."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Aggiunta..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "In biblioteca"
 
@@ -1903,49 +1923,49 @@ msgstr "In biblioteca"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Aggiungi nuovi brani da YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Cerca su YouTube per titolo, artista..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Cerca"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Includi risultati non karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Avanzate"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Incolla un URL di YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Risparmia per dopo"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1956,7 +1976,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1966,7 +1986,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/ja_JP/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ja_JP/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-13 22:54-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: ja_JP <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "%s 半音ずつ移調します: %s"
@@ -29,7 +29,7 @@ msgstr "%s 半音ずつ移調します: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "ボリューム: %s"
@@ -137,38 +137,38 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "何か問題が発生しました!あなたの設定はクリアされませんでした"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "曲はすでにキューにあります: %s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "キュー内のユーザーからの %s 曲の制限に達しました!"
 
 # auto-translated
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s がキューの先頭に追加されました: %s"
 
 # auto-translated
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s がキューに追加されました: %s"
 
 # auto-translated
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "曲がキューに追加されました: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "キューをクリアする"
 
@@ -303,7 +303,7 @@ msgstr "ファイル名変更エラー: '%s' から '%s'、ファイル名はす
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "歌"
 
@@ -475,7 +475,7 @@ msgstr "キューから削除中にエラーが発生しました"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "新規追加"
 
@@ -520,7 +520,7 @@ msgstr "演奏場所"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "出演者"
 
@@ -529,7 +529,7 @@ msgstr "出演者"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "歌"
 
@@ -621,7 +621,7 @@ msgstr "字幕のストリーミングに失敗しました:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -630,7 +630,7 @@ msgstr "このデバイスを使用している人の名前を変更しますか
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "キュー全体をクリアしてもよろしいですか?続行するには「ok」と入力してください"
 
@@ -638,21 +638,21 @@ msgstr "キュー全体をクリアしてもよろしいですか?続行する�
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "{title} をキューから削除してもよろしいですか?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "この曲をライブラリから削除してもよろしいですか?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 半音"
@@ -660,20 +660,20 @@ msgstr "{value} 半音"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "この曲を移調します: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "このトラックを再開してもよろしいですか?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -682,7 +682,7 @@ msgstr "半音はハーフステップとも呼ばれます。これは西洋古
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -690,14 +690,14 @@ msgstr "ファイルシステムを拡張してもよろしいですか?これ�
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "エラー"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -706,46 +706,46 @@ msgstr "お名前を入力してください。これは、このデバイスか
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "現在のセッション: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "家"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "列"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "ランキング"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "プレイ履歴"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "セッション"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "設定"
 
@@ -872,60 +872,60 @@ msgstr "この曲を削除"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "名前の一括変更"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "図書館で利用可能"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "すべてのフォルダー"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "タイトルやアーティストで検索..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "クリア"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "全曲"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "フォルダー"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "アルファベット順に並べ替える"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "日付順に並べ替える"
 
@@ -938,7 +938,7 @@ msgstr "このエントリを再生ログから削除しますか?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "まだ何もプレイされていません。"
 
@@ -990,9 +990,9 @@ msgstr "状態"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "キューに追加"
 
@@ -1804,6 +1804,26 @@ msgid "All sessions"
 msgstr "すべてのセッション"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "歌手の行列"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "歌手の名前"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "セッションを開始して歌手の列に並びます"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "保留中のダウンロード"
@@ -1929,51 +1949,51 @@ msgstr "ダウンロードキュー"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "見せる"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "ランク"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "演劇"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "トップソング"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "トップパフォーマー"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "まだ誰も歌っていません。"
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "追加中..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "図書館内"
 
@@ -1981,19 +2001,19 @@ msgstr "図書館内"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "YouTube から新しい曲を追加する"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "タイトルやアーティストで YouTube を検索..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "検索"
 
@@ -2001,33 +2021,33 @@ msgstr "検索"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "カラオケ以外の試合も含める"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "高度な"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "YouTube の URL を貼り付けます:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "後で使うために保存しておきます"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2038,7 +2058,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2048,7 +2068,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/ko_KR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ko_KR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-13 22:55-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: ko_KR <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "%s 반음씩 조옮김: %s"
@@ -29,7 +29,7 @@ msgstr "%s 반음씩 조옮김: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "볼륨: %s"
@@ -137,38 +137,38 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "문제가 발생했습니다. 환경설정이 삭제되지 않았습니다."
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "노래가 이미 대기열에 있습니다: %s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "대기열에 있는 사용자의 노래 한도인 %s곡에 도달했습니다!"
 
 # auto-translated
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s이(가) 대기열 맨 위에 추가되었습니다: %s"
 
 # auto-translated
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s이(가) 대기열에 추가되었습니다: %s"
 
 # auto-translated
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "대기열에 추가된 노래: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "대기열 지우기"
 
@@ -303,7 +303,7 @@ msgstr "파일 이름을 바꾸는 중 오류 발생: '%s'을(를) '%s'(으)로 
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "노래"
 
@@ -475,7 +475,7 @@ msgstr "대기열에서 삭제하는 중에 오류가 발생했습니다."
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "새로 추가"
 
@@ -520,7 +520,7 @@ msgstr "플레이 시간"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "수행자"
 
@@ -529,7 +529,7 @@ msgstr "수행자"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "노래"
 
@@ -621,7 +621,7 @@ msgstr "자막 스트리밍 실패:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -630,7 +630,7 @@ msgstr "이 장치를 사용하는 사람의 이름을 변경하시겠습니까?
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "대기열 전체를 삭제하시겠습니까? 계속하려면 확인을 입력하세요."
 
@@ -638,21 +638,21 @@ msgstr "대기열 전체를 삭제하시겠습니까? 계속하려면 확인을 
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "대기열에서 {title}을(를) 삭제하시겠습니까?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "정말로 이 노래를 라이브러리에서 삭제하시겠습니까?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 반음"
@@ -660,20 +660,20 @@ msgstr "{value} 반음"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "이 노래를 조옮김하세요: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "이 트랙을 다시 시작하시겠습니까?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -682,7 +682,7 @@ msgstr "반음은 반음이라고도 합니다. 고전 서양 음악에서 사�
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -690,14 +690,14 @@ msgstr "파일 시스템을 확장하시겠습니까? 그러면 라즈베리 파
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "오류"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -706,46 +706,46 @@ msgstr "이름을 입력해주세요. 이 장치에서 대기열에 추가한 �
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "현재 세션: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "집"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "대기줄"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "순위"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "플레이 기록"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "세션"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "설정"
 
@@ -872,60 +872,60 @@ msgstr "이 노래 삭제"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "일괄 이름 바꾸기"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "도서관에서 이용 가능"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "모든 폴더"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "제목, 아티스트로 검색..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "분명한"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "모든 노래"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "폴더"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "알파벳순으로 정렬"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "날짜순으로 정렬"
 
@@ -938,7 +938,7 @@ msgstr "플레이 로그에서 이 항목을 삭제하시겠습니까?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "아직 재생된 항목이 없습니다."
 
@@ -990,9 +990,9 @@ msgstr "상태"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "대기열에 추가"
 
@@ -1804,6 +1804,26 @@ msgid "All sessions"
 msgstr "모든 세션"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "가수 대기열"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "가수의 이름"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "가수 대기열에 세션을 시작하세요"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "다운로드 대기 중"
@@ -1929,51 +1949,51 @@ msgstr "대기열 다운로드"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "보여주다"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "계급"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "연극"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "인기곡"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "최고 성과자"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "아직 노래를 부른 사람은 없습니다."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "첨가..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "도서관에서"
 
@@ -1981,19 +2001,19 @@ msgstr "도서관에서"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "YouTube에서 새 노래 추가"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "YouTube에서 제목, 아티스트 등으로 검색하세요."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "찾다"
 
@@ -2001,33 +2021,33 @@ msgstr "찾다"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "노래방이 아닌 경기 포함"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "고급의"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "YouTube URL 붙여넣기:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "나중을 위해 저장"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2038,7 +2058,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2048,7 +2068,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/nb_NO/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-14 10:27-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: nb_NO <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponering med %s halvtoner: %s"
@@ -29,7 +29,7 @@ msgstr "Transponering med %s halvtoner: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volum: %s"
@@ -137,38 +137,38 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Noe gikk galt! Preferansene dine ble ikke slettet"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Sangen er allerede i køen: %s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Du har nådd grensen på %s sang(er) fra en bruker i kø!"
 
 # auto-translated
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s lagt til øverst i køen: %s"
 
 # auto-translated
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s lagt til i køen: %s"
 
 # auto-translated
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Sang lagt til i køen: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Fjern kø"
 
@@ -305,7 +305,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Sanger"
 
@@ -481,7 +481,7 @@ msgstr "Feil ved sletting fra køen"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Legg til ny"
 
@@ -526,7 +526,7 @@ msgstr "Spilt kl"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Utøver"
 
@@ -535,7 +535,7 @@ msgstr "Utøver"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Sang"
 
@@ -627,7 +627,7 @@ msgstr "Kunne ikke strømme undertekst:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -638,7 +638,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Er du sikker på at du vil tømme HELE køen? Skriv ok for å fortsette"
 
@@ -646,21 +646,21 @@ msgstr "Er du sikker på at du vil tømme HELE køen? Skriv ok for å fortsette"
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Er du sikker på at du vil slette {title} fra køen?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Er du sikker på at du vil slette denne sangen fra biblioteket?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} halvtoner"
@@ -668,20 +668,20 @@ msgstr "{value} halvtoner"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponere denne sangen: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Er du sikker på at du vil starte dette sporet på nytt?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -693,7 +693,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -703,14 +703,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Feil"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -721,46 +721,46 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Gjeldende økt: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Hjem"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Kø"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Rangeringer"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Spillhistorikk"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Økter"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Innstillinger"
 
@@ -887,60 +887,60 @@ msgstr "Slett denne sangen"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Gi nytt navn"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Tilgjengelig på biblioteket"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Alle mapper"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Søk etter tittel, artist..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Klar"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Alle sanger"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Mapper"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Sorter alfabetisk"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Sorter etter dato"
 
@@ -953,7 +953,7 @@ msgstr "Vil du slette denne oppføringen fra spilleloggen?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Ingenting er spilt ennå."
 
@@ -1005,9 +1005,9 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Legg til i kø"
 
@@ -1849,6 +1849,26 @@ msgid "All sessions"
 msgstr "Alle økter"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Kø for sanger"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Navnet på sangeren"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Start en økt for å stå i kø for sangere"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Venter på nedlastinger"
@@ -1974,51 +1994,51 @@ msgstr "Last ned kø"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Vise"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Rang"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Spiller"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Topp sanger"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Topp utøvere"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Ingen har sunget ennå."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Legger til ..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "På biblioteket"
 
@@ -2026,19 +2046,19 @@ msgstr "På biblioteket"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Legg til nye sanger fra YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Søk på YouTube etter tittel, artist..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Søk"
 
@@ -2046,33 +2066,33 @@ msgstr "Søk"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Inkluder ikke-karaoke-kamper"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Avansert"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Lim inn en YouTube-nettadresse:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Lagre til senere"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2083,7 +2103,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2093,7 +2113,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/nl_NL/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/nl_NL/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-13 22:56-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: nl_NL <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transponeren met %s halve tonen: %s"
@@ -29,7 +29,7 @@ msgstr "Transponeren met %s halve tonen: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
@@ -137,39 +137,39 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Er is iets misgegaan! Uw voorkeuren zijn niet gewist"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Nummer staat al in de wachtrij: %s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr ""
 "Je hebt de limiet van %s nummer(s) van een gebruiker in de wachtrij bereikt!"
 
 # auto-translated
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s toegevoegd bovenaan de wachtrij: %s"
 
 # auto-translated
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s toegevoegd aan de wachtrij: %s"
 
 # auto-translated
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Nummer toegevoegd aan de wachtrij: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Wachtrij wissen"
 
@@ -307,7 +307,7 @@ msgstr ""
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Liedjes"
 
@@ -485,7 +485,7 @@ msgstr "Fout bij verwijderen uit wachtrij"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Nieuw toevoegen"
 
@@ -530,7 +530,7 @@ msgstr "Gespeeld bij"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Uitvoerder"
 
@@ -539,7 +539,7 @@ msgstr "Uitvoerder"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Liedje"
 
@@ -631,7 +631,7 @@ msgstr "Kan ondertiteling niet streamen:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -642,7 +642,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Weet u zeker dat u de HELE wachtrij wilt wissen? Typ ok om door te gaan"
@@ -651,21 +651,21 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Weet u zeker dat u {title} uit de wachtrij wilt verwijderen?"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Weet je zeker dat je dit nummer uit de bibliotheek wilt verwijderen?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} halve tonen"
@@ -673,20 +673,20 @@ msgstr "{value} halve tonen"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponeer dit nummer: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Weet je zeker dat je dit nummer opnieuw wilt starten?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -698,7 +698,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -708,14 +708,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Fout"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -726,46 +726,46 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Huidige sessie: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Thuis"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Wachtrij"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Ranglijsten"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Speelgeschiedenis"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Sessies"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -893,60 +893,60 @@ msgstr "Verwijder dit nummer"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Bulk hernoemen"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Verkrijgbaar in de bibliotheek"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Alle mappen"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Zoek op titel, artiest..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Duidelijk"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Alle liedjes"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Mappen"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Alfabetisch sorteren"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Sorteer op datum"
 
@@ -959,7 +959,7 @@ msgstr "Deze vermelding uit het afspeellogboek verwijderen?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Er is nog niets gespeeld."
 
@@ -1011,9 +1011,9 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Toevoegen aan wachtrij"
 
@@ -1864,6 +1864,26 @@ msgid "All sessions"
 msgstr "Alle sessies"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Wachtrij voor zanger"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Naam van de zanger"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Start een sessie om in de rij te staan ​​voor zangers"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Downloads in behandeling"
@@ -1989,51 +2009,51 @@ msgstr "Wachtrij downloaden"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Show"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Rang"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Speelt"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Topnummers"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Toppresteerders"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Er heeft nog niemand gezongen."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Toevoegen..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "In bibliotheek"
 
@@ -2041,19 +2061,19 @@ msgstr "In bibliotheek"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Voeg nieuwe nummers van YouTube toe"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Zoek op YouTube op titel, artiest..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Zoekopdracht"
 
@@ -2061,33 +2081,33 @@ msgstr "Zoekopdracht"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Inclusief niet-karaokewedstrijden"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Geavanceerd"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Plak een YouTube-URL:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Bewaar voor later"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2098,7 +2118,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2108,7 +2128,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/pt_BR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: mawkee@gmail.com\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2022-06-28 18:57-0300\n"
 "Last-Translator: FULL NAME <mawkee@gmail.com>\n"
 "Language-Team: pt_BR <LL@li.org>\n"
@@ -20,14 +20,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Transpondo em %s semitons: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Volume: %s"
@@ -121,33 +121,33 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Algo deu errado! Suas preferências não foram limpas"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "A música já está na fila: %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Você atingiu o limite de %s música(s) de um usuário na fila!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s adicionado ao topo da fila: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s adicionou à fila: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Música adicionada à fila: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Fila limpa"
 
@@ -265,7 +265,7 @@ msgstr "Erro ao renomear o arquivo: '%s' para '%s', Nome do arquivo já existe"
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Músicas"
 
@@ -428,7 +428,7 @@ msgstr "Erro ao remover da fila"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Adicionar novo"
 
@@ -473,7 +473,7 @@ msgstr "Jogado em"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Intérprete"
 
@@ -482,7 +482,7 @@ msgstr "Intérprete"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Canção"
 
@@ -560,7 +560,7 @@ msgstr "Falha ao transmitir legenda:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -571,7 +571,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Tem certeza de que deseja limpar TODA a fila? Digite ok para continuar"
@@ -580,20 +580,20 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Tem certeza de que deseja excluir {title} da fila?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Tem certeza que quer excluir esta música da biblioteca?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} semitons"
@@ -601,20 +601,20 @@ msgstr "{value} semitons"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponha esta música: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Tem certeza de que deseja reiniciar esta faixa?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -625,7 +625,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -635,13 +635,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Erro"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -652,44 +652,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sessão atual: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Home"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Fila"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Classificações"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "Histórico de jogos"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Sessões"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Configurações"
 
@@ -808,59 +808,59 @@ msgstr "Apagar esta música"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Renomear em massa"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Disponível na biblioteca"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Todas as pastas"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Pesquise por título, artista..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Limpar"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Todas as músicas"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Pastas"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Classificar em ordem alfabética"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Classificar por data"
 
@@ -873,7 +873,7 @@ msgstr "Excluir esta entrada do registro de reprodução?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Nada foi jogado ainda."
 
@@ -924,9 +924,9 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Adicionar à fila"
 
@@ -1702,6 +1702,26 @@ msgid "All sessions"
 msgstr "Todas as sessões"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Fila para cantor"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Nome do cantor"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Inicie uma sessão para fazer fila para cantores"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Downloads pendentes"
@@ -1823,51 +1843,51 @@ msgstr "Fila de download"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Mostrar"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Classificação"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Peças"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Melhores músicas"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Melhores desempenhos"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Ninguém cantou ainda."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Adicionando..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "Na biblioteca"
 
@@ -1875,49 +1895,49 @@ msgstr "Na biblioteca"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Adicione novas músicas do YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Pesquise no YouTube por título, artista..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Busca"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Adicionar resultados não-karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Avançado"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Cole um URL do YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Salvar para mais tarde"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1926,7 +1946,7 @@ msgstr "Procurando no YouTube por <small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1936,7 +1956,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/ru_RU/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ru_RU/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-11-09 03:26+0300\n"
 "Last-Translator: \n"
 "Language-Team: ru_RU <LL@li.org>\n"
@@ -20,14 +20,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "Транспозиция на  %s полутонов: %s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "Громкость: %s"
@@ -121,33 +121,33 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Что-то пошло не так! Ваши настройки не были сброшены"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "Песня уже в очереди: %s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "Вы достигли предела %s песен от одного пользователя в очереди!"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s добавлено в начало очереди: %s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s добавлено в очередь: %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "Песня добавлена в очередь: %s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "Очистить очередь"
 
@@ -267,7 +267,7 @@ msgstr "Ошибка переименования файла из '%s' в '%s', 
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "Песни"
 
@@ -431,7 +431,7 @@ msgstr "Ошибка удаления из очереди"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "Добавить новый"
 
@@ -476,7 +476,7 @@ msgstr "Играл в"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "Исполнитель"
 
@@ -485,7 +485,7 @@ msgstr "Исполнитель"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "Песня"
 
@@ -563,7 +563,7 @@ msgstr "Не удалось передать субтитры:"
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -574,7 +574,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Вы уверены, что хотите очистить ВСЮ очередь? Введите ОК, чтобы продолжить"
@@ -583,20 +583,20 @@ msgstr ""
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "Вы уверены, что хотите удалить {title} из очереди?"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Вы уверены, что хотите удалить эту песню из библиотеки?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} полутонов"
@@ -604,20 +604,20 @@ msgstr "{value} полутонов"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Транспонировать эту песню: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "Вы уверены, что хотите перезапустить этот трек?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -628,7 +628,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -638,13 +638,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "Ошибка"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -655,44 +655,44 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Текущая сессия: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "Домой"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "Очередь"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "Рейтинги"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "История игр"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "Сессии"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "Настройки"
 
@@ -816,59 +816,59 @@ msgstr "Удалить эту песню"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "Массовое переименование"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "Доступно в библиотеке"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "Все папки"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "Поиск по названию, исполнителю..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "Очистить"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "Все песни"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "Папки"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "Сортировать по алфавиту"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "Сортировать по дате"
 
@@ -881,7 +881,7 @@ msgstr "Удалить эту запись из журнала воспроиз�
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "Еще ничего не сыграно."
 
@@ -932,9 +932,9 @@ msgstr "Статус"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "Добавить в очередь"
 
@@ -1720,6 +1720,26 @@ msgid "All sessions"
 msgstr "Все сессии"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "Очередь к певцу"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "Имя певца"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "Начать сеанс, чтобы встать в очередь для певцов"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "Ожидающие загрузки"
@@ -1841,51 +1861,51 @@ msgstr "Очередь загрузки"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "Показывать"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "Классифицировать"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "Пьесы"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "Лучшие песни"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "Лучшие исполнители"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "Никто еще не пел."
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "Добавление..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "В библиотеке"
 
@@ -1893,49 +1913,49 @@ msgstr "В библиотеке"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "Добавляйте новые песни с YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "Поиск на YouTube по названию, исполнителю..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "Поиск"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "Включить совпадения  не караоке"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "Продвинутое"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "Вставьте URL-адрес YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "Сохранить на потом"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1946,7 +1966,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1956,7 +1976,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/th_TH/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/th_TH/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2025-01-14 10:20-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: th_TH <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "ย้ายตาม %s ครึ่งเสียง: %s"
@@ -29,7 +29,7 @@ msgstr "ย้ายตาม %s ครึ่งเสียง: %s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "ระดับเสียง: %s"
@@ -137,38 +137,38 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "มีบางอย่างผิดพลาด! การตั้งค่าของคุณไม่ได้รับการล้าง"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "เพลงอยู่ในคิวแล้ว: %s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "คุณถึงขีดจำกัด %s เพลงจากผู้ใช้ในคิวแล้ว!"
 
 # auto-translated
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "เพิ่ม %s ที่ด้านบนของคิว: %s"
 
 # auto-translated
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s ถูกเพิ่มเข้าไปในคิว: %s"
 
 # auto-translated
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "เพิ่มเพลงในคิว: %s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "เคลียร์คิว"
 
@@ -303,7 +303,7 @@ msgstr "เกิดข้อผิดพลาดในการเปลี่
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "เพลง"
 
@@ -476,7 +476,7 @@ msgstr "เกิดข้อผิดพลาดในการลบออก
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "เพิ่มใหม่"
 
@@ -521,7 +521,7 @@ msgstr "เล่นที่"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "นักแสดง"
 
@@ -530,7 +530,7 @@ msgstr "นักแสดง"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "เพลง"
 
@@ -622,7 +622,7 @@ msgstr "ไม่สามารถสตรีมคำบรรยายได
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -633,7 +633,7 @@ msgstr ""
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการล้างคิวทั้งหมด พิมพ์ตกลงเพื่อดำเนินการต่อ"
 
@@ -641,21 +641,21 @@ msgstr "คุณแน่ใจหรือไม่ว่าต้องกา
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบ {title} ออกจากคิว"
 
 # auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบเพลงนี้ออกจากห้องสมุด"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} ครึ่งเสียง"
@@ -663,20 +663,20 @@ msgstr "{value} ครึ่งเสียง"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "ย้ายเพลงนี้: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการรีสตาร์ทแทร็กนี้"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -688,7 +688,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -697,14 +697,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "ข้อผิดพลาด"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -713,46 +713,46 @@ msgstr "กรุณากรอกชื่อของคุณ ซึ่ง�
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "เซสชันปัจจุบัน: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "บ้าน"
 
 # auto-translated
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "คิว"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "อันดับ"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "ประวัติการเล่น"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "เซสชัน"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "การตั้งค่า"
 
@@ -879,60 +879,60 @@ msgstr "ลบเพลงนี้"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "เปลี่ยนชื่อเป็นกลุ่ม"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "มีจำหน่ายแล้วในห้องสมุด"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "โฟลเดอร์ทั้งหมด"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "ค้นหาตามชื่อศิลปิน..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "ชัดเจน"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "ทุกเพลง"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "โฟลเดอร์"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "จัดเรียงตามตัวอักษร"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "เรียงตามวันที่"
 
@@ -945,7 +945,7 @@ msgstr "ลบรายการนี้ออกจากบันทึกก
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "ยังไม่ได้เล่นอะไรเลย"
 
@@ -997,9 +997,9 @@ msgstr "สถานะ"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "เพิ่มเข้าคิว"
 
@@ -1837,6 +1837,26 @@ msgid "All sessions"
 msgstr "เซสชันทั้งหมด"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "ต่อคิวนักร้อง"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "ชื่อนักร้อง"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "เริ่มเซสชั่นเพื่อเข้าคิวนักร้อง"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "รอการดาวน์โหลด"
@@ -1962,51 +1982,51 @@ msgstr "คิวดาวน์โหลด"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "แสดง"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "อันดับ"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "เล่น"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "เพลงยอดนิยม"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "นักแสดงชั้นนำ"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "ยังไม่มีใครร้องเลย"
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "กำลังเพิ่ม..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "ในห้องสมุด"
 
@@ -2014,19 +2034,19 @@ msgstr "ในห้องสมุด"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "เพิ่มเพลงใหม่จาก YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "ค้นหา YouTube ตามชื่อศิลปิน..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "ค้นหา"
 
@@ -2034,33 +2054,33 @@ msgstr "ค้นหา"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "รวมการแข่งขันที่ไม่ใช่คาราโอเกะ"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "ขั้นสูง"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "วาง URL ของ YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "เก็บไว้ดูทีหลัง"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2071,7 +2091,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2081,7 +2101,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2022-04-28 10:09-0400\n"
 "Last-Translator: \n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 # auto-translated
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "移调 %s 个半音：%s"
@@ -29,7 +29,7 @@ msgstr "移调 %s 个半音：%s"
 # auto-translated
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "音量：%s"
@@ -133,35 +133,35 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "出了问题！您的偏好未清除"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "歌曲已在队列中：%s"
 
 # auto-translated
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "您已达到队列中用户 %s 首歌曲的限制！"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s 已添加到队列顶部：%s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s 成功添加歌曲： %s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "成功添加歌曲：%s"
 
 # auto-translated
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "清除队列"
 
@@ -291,7 +291,7 @@ msgstr "将文件 '%s' 重命名为 '%s' 时出错，文件名已存在"
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "歌曲"
 
@@ -462,7 +462,7 @@ msgstr "从队列中删除时出错"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "添加新内容"
 
@@ -507,7 +507,7 @@ msgstr "玩过"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "演员"
 
@@ -516,7 +516,7 @@ msgstr "演员"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "歌曲"
 
@@ -608,7 +608,7 @@ msgstr "无法传输字幕："
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -617,7 +617,7 @@ msgstr "您想更改使用此设备的人的姓名吗？这将显示在排队的
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "您确定要清除整个队列吗？输入“确定”继续"
 
@@ -625,20 +625,20 @@ msgstr "您确定要清除整个队列吗？输入“确定”继续"
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "您确定要从队列中删除 {title} 吗？"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "确认即将把此歌曲从音乐库里删除？"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 半音"
@@ -646,20 +646,20 @@ msgstr "{value} 半音"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "转置这首歌：{label}？"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "您确定要重新开始该曲目吗？"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -668,7 +668,7 @@ msgstr "半音也称为半音。它是西方古典音乐中使用的最小音程
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -676,13 +676,13 @@ msgstr "您确定要扩展文件系统吗？这将重新启动您的树莓派。
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "错误"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -691,44 +691,44 @@ msgstr "演唱者（我）的名字是："
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "当前会话：{name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "主页"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "列表"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "排行榜"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "播放历史"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "会议"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "设置"
 
@@ -852,59 +852,59 @@ msgstr "删除此曲"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "批量重命名"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "在图书馆可以找到"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "所有文件夹"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "按标题、艺术家搜索..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "清除所有"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "所有歌曲"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "文件夹"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "按字母顺序排序"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "按日期排序"
 
@@ -917,7 +917,7 @@ msgstr "从播放日志中删除此条目吗？"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "还没有播放任何内容。"
 
@@ -968,9 +968,9 @@ msgstr "地位"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "添加至播放列表"
 
@@ -1745,6 +1745,26 @@ msgid "All sessions"
 msgstr "所有会议"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "歌手排队"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "歌手姓名"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "开始一个会话来排队等待歌手"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "待下载"
@@ -1868,51 +1888,51 @@ msgstr "下载队列"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "展示"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "秩"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "戏剧"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "热门歌曲"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "表现最佳者"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "还没有人唱歌。"
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "添加..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "在图书馆"
 
@@ -1920,49 +1940,49 @@ msgstr "在图书馆"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "添加来自 YouTube 的新歌曲"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "按标题、艺术家搜索 YouTube..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "搜索"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "搜索包含原唱版本（非伴奏）"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "高级设置"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "粘贴 YouTube 网址："
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "保存以供稍后使用"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1971,7 +1991,7 @@ msgstr "在YouTube上搜索<small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1981,7 +2001,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."

--- a/pikaraoke/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-19 09:35+1000\n"
+"POT-Creation-Date: 2026-08-20 10:03+1000\n"
 "PO-Revision-Date: 2024-08-28 10:09-0400\n"
 "Last-Translator: \n"
 "Language-Team: zh_hant_TW <LL@li.org>\n"
@@ -19,14 +19,14 @@ msgstr ""
 
 #. Message shown after the song is transposed, first is the semitones and then
 #. the song name
-#: karaoke.py:557
+#: karaoke.py:559
 #, python-format
 msgid "Transposing by %s semitones: %s"
 msgstr "調整音調 %s 個半音：%s"
 
 #. Message shown after the volume is changed, will be followed by the volume
 #. level
-#: karaoke.py:571
+#: karaoke.py:573
 #, python-format
 msgid "Volume: %s"
 msgstr "音量：%s"
@@ -120,33 +120,33 @@ msgid "Something went wrong! Your preferences were not cleared"
 msgstr "發生錯誤！您的偏好設定未被清除"
 
 # auto-translated
-#: lib/queue_manager.py:111
+#: lib/queue_manager.py:128
 #, python-format
 msgid "Song is already in the queue: %s"
 msgstr "歌曲已在隊列中：%s"
 
-#: lib/queue_manager.py:119
+#: lib/queue_manager.py:136
 #, python-format
 msgid "You reached the limit of %s song(s) from an user in queue!"
 msgstr "您已達到每位用戶在播放列表中的 %s 首歌曲限制！"
 
-#: lib/queue_manager.py:132
+#: lib/queue_manager.py:149
 #, python-format
 msgid "%s added to top of queue: %s"
 msgstr "%s 成功添加歌曲到播放列表頂部：%s"
 
-#: lib/queue_manager.py:141
+#: lib/queue_manager.py:158
 #, python-format
 msgid "%s added to the queue: %s"
 msgstr "%s 成功添加歌曲到播放列表：%s"
 
-#: lib/queue_manager.py:153
+#: lib/queue_manager.py:170
 #, python-format
 msgid "Song added to the queue: %s"
 msgstr "成功添加歌曲到播放列表：%s"
 
 #. Message shown after the queue is cleared
-#: lib/queue_manager.py:210
+#: lib/queue_manager.py:227
 msgid "Clear queue"
 msgstr "清空播放列表"
 
@@ -264,7 +264,7 @@ msgstr "重命名檔案時出錯：'%s' 到 '%s'，檔案名已存在"
 # auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:343 templates/base.html:346
+#: routes/files.py:187 templates/base.html:456 templates/base.html:459
 msgid "Songs"
 msgstr "歌曲"
 
@@ -422,7 +422,7 @@ msgstr "從播放列表中刪除時出錯"
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:349 templates/base.html:352
+#: routes/search.py:61 templates/base.html:462 templates/base.html:465
 msgid "Add New"
 msgstr "新增內容"
 
@@ -467,7 +467,7 @@ msgstr "玩過"
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
 #: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:185
+#: templates/history.html:469 templates/rankings.html:176
 msgid "Performer"
 msgstr "演員"
 
@@ -476,7 +476,7 @@ msgstr "演員"
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
 #: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:138
+#: templates/history.html:473 templates/rankings.html:128
 msgid "Song"
 msgstr "歌曲"
 
@@ -553,7 +553,7 @@ msgstr "無法傳輸字幕："
 # auto-translated
 #. Prompt to change the username displayed next to queued songs. {name} is
 #. replaced with the name
-#: templates/base.html:33
+#: templates/base.html:37
 #, python-brace-format
 msgid ""
 "Do you want to change the name of the person using this device? This will "
@@ -562,7 +562,7 @@ msgstr "您要更改使用此設備的人的姓名嗎？這將顯示在排隊的
 
 # auto-translated
 #. Confirmation prompt to clear entire queue. User must type ok to confirm
-#: templates/base.html:35
+#: templates/base.html:39
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "您確定要清除整個佇列嗎？輸入“確定”繼續"
 
@@ -570,20 +570,20 @@ msgstr "您確定要清除整個佇列嗎？輸入“確定”繼續"
 #. Confirmation dialog when removing a song from the queue. {title} is
 #. replaced
 #. with the title
-#: templates/base.html:37
+#: templates/base.html:41
 #, python-brace-format
 msgid "Are you sure you want to delete {title} from the queue?"
 msgstr "您確定要從佇列中刪除 {title} 嗎？"
 
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:39
+#: templates/base.html:43
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "您確定要從音樂庫中刪除此歌曲嗎？"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:41
+#: templates/base.html:45
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 半音"
@@ -591,20 +591,20 @@ msgstr "{value} 半音"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:43
+#: templates/base.html:47
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "轉置這首歌：{label}？"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:45
+#: templates/base.html:49
 msgid "Are you sure you want to restart this track?"
 msgstr "您確定要重新開始該曲目嗎？"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:47
+#: templates/base.html:51
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -613,7 +613,7 @@ msgstr "半音也稱為半音。它是西方古典音樂中使用的最小音程
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:49
+#: templates/base.html:53
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -621,13 +621,13 @@ msgstr "您確定要擴充檔案系統嗎？這將重新啟動您的樹莓派。
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:51
+#: templates/base.html:55
 msgid "Error"
 msgstr "錯誤"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:116
+#: templates/base.html:120
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -636,44 +636,44 @@ msgstr "請輸入您的名字。這將顯示在您從此設備添加的歌曲旁
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:144 templates/base.html:413
+#: templates/base.html:212 templates/base.html:526
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "目前會話：{name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:330
+#: templates/base.html:443
 msgid "Home"
 msgstr "首頁"
 
 #. Navigation link for the queue page.
-#: templates/base.html:336 templates/queue.html:509
+#: templates/base.html:449 templates/queue.html:509
 msgid "Queue"
 msgstr "播放列表"
 
 # auto-translated
 #. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:380
+#: templates/base.html:493
 msgid "Rankings"
 msgstr "排行榜"
 
 # auto-translated
 #. Dropdown link to the log of everything that has been sung.
 #. Header of the play history management section of the settings page.
-#: templates/base.html:385 templates/info.html:432
+#: templates/base.html:498 templates/info.html:432
 msgid "Play History"
 msgstr "播放歷史"
 
 # auto-translated
 #. Dropdown link to the karaoke session management page, only shown to the
 #. host.
-#: templates/base.html:392
+#: templates/base.html:505
 msgid "Sessions"
 msgstr "會議"
 
 # auto-translated
 #. Dropdown link to the settings and system information page.
-#: templates/base.html:398
+#: templates/base.html:511
 msgid "Settings"
 msgstr "設定"
 
@@ -797,59 +797,59 @@ msgstr "刪除此歌曲"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:218
+#: templates/files.html:220
 msgid "Bulk rename"
 msgstr "批次重命名"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:224
+#: templates/files.html:226
 msgid "Available in the library"
 msgstr "在圖書館可以找到"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:353
+#: templates/files.html:356
 msgid "All folders"
 msgstr "所有資料夾"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:377
+#: templates/files.html:382
 msgid "Search by title, artist..."
 msgstr "按標題、藝術家搜尋..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:383 templates/search.html:552
+#: templates/files.html:388 templates/search.html:554
 msgid "Clear"
 msgstr "清除"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:441
+#: templates/files.html:446
 msgid "All songs"
 msgstr "所有歌曲"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:446
+#: templates/files.html:451
 msgid "Folders"
 msgstr "資料夾"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:457
+#: templates/files.html:462
 msgid "Sort Alphabetically"
 msgstr "按字母順序排序"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:462
+#: templates/files.html:467
 msgid "Sort by Date"
 msgstr "按日期排序"
 
@@ -862,7 +862,7 @@ msgstr "從播放日誌中刪除此條目嗎？"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:172
+#: templates/history.html:42 templates/rankings.html:163
 msgid "Nothing has been played yet."
 msgstr "還沒有播放任何內容。"
 
@@ -913,9 +913,9 @@ msgstr "地位"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:151
-#: templates/search.html:369 templates/search.html:577
-#: templates/search.html:644 templates/search.html:654
+#: templates/history.html:496 templates/rankings.html:141
+#: templates/search.html:370 templates/search.html:579
+#: templates/search.html:647 templates/search.html:657
 msgid "Add to queue"
 msgstr "添加到播放列表"
 
@@ -1665,6 +1665,26 @@ msgid "All sessions"
 msgstr "所有會議"
 
 # auto-translated
+#. Label for the KJ-mode field naming who is about to sing the songs being
+#. queued.
+#: templates/partials/singer_field.html:14
+msgid "Queue for singer"
+msgstr "歌手排隊"
+
+# auto-translated
+#. Placeholder in the KJ-mode singer field.
+#: templates/partials/singer_field.html:21
+msgid "Name of the singer"
+msgstr "歌手姓名"
+
+# auto-translated
+#. Button shown in place of the KJ singer field when no session is running.
+#. Links to the sessions page.
+#: templates/partials/singer_field.html:35
+msgid "Start a session to queue for singers"
+msgstr "開始一個會話來排隊等待歌手"
+
+# auto-translated
 #: templates/queue.html:214
 msgid "Pending downloads"
 msgstr "待下載"
@@ -1787,51 +1807,51 @@ msgstr "下載隊列"
 
 # auto-translated
 #. Label before the dropdown choosing how many ranked rows to show.
-#: templates/rankings.html:39
+#: templates/rankings.html:29
 msgid "Show"
 msgstr "展示"
 
 # auto-translated
 #. Ranking table column header for a row's position in the chart.
-#: templates/rankings.html:55
+#: templates/rankings.html:45
 msgid "Rank"
 msgstr "秩"
 
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:58 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:689
 msgid "Plays"
 msgstr "戲劇"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:129
+#: templates/rankings.html:119
 msgid "Top songs"
 msgstr "熱門歌曲"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:176
+#: templates/rankings.html:167
 msgid "Top performers"
 msgstr "表現最佳者"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:203
+#: templates/rankings.html:194
 msgid "Nobody has sung yet."
 msgstr "還沒有人唱歌。"
 
 # auto-translated
 #. Status shown on a search result that has been requested but has not arrived
 #. yet.
-#: templates/search.html:348
+#: templates/search.html:350
 msgid "Adding..."
 msgstr "新增..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:375 templates/search.html:624
+#: templates/search.html:376 templates/search.html:626
 msgid "In library"
 msgstr "在圖書館"
 
@@ -1839,49 +1859,49 @@ msgstr "在圖書館"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:519
+#: templates/search.html:520
 msgid "Add new songs from YouTube"
 msgstr "新增 YouTube 的新歌曲"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:532
+#: templates/search.html:534
 msgid "Search YouTube by title, artist..."
 msgstr "按標題、藝術家搜尋 YouTube..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:538
+#: templates/search.html:540
 msgid "Search"
 msgstr "搜尋"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:548
+#: templates/search.html:550
 msgid "Include non-karaoke matches"
 msgstr "包含非卡拉OK版本"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:554
+#: templates/search.html:556
 msgid "Advanced"
 msgstr "進階"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:562
+#: templates/search.html:564
 msgid "Paste a YouTube url:"
 msgstr "貼上 YouTube 網址："
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:582 templates/search.html:659
+#: templates/search.html:584 templates/search.html:662
 msgid "Save for later"
 msgstr "儲存以供稍後使用"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:601
+#: templates/search.html:603
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1892,7 +1912,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:608
+#: templates/search.html:610
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1902,7 +1922,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:673
+#: templates/search.html:676
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."


### PR DESCRIPTION
Final translation gap fill before release. Picks up the singer field text added with KJ mode (#857): `Queue for singer`, `Start a session to queue for singers`, and a reworded `Name of the singer`.

Translated into all 15 locales. No code changes.
