### PR TITLE
fix: loosen exact pins so Dependabot can resolve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ classifiers = [
 ]
 dependencies = [
   "Flask>=3.1.0,<3.1.3",  # 3.1.3 breaks flask-socketio; remove cap when fixed
-  "qrcode[png]==8.2",
-  "psutil==7.2.1",
-  "requests==2.32.5",
-  "flask-paginate==2024.4.12",
+  "qrcode[png]>=8.2,<9",
+  "psutil>=7.2.1,<8",
+  "requests>=2.32.5,<3",
+  "flask-paginate>=2024.4.12",
   "flask-smorest>=0.46.0",
-  "Babel==2.17.0",
-  "Flask-Babel==4.0.0",
-  "ffmpeg-python==0.2.0",
+  "Babel>=2.17.0,<3",
+  "Flask-Babel>=4.0.0,<5",
+  "ffmpeg-python>=0.2.0,<1",
   "yt-dlp[default]>=2026.07.04",
   "flask-socketio>=5.5.0",
   "gevent>=24.11.1",

--- a/uv.lock
+++ b/uv.lock
@@ -521,7 +521,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -960,20 +960,20 @@ translations = [
 
 [package.metadata]
 requires-dist = [
-    { name = "babel", specifier = "==2.17.0" },
-    { name = "ffmpeg-python", specifier = "==0.2.0" },
+    { name = "babel", specifier = ">=2.17.0,<3" },
+    { name = "ffmpeg-python", specifier = ">=0.2.0,<1" },
     { name = "flask", specifier = ">=3.1.0,<3.1.3" },
-    { name = "flask-babel", specifier = "==4.0.0" },
-    { name = "flask-paginate", specifier = "==2024.4.12" },
+    { name = "flask-babel", specifier = ">=4.0.0,<5" },
+    { name = "flask-paginate", specifier = ">=2024.4.12" },
     { name = "flask-smorest", specifier = ">=0.46.0" },
     { name = "flask-socketio", specifier = ">=5.5.0" },
     { name = "gevent", specifier = ">=24.11.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.1" },
-    { name = "psutil", specifier = "==7.2.1" },
+    { name = "psutil", specifier = ">=7.2.1,<8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "qrcode", extras = ["png"], specifier = "==8.2" },
-    { name = "requests", specifier = "==2.32.5" },
+    { name = "qrcode", extras = ["png"], specifier = ">=8.2,<9" },
+    { name = "requests", specifier = ">=2.32.5,<3" },
     { name = "sounddevice", marker = "sys_platform != 'linux'", specifier = ">=0.5.0" },
     { name = "yt-dlp", extras = ["default"], specifier = ">=2026.7.4" },
 ]


### PR DESCRIPTION
Dependabot bumps a dependency by running `uv lock --upgrade-package <name>==<version>`, which layers a constraint over the manifest. An `==` pin in `[project].dependencies` contradicts it, so the resolve fails and no PR is ever opened. Only transitive deps have been bumpable until now; `requests` is the first pinned direct dependency it has tried to move, and the failure is currently blocking the 2.33.0 security patch (GHSA-gc5v-m9x4-r6x2).

Swaps the seven exact pins for `>=current,<next-major`, which keeps the guard against surprise majors on fresh PyPI installs. `flask-paginate` is CalVer, so it gets a lower bound only.

`uv.lock` resolves to identical versions -- only the recorded specifiers change, plus one stale `typing-extensions` marker that `uv lock` normalised on the way through.

