### PR TITLE
fix: default download format

### DIFF
--- a/pikaraoke/lib/download_manager.py
+++ b/pikaraoke/lib/download_manager.py
@@ -27,6 +27,21 @@ from pikaraoke.lib.youtube_dl import (
 MAX_DOWNLOAD_ATTEMPTS = 5
 
 
+def _summarise_ytdl_failure(output: str) -> str:
+    """Reduce yt-dlp's captured output to the line that says what went wrong.
+
+    yt-dlp reports warnings before it attempts a download, so the whole transcript on an
+    error card buries the diagnosis past the truncation point. The full output is logged
+    either way.
+    """
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ERROR:"):
+            return stripped.removeprefix("ERROR:").strip()
+    tail = [line.strip() for line in output.splitlines() if line.strip()]
+    return tail[-1] if tail else "Unknown error"
+
+
 def _use_spare_capacity(process: subprocess.Popen) -> None:
     """Drop a download to background priority so it never competes with playback.
 
@@ -376,7 +391,7 @@ class DownloadManager:
                     "url": video_url,
                     "user": user,
                     "enqueue": enqueue,
-                    "error": output or "Unknown error",
+                    "error": _summarise_ytdl_failure(output),
                 }
             )
         else:

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -156,7 +156,13 @@ def build_ytdl_download_command(
     # Both branches must be DASH: "mp4" selects the best pre-merged format, and YouTube
     # refuses those far more often than it refuses the separate streams.
     height = 1080 if high_quality else 720
-    file_quality = f"bestvideo[vcodec^=avc1][height<={height}]+bestaudio[ext!=webm]/best[ext!=webm]"
+    # The capped fallback matters because -S sorts on resolution: without it, a video with
+    # no avc1 DASH pair lands on a 1080p HLS variant no matter what the cap says.
+    file_quality = (
+        f"bestvideo[vcodec^=avc1][height<={height}]+bestaudio[ext!=webm]"
+        f"/best[ext!=webm][height<={height}]"
+        "/best[ext!=webm]"
+    )
     args = [
         "-f",
         file_quality,

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -143,7 +143,7 @@ def build_ytdl_download_command(
     Args:
         video_url: URL of the video to download.
         download_path: Directory path where videos will be saved.
-        high_quality: If True, download up to 1080p; otherwise download mp4.
+        high_quality: If True, cap the download at 1080p; otherwise cap it at 720p.
         youtubedl_proxy: Optional proxy server URL.
         additional_args: Optional additional command-line arguments as a string.
 
@@ -153,11 +153,10 @@ def build_ytdl_download_command(
     dl_path = os.path.join(download_path, "%(title)s---%(id)s.%(ext)s")
     # AV1 ships in an mp4 container, so ext!=webm admits it and -S only sorts. Filtering
     # on the codec is what keeps playback a stream copy instead of a libx264 transcode.
-    file_quality = (
-        "bestvideo[vcodec^=avc1][height<=1080]+bestaudio[ext!=webm]/best[ext!=webm]"
-        if high_quality
-        else "mp4"
-    )
+    # Both branches must be DASH: "mp4" selects the best pre-merged format, and YouTube
+    # refuses those far more often than it refuses the separate streams.
+    height = 1080 if high_quality else 720
+    file_quality = f"bestvideo[vcodec^=avc1][height<={height}]+bestaudio[ext!=webm]/best[ext!=webm]"
     args = [
         "-f",
         file_quality,

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pikaraoke.lib.download_manager import MAX_DOWNLOAD_ATTEMPTS, DownloadManager
+from pikaraoke.lib.download_manager import (
+    MAX_DOWNLOAD_ATTEMPTS,
+    DownloadManager,
+    _summarise_ytdl_failure,
+)
 from pikaraoke.lib.events import EventSystem
 from pikaraoke.lib.preference_manager import PreferenceManager
 
@@ -393,6 +397,32 @@ class TestDownloadManagerRetry:
         assert download_manager.download_queue.get_nowait()["title"] == "Broken"
 
     @patch("flask_babel._", side_effect=lambda x: x)
+    @patch("subprocess.Popen")
+    @patch("pikaraoke.lib.download_manager.build_ytdl_download_command")
+    def test_error_card_carries_only_the_error_line(
+        self, mock_build_cmd, mock_popen, mock_gettext, download_manager
+    ):
+        """The card shows the diagnosis, not the whole transcript that buried it."""
+        mock_build_cmd.return_value = ["yt-dlp", "url"]
+        lines = [
+            'WARNING: "-f mp4" selects the best pre-merged mp4 format\n',
+            "[info] fAzCnCwJO5c: Downloading 1 format(s): 18\n",
+            "ERROR: unable to download video data: HTTP Error 403: Forbidden\n",
+        ]
+        process = MagicMock()
+        process.stdout.readline.side_effect = (lines + [""]) * MAX_DOWNLOAD_ATTEMPTS
+        process.poll.return_value = 1
+        mock_popen.return_value = process
+
+        download_manager.queue_download("https://youtube.com/watch?v=fAzCnCwJO5c", title="Broken")
+        self._drain(download_manager)
+
+        assert (
+            download_manager.download_errors[0]["error"]
+            == "unable to download video data: HTTP Error 403: Forbidden"
+        )
+
+    @patch("flask_babel._", side_effect=lambda x: x)
     def test_retry_error_requeues_and_clears(self, mock_gettext, download_manager):
         """The Retry button restores the request, enqueue flag included."""
         download_manager.download_errors = [
@@ -419,6 +449,35 @@ class TestDownloadManagerRetry:
         """An already-dismissed error cannot be retried."""
         assert download_manager.retry_error("nope") is False
         assert download_manager.download_queue.empty()
+
+
+class TestSummariseYtdlFailure:
+    """Tests for reducing yt-dlp's transcript to the line that names the failure."""
+
+    # Verbatim from a real 403, whose warning block pushed the diagnosis past truncation.
+    REAL_OUTPUT = (
+        '\nWARNING: "-f mp4" selects the best pre-merged mp4 format which is often not'
+        " what's intended.\n"
+        "         Pre-merged mp4 formats are not available from all sites, or may only be"
+        " available in lower quality.\n"
+        "[youtube] Extracting URL: https://www.youtube.com/watch?v=fAzCnCwJO5c\n"
+        "[youtube] fAzCnCwJO5c: Downloading android vr player API JSON\n"
+        "[info] fAzCnCwJO5c: Downloading 1 format(s): 18\n"
+        "ERROR: unable to download video data: HTTP Error 403: Forbidden\n"
+    )
+
+    def test_picks_the_error_line_out_of_the_transcript(self):
+        assert (
+            _summarise_ytdl_failure(self.REAL_OUTPUT)
+            == "unable to download video data: HTTP Error 403: Forbidden"
+        )
+
+    def test_falls_back_to_the_last_line_when_nothing_is_flagged(self):
+        """yt-dlp can die without an ERROR: line; the card still needs something."""
+        assert _summarise_ytdl_failure("[youtube] Extracting URL: x\nkilled\n") == "killed"
+
+    def test_empty_output(self):
+        assert _summarise_ytdl_failure("") == "Unknown error"
 
 
 class TestDownloadManagerStatus:

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -127,6 +127,25 @@ class TestBuildYtdlDownloadCommand:
         assert "vcodec^=avc1" in cmd[format_idx]
         assert "720" in cmd[format_idx]
 
+    @pytest.mark.parametrize("high_quality, height", [(True, 1080), (False, 720)])
+    @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
+    def test_pre_merged_fallback_honours_the_cap_before_giving_up_on_it(
+        self, mock_js, high_quality, height
+    ):
+        """A video with no avc1 DASH pair still has to respect the height cap.
+
+        -S sorts on resolution, so an uncapped fallback would pick a 1080p HLS variant.
+        The uncapped tier stays last so selection can never fail outright.
+        """
+        cmd = build_ytdl_download_command(
+            video_url="https://www.youtube.com/watch?v=test123",
+            download_path="/songs",
+            high_quality=high_quality,
+        )
+        tiers = cmd[cmd.index("-f") + 1].split("/")
+        assert tiers[1] == f"best[ext!=webm][height<={height}]"
+        assert tiers[2] == "best[ext!=webm]"
+
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_with_proxy(self, mock_js):
         """Test command with proxy setting."""

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -111,14 +111,21 @@ class TestBuildYtdlDownloadCommand:
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_standard_quality_format(self, mock_js):
-        """Test that standard quality uses mp4 format."""
+        """Standard quality is DASH too, just capped lower.
+
+        A bare "mp4" would select the best pre-merged format, which YouTube refuses
+        far more often than it refuses the separate video and audio streams.
+        """
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
             download_path="/songs",
             high_quality=False,
         )
         format_idx = cmd.index("-f") + 1
-        assert cmd[format_idx] == "mp4"
+        assert cmd[format_idx] != "mp4"
+        assert "bestvideo" in cmd[format_idx]
+        assert "vcodec^=avc1" in cmd[format_idx]
+        assert "720" in cmd[format_idx]
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_with_proxy(self, mock_js):


### PR DESCRIPTION
## What

Two fixes for failed YouTube downloads.

**Default downloads no longer ride pre-merged formats.** `-f mp4` selects the best *pre-merged* format, which YouTube publishes only as legacy itag 18 or an HLS variant, and refuses far more often than it refuses the separate video and audio streams. Measured across four videos: pre-merged was served 3 times in 12, the DASH pair 12 times in 12. The default branch now uses the same shape as the high quality branch, capped at 720p instead of 1080p.

**Error cards show the error, not the transcript.** yt-dlp's entire captured output was stored as the error text — 716 characters over nine lines on a real 403. Warnings are printed before the download is attempted, so the diagnosis was always last and the card's truncation always removed it. It is now reduced to the `ERROR:` line, and the full output is still logged.

Selection for a previously failing video moves from `18` (360p) to `136+140` (720p), about 1.5x the file size. The codec filter keeps playback a stream copy rather than a transcode.

The pre-merged fallback carries the same cap, because `-S` sorts on resolution: without it, a video with no avc1 DASH pair was selecting the 1080p HLS variant no matter what the cap said. An uncapped tier stays last so selection can never fail outright.

## Effect on a Raspberry Pi

This lowers the peak load rather than raising it. `-f mp4` was never reliably the cheap option — on any video offering an HLS variant it already pulled 1080p, so the old default alternated between 360p and 1080p depending on the video. Downloads are now a uniform 720p, and the worst case a slow Pi has to decode drops from 1080p to 720p.

The costs that do rise are small and measured. File size is 1.5x, because itag 18 is an old, inefficient encode. The merge is a container-level copy at 0.000s user CPU over three runs, and it already runs at idle I/O priority so it cannot compete with playback. Playback itself is unchanged: an h264 `.mp4` plays as a `vcodec=copy` remux, so its cost is bytes moved rather than pixels decoded.

## Test plan

- \[x\] Download a song with high quality **off** — log reads `Downloading 1 format(s): 136+140`, file is 720p h264 mp4
- \[x\] Download with high quality **on** — still capped at 1080p
- \[x\] No `-f mp4` warning appears in the logs
- \[x\] The full yt-dlp output is still in the server log
- \[x\] Play a downloaded song — no stutter, and the log shows no libx264 transcode
