### PR TITLE
fix: block background music path traversal

### DIFF
--- a/pikaraoke/routes/background_music.py
+++ b/pikaraoke/routes/background_music.py
@@ -5,7 +5,7 @@ import random
 import urllib
 
 import flask_babel
-from flask import jsonify, send_file, url_for
+from flask import jsonify, send_from_directory, url_for
 from flask_smorest import Blueprint
 
 from pikaraoke.lib.current_app import get_karaoke_instance
@@ -39,10 +39,13 @@ def create_randomized_playlist(input_directory, base_url, max_songs=50):
 
 @background_music_bp.route("/bg_music/<file>", methods=["GET"])
 def bg_music(file):
-    """Stream a background music file."""
+    """Stream a background music file.
+
+    send_from_directory, not send_file: `file` comes from the URL, and only this
+    refuses one that escapes the directory.
+    """
     k = get_karaoke_instance()
-    mp3_path = os.path.join(k.bg_music_path, file)
-    return send_file(os.path.abspath(mp3_path), mimetype="audio/mpeg")
+    return send_from_directory(k.bg_music_path, file, mimetype="audio/mpeg")
 
 
 @background_music_bp.route("/bg_playlist", methods=["GET"])

--- a/tests/unit/test_background_music.py
+++ b/tests/unit/test_background_music.py
@@ -1,0 +1,59 @@
+"""Tests for the background music routes, focused on the path the URL supplies."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pikaraoke.routes.background_music import background_music_bp
+from tests.conftest import make_route_app
+
+CANARY = "TOP-SECRET-CANARY"
+
+
+@pytest.fixture
+def app():
+    return make_route_app(background_music_bp, [])
+
+
+@pytest.fixture
+def music_dir(tmp_path):
+    """A music directory with a song in it, and a canary file one level up."""
+    music = tmp_path / "music"
+    music.mkdir()
+    (music / "song.mp3").write_text("legit-audio", encoding="utf-8")
+    (tmp_path / "secret.txt").write_text(CANARY, encoding="utf-8")
+
+    k = MagicMock()
+    k.bg_music_path = str(music)
+    with patch("pikaraoke.routes.background_music.get_karaoke_instance", return_value=k):
+        yield tmp_path
+
+
+class TestBackgroundMusicPath:
+    """Flask's converter refuses a forward slash, but not a backslash or a drive
+    letter, so on Windows these all resolved outside the music directory."""
+
+    @pytest.mark.parametrize(
+        "attempt",
+        [
+            "..%5Csecret.txt",
+            "..\\secret.txt",
+            "..%2Fsecret.txt",
+            "..%5C..%5Csecret.txt",
+            "C%3A%5CWindows%5Cwin.ini",
+        ],
+    )
+    def test_refuses_a_path_outside_the_music_directory(self, client, music_dir, attempt):
+        response = client.get(f"/bg_music/{attempt}")
+
+        assert response.status_code == 404
+        assert CANARY not in response.get_data(as_text=True)
+
+    def test_serves_a_file_in_the_music_directory(self, client, music_dir):
+        response = client.get("/bg_music/song.mp3")
+
+        assert response.status_code == 200
+        assert response.get_data(as_text=True) == "legit-audio"
+
+    def test_unknown_song_is_404(self, client, music_dir):
+        assert client.get("/bg_music/nothing-here.mp3").status_code == 404


### PR DESCRIPTION
`/bg_music/<file>` built a filesystem path by joining the URL segment onto the music directory by hand, and served whatever it resolved to. Flask's default converter refuses a forward slash, which is the whole of the defence on Linux, but it allows a backslash and a drive letter. On Windows that made any file the PiKaraoke process could read reachable — either by climbing out with `..%5C`, or by passing an absolute path, which `os.path.join` takes in place of the base directory entirely. The route is unauthenticated, so no admin password was needed.

Linux and Raspberry Pi installs are not affected: an absolute POSIX path needs a leading slash, and the URL converter already refuses that.

`send_from_directory` puts the name through werkzeug's `safe_join`, which refuses `..` segments, absolute paths and drive letters, and raises `NotFound` rather than serving. A missing file now 404s instead of raising an uncaught `FileNotFoundError`.

