### PR TITLE
fix: set SameSite and HttpOnly on the admin cookie

### DIFF
--- a/pikaraoke/routes/admin.py
+++ b/pikaraoke/routes/admin.py
@@ -173,7 +173,15 @@ def auth(form):
         resp = make_response(redirect(next_url))
         expire_date = datetime.datetime.now()
         expire_date = expire_date + datetime.timedelta(days=90)
-        resp.set_cookie("admin", admin_password, expires=expire_date)
+        # Not secure=True: PiKaraoke serves plain HTTP on a LAN, so the browser
+        # would never send the cookie back.
+        resp.set_cookie(
+            "admin",
+            admin_password,
+            expires=expire_date,
+            httponly=True,
+            samesite="Lax",
+        )
         # MSG: Message shown after logging in as admin successfully
         flash(_("Admin mode granted!"), "is-success")
     else:
@@ -187,7 +195,7 @@ def auth(form):
 def logout():
     """Log out of admin mode."""
     resp = make_response(redirect(url_for("info.info")))
-    resp.set_cookie("admin", "")
+    resp.set_cookie("admin", "", httponly=True, samesite="Lax")
     # MSG: Message shown after logging out as admin successfully
     flash(_("Logged out of admin mode!"), "is-success")
     return resp

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -1,0 +1,61 @@
+"""Tests for admin authentication routes."""
+
+from unittest.mock import patch
+
+import pytest
+import werkzeug
+from flask import Flask
+from flask_babel import Babel
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3.0.0"
+
+from pikaraoke.routes.admin import admin_bp
+
+ROUTE_PREFIX = "pikaraoke.routes.admin"
+
+
+@pytest.fixture
+def app():
+    test_app = Flask(__name__)
+    test_app.secret_key = "test"
+    Babel(test_app)
+    test_app.register_blueprint(admin_bp)
+    test_app.add_url_rule("/info", "info.info", lambda: "")
+    return test_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _set_cookie_header(response):
+    return response.headers["Set-Cookie"]
+
+
+class TestAdminCookieAttributes:
+    """The admin cookie carries the attributes that blunt cross-site requests."""
+
+    def test_login_cookie_is_httponly_and_samesite_lax(self, client):
+        with patch(f"{ROUTE_PREFIX}.get_admin_password", return_value="hunter2"):
+            response = client.post("/auth", data={"admin_password": "hunter2", "next": "/"})
+
+        header = _set_cookie_header(response)
+        assert "HttpOnly" in header
+        assert "SameSite=Lax" in header
+
+    def test_login_cookie_is_not_secure(self, client):
+        """PiKaraoke serves plain HTTP on a LAN; a Secure cookie would never come back."""
+        with patch(f"{ROUTE_PREFIX}.get_admin_password", return_value="hunter2"):
+            response = client.post("/auth", data={"admin_password": "hunter2", "next": "/"})
+
+        assert "Secure" not in _set_cookie_header(response)
+
+    def test_logout_cookie_matches_the_login_attributes(self, client):
+        with patch(f"{ROUTE_PREFIX}.get_admin_password", return_value="hunter2"):
+            response = client.get("/logout")
+
+        header = _set_cookie_header(response)
+        assert "HttpOnly" in header
+        assert "SameSite=Lax" in header


### PR DESCRIPTION
The admin cookie is set with neither attribute, so each browser's default decides whether it rides along on cross-site requests. That default varies by browser and version, which means the same box behaves differently depending on which phone the host logged in from.

`SameSite=Lax` makes it deterministic and stops the cookie being attached to cross-site subresource loads — an `<img>` or `<iframe>` pointing at `/shutdown` on a page the host happens to visit. `HttpOnly` is free here: nothing in the app reads this cookie from JavaScript.

Not `Secure`. PiKaraoke serves plain HTTP on a LAN, and a `Secure` cookie is never sent back over HTTP, so that flag would stop admin login working at all.

Logout gets the same attributes so the pair cannot drift.

This does not close the hole on its own. Lax deliberately still sends the cookie on a top-level GET navigation, so `<a href="http://pikaraoke.local:5555/shutdown">` keeps working — that needs the eleven state-changing routes moved to POST, which is a separate PR.

## Test plan

Run with `--admin-password` set.

- [x] Log in, and check in devtools that the `admin` cookie has `HttpOnly` and `SameSite=Lax`, and no `Secure`
- [x] Reload an admin page — admin mode is still active
- [x] Log out — admin mode ends and the admin-only buttons disappear
