### PR TITLE
fix: require POST for the host-only routes that change state

### DIFF
--- a/pikaraoke/routes/admin.py
+++ b/pikaraoke/routes/admin.py
@@ -44,7 +44,7 @@ def delayed_halt(cmd: int, k: Karaoke):
         os.system("reboot")
 
 
-@admin_bp.route("/update_ytdl")
+@admin_bp.route("/update_ytdl", methods=["POST"])
 def update_ytdl():
     """Update yt-dlp to the latest version."""
     k = get_karaoke_instance()
@@ -76,7 +76,7 @@ def library_stats():
     return jsonify({"song_count": len(k.song_manager.songs)})
 
 
-@admin_bp.route("/sync_library")
+@admin_bp.route("/sync_library", methods=["POST"])
 def sync_library():
     """Trigger a background library scan."""
     if not is_admin():
@@ -88,7 +88,7 @@ def sync_library():
     return jsonify({"status": "already_syncing"})
 
 
-@admin_bp.route("/quit")
+@admin_bp.route("/quit", methods=["POST"])
 def quit():
     """Exit the PiKaraoke application."""
     k = get_karaoke_instance()
@@ -105,7 +105,7 @@ def quit():
     return redirect(url_for("home.home"))
 
 
-@admin_bp.route("/shutdown")
+@admin_bp.route("/shutdown", methods=["POST"])
 def shutdown():
     """Shut down the host system."""
     k = get_karaoke_instance()
@@ -122,7 +122,7 @@ def shutdown():
     return redirect(url_for("home.home"))
 
 
-@admin_bp.route("/reboot")
+@admin_bp.route("/reboot", methods=["POST"])
 def reboot():
     """Reboot the host system."""
     k = get_karaoke_instance()
@@ -139,7 +139,7 @@ def reboot():
     return redirect(url_for("home.home"))
 
 
-@admin_bp.route("/expand_fs")
+@admin_bp.route("/expand_fs", methods=["POST"])
 def expand_fs():
     """Expand filesystem on Raspberry Pi."""
     k = get_karaoke_instance()

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -205,7 +205,7 @@ def browse():
     return render_template("files.html", **context)
 
 
-@files_bp.route("/files/delete", methods=["GET"])
+@files_bp.route("/files/delete", methods=["POST"])
 @files_bp.arguments(SongReferrerQuery, location="query")
 def delete_file(query):
     """Delete a song file."""

--- a/pikaraoke/routes/preferences.py
+++ b/pikaraoke/routes/preferences.py
@@ -16,21 +16,21 @@ _SCORE_PHRASE_KEYS = {"low_score_phrases", "mid_score_phrases", "high_score_phra
 preferences_bp = Blueprint("preferences", __name__)
 
 
-class ChangePreferenceQuery(Schema):
+class ChangePreferenceForm(Schema):
     pref = fields.String(
         required=True, metadata={"description": "Name of the preference to change"}
     )
     val = fields.String(required=True, metadata={"description": "New value for the preference"})
 
 
-@preferences_bp.route("/change_preferences", methods=["GET"])
-@preferences_bp.arguments(ChangePreferenceQuery, location="query")
-def change_preferences(query):
+@preferences_bp.route("/change_preferences", methods=["POST"])
+@preferences_bp.arguments(ChangePreferenceForm, location="form")
+def change_preferences(form):
     """Change a user preference setting."""
     k = get_karaoke_instance()
     if is_admin():
-        preference = query["pref"]
-        val = query["val"]
+        preference = form["pref"]
+        val = form["val"]
         success, message = k.preferences.set(preference, val)
         if success:
             broadcast_event("preferences_update", {"key": preference, "value": val})
@@ -43,7 +43,7 @@ def change_preferences(query):
     return redirect(url_for("info.info"))
 
 
-@preferences_bp.route("/clear_preferences", methods=["GET"])
+@preferences_bp.route("/clear_preferences", methods=["POST"])
 def clear_preferences():
     """Reset all preferences to defaults."""
     k = get_karaoke_instance()

--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -73,7 +73,7 @@ def get_queue():
     return json.dumps(k.queue_manager.queue)
 
 
-@queue_bp.route("/queue/addrandom/<int:amount>", methods=["GET"])
+@queue_bp.route("/queue/addrandom/<int:amount>", methods=["POST"])
 def add_random(amount):
     """Add random songs to the queue."""
     if not is_admin():
@@ -108,7 +108,7 @@ def reorder(form):
     return json.dumps({"success": False})
 
 
-@queue_bp.route("/queue/edit", methods=["GET"])
+@queue_bp.route("/queue/edit", methods=["POST"])
 @queue_bp.arguments(QueueEditQuery, location="query")
 def queue_edit(query):
     """Edit queue items (admin only)."""

--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -144,18 +144,9 @@
      * This ensures they work reliably across all page transitions
      */
     function initQueueHandlers() {
-        // Global flag to prevent rapid up/down clicks
-        // Survives DOM regeneration caused by socket updates
-        if (typeof window.queueButtonDebouncing === 'undefined') {
-            window.queueButtonDebouncing = false;
-        }
-
         // Remove any existing handlers first to avoid duplicates
         $(document).off('click', '.confirm-clear');
-        $(document).off('click', '.confirm-delete');
         $(document).off('click', '.confirm-delete-file');
-        $(document).off('click', '.up-button');
-        $(document).off('click', '.down-button');
         $(document).off('click', '.add-random');
 
         // Clear queue confirmation
@@ -171,17 +162,6 @@
             }
         });
 
-        // Delete song from queue confirmation
-        $(document).on('click', '.confirm-delete', function(e) {
-            e.preventDefault();
-            var msg = (window.translations && window.translations.confirmDeleteFromQueue)
-                ? window.translations.confirmDeleteFromQueue.replace('{title}', this.title)
-                : `Are you sure you want to delete "${this.title}" from the queue?`;
-            if (window.confirm(msg)) {
-                $.post(this.href);
-            }
-        });
-
         // Delete song file from library confirmation (full page navigation)
         $(document).on('click', '.confirm-delete-file', function(e) {
             e.preventDefault();
@@ -191,54 +171,6 @@
             if (window.confirm(msg)) {
                 window.postNavigate(this.href);
             }
-        });
-
-        // Move song up in queue
-        $(document).on('click', '.up-button', function(e) {
-            e.preventDefault();
-
-            // Check global debounce flag - prevents all up/down clicks during debounce
-            if (window.queueButtonDebouncing) {
-                return;
-            }
-
-            // Set global debounce flag
-            window.queueButtonDebouncing = true;
-
-            // Visual feedback on all up/down buttons
-            $('.up-button, .down-button').css('pointer-events', 'none').css('opacity', '0.5');
-
-            $.post(this.href).always(function() {
-                // Re-enable all buttons after request completes + 500ms
-                setTimeout(function() {
-                    $('.up-button, .down-button').css('pointer-events', 'auto').css('opacity', '1');
-                    window.queueButtonDebouncing = false;
-                }, 500);
-            });
-        });
-
-        // Move song down in queue
-        $(document).on('click', '.down-button', function(e) {
-            e.preventDefault();
-
-            // Check global debounce flag - prevents all up/down clicks during debounce
-            if (window.queueButtonDebouncing) {
-                return;
-            }
-
-            // Set global debounce flag
-            window.queueButtonDebouncing = true;
-
-            // Visual feedback on all up/down buttons
-            $('.up-button, .down-button').css('pointer-events', 'none').css('opacity', '0.5');
-
-            $.post(this.href).always(function() {
-                // Re-enable all buttons after request completes + 500ms
-                setTimeout(function() {
-                    $('.up-button, .down-button').css('pointer-events', 'auto').css('opacity', '1');
-                    window.queueButtonDebouncing = false;
-                }, 500);
-            });
         });
 
         // Add random songs to queue
@@ -280,10 +212,7 @@
             $link.hasClass('edit-button') ||
             $link.hasClass('add-song-link') ||  // Browse page add to queue
             $link.hasClass('confirm-clear') ||   // Clear queue button (has its own handler)
-            $link.hasClass('confirm-delete') ||  // Delete song from queue (has its own handler)
             $link.hasClass('confirm-delete-file') ||  // Delete song file from library (has its own handler)
-            $link.hasClass('up-button') ||       // Move song up button (has its own handler)
-            $link.hasClass('down-button') ||     // Move song down button (has its own handler)
             $link.hasClass('add-random')) {      // Add random songs button (has its own handler)
             return true;
         }

--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -38,6 +38,18 @@
         }
     };
 
+    /**
+     * Navigate to `url` by POST, so a cross-site link cannot fire the route.
+     * A POST form action keeps its query string, so pass the href unchanged.
+     */
+    window.postNavigate = function (url) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = url;
+        document.body.appendChild(form);
+        form.submit();
+    };
+
     // State management
     let isNavigating = false;
     let currentPath = window.location.pathname + window.location.search;
@@ -155,7 +167,7 @@
             let userInput = window.prompt(promptMsg);
             // Only clear if user typed 'ok' exactly (case insensitive)
             if (userInput !== null && userInput.toLowerCase() === "ok") {
-                $.get(this.href);
+                $.post(this.href);
             }
         });
 
@@ -166,7 +178,7 @@
                 ? window.translations.confirmDeleteFromQueue.replace('{title}', this.title)
                 : `Are you sure you want to delete "${this.title}" from the queue?`;
             if (window.confirm(msg)) {
-                $.get(this.href);
+                $.post(this.href);
             }
         });
 
@@ -177,7 +189,7 @@
                 ? window.translations.confirmDeleteFromLibrary
                 : 'Are you sure you want to delete this song from the library?';
             if (window.confirm(msg)) {
-                window.location.href = this.href;
+                window.postNavigate(this.href);
             }
         });
 
@@ -196,7 +208,7 @@
             // Visual feedback on all up/down buttons
             $('.up-button, .down-button').css('pointer-events', 'none').css('opacity', '0.5');
 
-            $.get(this.href).always(function() {
+            $.post(this.href).always(function() {
                 // Re-enable all buttons after request completes + 500ms
                 setTimeout(function() {
                     $('.up-button, .down-button').css('pointer-events', 'auto').css('opacity', '1');
@@ -220,7 +232,7 @@
             // Visual feedback on all up/down buttons
             $('.up-button, .down-button').css('pointer-events', 'none').css('opacity', '0.5');
 
-            $.get(this.href).always(function() {
+            $.post(this.href).always(function() {
                 // Re-enable all buttons after request completes + 500ms
                 setTimeout(function() {
                     $('.up-button, .down-button').css('pointer-events', 'auto').css('opacity', '1');
@@ -234,7 +246,7 @@
             e.preventDefault();
             const amount = $('#randomNumberInput').val();
             const baseUrl = `${window.pikaraokeConfig.basePath}/queue/addrandom`;
-            $.get(`${baseUrl}/${amount}`);
+            $.post(`${baseUrl}/${amount}`);
         });
     }
 

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -37,8 +37,6 @@
       promptChangeUsername: {{ _('Do you want to change the name of the person using this device? This will show up on queued songs. Current: {name}') | tojson }},
       // {# MSG: Confirmation prompt to clear entire queue. User must type ok to confirm #}
       promptClearQueue: {{ _('Are you sure you want to clear the ENTIRE queue? Type ok to continue') | tojson }},
-      // {# MSG: Confirmation dialog when removing a song from the queue. {title} is replaced with the title #}
-      confirmDeleteFromQueue: {{ _('Are you sure you want to delete {title} from the queue?') | tojson }},
       // {# MSG: Confirmation dialog when permanently deleting a song file from the library #}
       confirmDeleteFromLibrary: {{ _("Are you sure you want to delete this song from the library?") | tojson }},
       // {# MSG: Label showing the number of semitones for pitch shift. {value} is replaced with a number like +3 or -2. #}

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -5,7 +5,7 @@
 
 			try {
 				for (const phraseRange in phrases) {
-					returnData = await $.get("{{ url_for('preferences.change_preferences') }}", {
+					returnData = await $.post("{{ url_for('preferences.change_preferences') }}", {
 							pref: phraseRange,
 							val: phrases[phraseRange]
 					})
@@ -51,7 +51,7 @@
 			})
 
 			function changePreferences(pref, val) {
-				$.get("{{ url_for('preferences.change_preferences') }}", {
+				$.post("{{ url_for('preferences.change_preferences') }}", {
 					"pref": pref,
 					"val": val
 				})
@@ -65,7 +65,7 @@
 				e.preventDefault();
 				// {# MSG: Confirmation text whe the user selects quit. #}
 				if (window.confirm({{ _('Are you sure you want to quit?') | tojson }})) {
-					location.href = this.href;
+					window.postNavigate(this.href);
 				}
 			});
 
@@ -73,7 +73,7 @@
 				e.preventDefault();
 				// {# MSG: Confirmation text whe the user starts to turn off the machine running Pikaraoke. #}
 				if (window.confirm({{ _('Are you sure you want to shut down?') | tojson }})) {
-					location.href = this.href;
+					window.postNavigate(this.href);
 				}
 			});
 
@@ -81,7 +81,7 @@
 				e.preventDefault();
 				// {# MSG: Confirmation text whe the user clears preferences. #}
 				if (window.confirm({{ _('Are you sure you want to clear your preferences?') | tojson }})) {
-					location.href = this.href;
+					window.postNavigate(this.href);
 				}
 			});
 
@@ -89,7 +89,7 @@
 				e.preventDefault();
 				// {# MSG: Confirmation text whe the user starts to reboot the machine running Pikaraoke. #}
 				if (window.confirm({{ _('Are you sure you want to reboot?') | tojson }})) {
-					location.href = this.href;
+					window.postNavigate(this.href);
 				}
 			});
 
@@ -101,7 +101,7 @@
 						{{ _('Are you sure you want to update yt-dlp right now? Current and pending downloads may fail.') | tojson }}
 					)
 				) {
-					location.href = this.href;
+					window.postNavigate(this.href);
 				}
 			});
 
@@ -109,7 +109,7 @@
 			e.preventDefault();
 			// {# MSG: Confirmation text when the user wants to expand the filesystem to take the entire SD card. #}
 			if (window.confirm(window.translations.confirmExpandFilesystem)) {
-				location.href = this.href;
+				window.postNavigate(this.href);
 			}
 		});
 
@@ -264,7 +264,7 @@
 			$("#sync-library-btn").click(function() {
 				var $btn = $(this);
 				$btn.addClass("is-loading").prop("disabled", true);
-				$.getJSON("{{ url_for('admin.sync_library') }}", function(data) {
+				$.post("{{ url_for('admin.sync_library') }}", function(data) {
 					if (data.status !== "already_syncing") return;
 					// stays disabled -- sync_finished will re-enable
 				}).fail(function() {

--- a/pikaraoke/templates/queue.html
+++ b/pikaraoke/templates/queue.html
@@ -377,7 +377,7 @@
 
       $.ajax({
           url: url,
-          method: 'GET',
+          method: 'POST',
           headers: { 'X-Requested-With': 'XMLHttpRequest' }
       }).done(function(response) {
           var result = JSON.parse(response);

--- a/tests/unit/test_preference_routes.py
+++ b/tests/unit/test_preference_routes.py
@@ -52,7 +52,7 @@ class TestChangePreferencesBroadcast:
     def test_broadcasts_preferences_update_on_success(self, client, route_mocks):
         route_mocks["karaoke"].preferences.set.return_value = (True, "Success")
 
-        client.get("/change_preferences?pref=disable_bg_video&val=True")
+        client.post("/change_preferences", data={"pref": "disable_bg_video", "val": "True"})
 
         route_mocks["broadcast"].assert_any_call(
             "preferences_update", {"key": "disable_bg_video", "value": "True"}
@@ -61,7 +61,7 @@ class TestChangePreferencesBroadcast:
     def test_does_not_broadcast_on_failure(self, client, route_mocks):
         route_mocks["karaoke"].preferences.set.return_value = (False, "Error")
 
-        client.get("/change_preferences?pref=volume&val=0.5")
+        client.post("/change_preferences", data={"pref": "volume", "val": "0.5"})
 
         route_mocks["broadcast"].assert_not_called()
 
@@ -69,7 +69,7 @@ class TestChangePreferencesBroadcast:
         route_mocks["karaoke"].preferences.set.return_value = (True, "Success")
         route_mocks["phrases"].return_value = {"low": ["Bad"], "mid": ["OK"], "high": ["Great"]}
 
-        client.get("/change_preferences?pref=low_score_phrases&val=Bad")
+        client.post("/change_preferences", data={"pref": "low_score_phrases", "val": "Bad"})
 
         assert route_mocks["broadcast"].call_count == 2
         route_mocks["broadcast"].assert_any_call(
@@ -82,7 +82,7 @@ class TestChangePreferencesBroadcast:
     def test_non_score_pref_does_not_broadcast_score_phrases(self, client, route_mocks):
         route_mocks["karaoke"].preferences.set.return_value = (True, "Success")
 
-        client.get("/change_preferences?pref=hide_overlay&val=True")
+        client.post("/change_preferences", data={"pref": "hide_overlay", "val": "True"})
 
         assert route_mocks["broadcast"].call_count == 1
         route_mocks["broadcast"].assert_called_once_with(
@@ -97,7 +97,7 @@ class TestClearPreferencesBroadcast:
         route_mocks["karaoke"].preferences.reset_all.return_value = (True, "Success")
         route_mocks["phrases"].return_value = {"low": ["L"], "mid": ["M"], "high": ["H"]}
 
-        client.get("/clear_preferences", follow_redirects=False)
+        client.post("/clear_preferences", follow_redirects=False)
 
         route_mocks["broadcast"].assert_any_call("preferences_reset", PreferenceManager.DEFAULTS)
         route_mocks["broadcast"].assert_any_call(
@@ -107,6 +107,6 @@ class TestClearPreferencesBroadcast:
     def test_does_not_broadcast_on_reset_failure(self, client, route_mocks):
         route_mocks["karaoke"].preferences.reset_all.return_value = (False, "Error")
 
-        client.get("/clear_preferences", follow_redirects=False)
+        client.post("/clear_preferences", follow_redirects=False)
 
         route_mocks["broadcast"].assert_not_called()

--- a/tests/unit/test_queue_reorder.py
+++ b/tests/unit/test_queue_reorder.py
@@ -83,7 +83,7 @@ class TestQueueReorderSocketUpdates:
         queue_with_events.song_manager.display_name_from_path.return_value = "song2"
         mock_get_instance.return_value = queue_with_events
 
-        response = client.get("/queue/edit?action=top&song=song2")
+        response = client.post("/queue/edit?action=top&song=song2")
 
         assert response.status_code == 302
         queue_with_events.update_now_playing_socket.assert_called_once()
@@ -104,7 +104,7 @@ class TestQueueReorderSocketUpdates:
         queue_with_events.song_manager.display_name_from_path.return_value = "song1"
         mock_get_instance.return_value = queue_with_events
 
-        response = client.get("/queue/edit?action=bottom&song=song1")
+        response = client.post("/queue/edit?action=bottom&song=song1")
 
         assert response.status_code == 302
         queue_with_events.update_now_playing_socket.assert_called_once()

--- a/tests/unit/test_queue_routes.py
+++ b/tests/unit/test_queue_routes.py
@@ -198,7 +198,7 @@ class TestQueueEditSocketUpdates:
         qm.queue = [_make_queue_item(1), _make_queue_item(2)]
         mock_get_instance.return_value = mock_karaoke
 
-        response = client_with_session.get(f"/queue/edit?action={action}{song_param}")
+        response = client_with_session.post(f"/queue/edit?action={action}{song_param}")
 
         assert response.status_code == 302
         assert len(queue_updates) >= 1, "queue_update event should be emitted"
@@ -230,7 +230,7 @@ class TestQueueEditSocketUpdates:
         qm.queue = [_make_queue_item(1), _make_queue_item(2), _make_queue_item(3)]
         mock_get_instance.return_value = mock_karaoke
 
-        response = client_with_session.get(f"/queue/edit?action={action}{song_param}")
+        response = client_with_session.post(f"/queue/edit?action={action}{song_param}")
 
         assert response.status_code == 302
         assert qm.queue[expected_new_index]["file"] in song_param.split("=")[1]

--- a/tests/unit/test_state_changing_methods.py
+++ b/tests/unit/test_state_changing_methods.py
@@ -1,0 +1,53 @@
+"""The host-only routes that change state must not answer GET.
+
+SameSite=Lax still attaches the admin cookie to a top-level GET navigation, so
+a route that mutates on GET can be fired by a link on any page the host visits.
+"""
+
+import pytest
+import werkzeug
+from flask import Flask
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3.0.0"
+
+from pikaraoke.routes.admin import admin_bp
+from pikaraoke.routes.files import files_bp
+from pikaraoke.routes.preferences import preferences_bp
+from pikaraoke.routes.queue import queue_bp
+
+STATE_CHANGING_ENDPOINTS = {
+    "admin.update_ytdl",
+    "admin.sync_library",
+    "admin.quit",
+    "admin.shutdown",
+    "admin.reboot",
+    "admin.expand_fs",
+    "preferences.change_preferences",
+    "preferences.clear_preferences",
+    "files.delete_file",
+    "queue.add_random",
+    "queue.queue_edit",
+}
+
+
+@pytest.fixture
+def url_map():
+    app = Flask(__name__)
+    for blueprint in (admin_bp, files_bp, preferences_bp, queue_bp):
+        app.register_blueprint(blueprint)
+    return app.url_map
+
+
+def test_every_listed_endpoint_is_registered(url_map):
+    registered = {rule.endpoint for rule in url_map.iter_rules()}
+    assert STATE_CHANGING_ENDPOINTS <= registered
+
+
+@pytest.mark.parametrize("endpoint", sorted(STATE_CHANGING_ENDPOINTS))
+def test_state_changing_route_rejects_get(url_map, endpoint):
+    methods = {
+        m for rule in url_map.iter_rules() if rule.endpoint == endpoint for m in rule.methods
+    }
+    assert "GET" not in methods
+    assert "POST" in methods


### PR DESCRIPTION
Eleven host-only routes change state on `GET`, so firing them cross-site needs no form and no script. A link on any page the host visits is enough — the browser attaches the admin cookie itself, and `<a href="http://pikaraoke.local:5555/shutdown">Free karaoke tracks</a>` powers the box off.

`SameSite=Lax` does not help here: it deliberately still sends the cookie on a top-level GET navigation, which is exactly what a link is. It does not send it on a cross-site POST, so the method is the fix.

Converted: `/quit`, `/shutdown`, `/reboot`, `/expand_fs`, `/update_ytdl`, `/sync_library`, `/change_preferences`, `/clear_preferences`, `/files/delete`, `/queue/edit`, `/queue/addrandom/<n>`.

The diff is smaller than that list suggests. All six admin buttons on the info page already had a click handler doing `preventDefault` then `location.href`, so no markup moves — they call a new `postNavigate()` that submits a hidden form. A POST form action keeps its query string, so the hrefs carrying `?song=` and `?action=` are untouched, and the AJAX callers only change verb.

`change_preferences` is the one route that also moves its arguments from query to form, because both callers already hand jQuery a params object.

The public state-changing GETs (`skip`, `pause`, `volume`, `enqueue`) are deliberately open to the room, so a forged request borrows no privilege. Left alone.

The second commit deletes the `.up-button`, `.down-button` and `.confirm-delete` handlers in `spa-navigation.js` — they bind to classes no markup carries, since the queue moved into the song-options modal. Converting handlers nothing can reach seemed worse than removing them. `.confirm-delete-file` is a different class, still live, and stays.

`tests/unit/test_state_changing_methods.py` lists the eleven endpoints and asserts each answers POST and not GET, so adding a state-changing route means adding a line a reviewer sees.

Touches `routes/admin.py` alongside the SameSite PR, in a different hunk.

## Test plan

Run with `--admin-password` set and log in as admin.

- [x] Info page: Quit, Reboot, Shutdown, Expand filesystem, Update yt-dlp and Clear preferences each still confirm first, and cancelling does nothing
- [x] Info page: change a preference slider and a checkbox — the toast confirms it and the value survives a reload
- [x] Info page: Sync Now starts a scan and the button re-enables when it finishes
- [x] Queue page: add random songs, move a song to top and bottom, delete one, then Clear all
- [x] Browse page: delete a song file and land back on browse with the flash message
- [x] `http://<host>:5555/shutdown` typed into the address bar returns 405 instead of powering off the box
