### PR TITLE
refactor: group the CLI arguments in --help

### DIFF
--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -161,7 +161,7 @@ def parse_pikaraoke_args() -> argparse.Namespace:
     )
     library.add_argument(
         "--ytdl-args",
-        help="Additional arguments to pass to yt-dlp (as a single string)",
+        help='Additional arguments to pass to yt-dlp, as a single string. Attach the value with an equals sign, or its leading dashes are read as PiKaraoke arguments (Example: --ytdl-args="--sleep-requests 1.5")',
         required=False,
     )
     library.add_argument(

--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -69,11 +69,47 @@ def parse_pikaraoke_args() -> argparse.Namespace:
     Returns:
         Parsed arguments namespace with all configuration options.
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(usage="pikaraoke [OPTIONS]")
 
-    # --- Non-preference arguments (keep their own defaults) ---
+    # Arguments defaulting to None are preference-backed: PreferenceManager
+    # persists them to the config file and only overrides a stored value when
+    # the argument is actually passed. The rest are launch-only.
 
-    parser.add_argument(
+    general = parser.add_argument_group("General")
+    general.add_argument(
+        "--config-file-path",
+        help=f"Path to a config file to load settings from. CLI arguments override and persist to this file. (default: {default_config_file_path})",
+        default=default_config_file_path,
+        required=False,
+    )
+    general.add_argument(
+        "-l",
+        "--log-level",
+        help=f"Logging level int value (DEBUG: 10, INFO: 20, WARNING: 30, ERROR: 40, CRITICAL: 50). (default: {default_log_level})",
+        default=default_log_level,
+        required=False,
+    )
+    general.add_argument(
+        "--preferred-language",
+        help="Set the preferred language for the web interface. This will persist across restarts. Available codes: en, de_DE, es_VE, fi_FI, fr_FR, id_ID,it_IT, ja_JP, ko_KR, nl_NL, nb_NO, pt_BR, ru_RU, th_TH, zh_Hans_CN, zh_Hant_TW",
+        default=None,
+        required=False,
+    )
+    general.add_argument(
+        "--enable-swagger",
+        action="store_true",
+        help="Enable Swagger API documentation at /apidocs.",
+        required=False,
+    )
+    general.add_argument(
+        "--dolphly",
+        action="store_true",
+        help="Enable top-secret DOLPHLY mode.",
+        required=False,
+    )
+
+    server = parser.add_argument_group("Server and network")
+    server.add_argument(
         "-p",
         "--port",
         help=f"Desired http port (default: {default_port})",
@@ -81,7 +117,36 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         type=int,
         required=False,
     )
-    parser.add_argument(
+    server.add_argument(
+        "-u",
+        "--url",
+        help="Override the displayed IP address with a supplied URL. This argument should include port, if necessary",
+        default=None,
+        required=False,
+    )
+    server.add_argument(
+        "--base-path",
+        help="URL path prefix for reverse proxy deployments (e.g., /karaoke). Requires a reverse proxy to handle the path routing; PiKaraoke only generates correct URLs with this prefix.",
+        default="",
+        type=normalize_url_base_path,
+        required=False,
+    )
+    server.add_argument(
+        "--prefer-hostname",
+        action="store_true",
+        help=f"Use the local hostname instead of the IP as the connection URL. Use at your discretion: mDNS is not guaranteed to work on all LAN configurations. (default: {default_prefer_hostname})",
+        default=default_prefer_hostname,
+        required=False,
+    )
+    server.add_argument(
+        "--admin-password",
+        help="Administrator password, for locking down certain features of the web UI such as queue editing, player controls, song editing, and system shutdown. If unspecified, everyone is an admin.",
+        default=None,
+        required=False,
+    )
+
+    library = parser.add_argument_group("Song library and downloads")
+    library.add_argument(
         "-d",
         "--download-path",
         nargs="+",
@@ -89,146 +154,100 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         default=default_dl_dir,
         required=False,
     )
-    parser.add_argument(
+    library.add_argument(
         "--youtubedl-proxy",
         help="Proxy server to use for yt-dlp, in case blocked by a firewall",
         required=False,
     )
-    parser.add_argument(
+    library.add_argument(
         "--ytdl-args",
         help="Additional arguments to pass to yt-dlp (as a single string)",
         required=False,
     )
-    parser.add_argument(
+    library.add_argument(
         "--skip-youtubedl-upgrade",
         "--skip-ytdl-upgrade",
         action="store_true",
         help="Skip automatic yt-dlp upgrade check on startup.",
         required=False,
     )
-    parser.add_argument(
-        "-l",
-        "--log-level",
-        help=f"Logging level int value (DEBUG: 10, INFO: 20, WARNING: 30, ERROR: 40, CRITICAL: 50). (default: {default_log_level})",
-        default=default_log_level,
-        required=False,
-    )
-    parser.add_argument(
-        "--prefer-hostname",
+    library.add_argument(
+        "--high-quality",
         action="store_true",
-        help=f"Use the local hostname instead of the IP as the connection URL. Use at your discretion: mDNS is not guaranteed to work on all LAN configurations. (default: {default_prefer_hostname})",
-        default=default_prefer_hostname,
+        help="Download higher quality video. May cause CPU, download speed, and other performance issues",
         required=False,
     )
-    parser.add_argument(
+    library.add_argument(
+        "--enable-folder-browsing",
+        action="store_true",
+        help="Let users browse the song library by the folders it is stored in. Adds a Folders view to the Songs page when the library has subdirectories.",
+        required=False,
+    )
+
+    splash = parser.add_argument_group("Splash screen")
+    splash.add_argument(
         "--hide-splash-screen",
         "--headless",
         action="store_true",
         help="Headless mode. Don't launch the splash screen/player on the pikaraoke server",
         required=False,
     )
-    parser.add_argument(
-        "--keep-awake",
-        action="store_true",
-        help="Prevent the host machine from sleeping while PiKaraoke is running. Especially useful when headless, where no local player window keeps the system awake.",
+    splash.add_argument(
+        "--window-size",
+        help="Desired window geometry in pixels for headed mode, specified as width,height (Example: --window-size 800,600). Only works on Chromium browsers. Disables kiosk fullscreen mode. This can be used to open a windowed mode splash screen and move it to an external monitor where it can be fullscreened from the menu or a keyboard shortcut (F11 key, or control+cmd+f on Mac).",
+        default=0,
         required=False,
     )
-    parser.add_argument(
+    splash.add_argument(
+        "--external-monitor",
+        action="store_true",
+        help="Experimental: Launch the splash screen on an external monitor by positioning window at x=2000. Useful for dual-monitor setups. Only works on Chromium browsers and possibly only windows.",
+        required=False,
+    )
+    splash.add_argument(
         "--logo-path",
         nargs="+",
         help="Path to a custom logo image file for the splash screen. Recommended dimensions ~ 2048x1024px",
         default=None,
         required=False,
     )
-    parser.add_argument(
-        "-u",
-        "--url",
-        help="Override the displayed IP address with a supplied URL. This argument should include port, if necessary",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "--base-path",
-        help="URL path prefix for reverse proxy deployments (e.g., /karaoke). Requires a reverse proxy to handle the path routing; PiKaraoke only generates correct URLs with this prefix.",
-        default="",
-        type=normalize_url_base_path,
-        required=False,
-    )
-    parser.add_argument(
-        "--window-size",
-        help="Desired window geometry in pixels for headed mode, specified as width,height (Example: --window-size 800,600). Only works on Chromium browsers. Disables kiosk fullscreen mode. This can be used to open a windowed mode splash screen and move it to an external monitor where it can be fullscreened from the menu or a keyboard shortcut (F11 key, or control+cmd+f on Mac).",
-        default=0,
-        required=False,
-    )
-    parser.add_argument(
-        "--external-monitor",
+    splash.add_argument(
+        "--hide-url",
         action="store_true",
-        help="Experimental: Launch the splash screen on an external monitor by positioning window at x=2000. Useful for dual-monitor setups. Only works on Chromium browsers and possibly only windows.",
+        help="Hide URL and QR code from the splash screen.",
         required=False,
     )
-    parser.add_argument(
-        "--admin-password",
-        help="Administrator password, for locking down certain features of the web UI such as queue editing, player controls, song editing, and system shutdown. If unspecified, everyone is an admin.",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "--bg-music-path",
-        nargs="+",
-        help="Path to a custom directory for the splash screen background music. Directory must contain mp3 files which will be randomized in a playlist.",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "--bg-video-path",
-        nargs="+",
-        help="Path to a background video mp4 file. Will play in the background of the splash screen.",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "--config-file-path",
-        help=f"Path to a config file to load settings from. CLI arguments override and persist to this file. (default: {default_config_file_path})",
-        default=default_config_file_path,
-        required=False,
-    )
-    parser.add_argument(
-        "--preferred-language",
-        help="Set the preferred language for the web interface. This will persist across restarts. Available codes: en, de_DE, es_VE, fi_FI, fr_FR, id_ID,it_IT, ja_JP, ko_KR, nl_NL, nb_NO, pt_BR, ru_RU, th_TH, zh_Hans_CN, zh_Hant_TW",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "--enable-swagger",
+    splash.add_argument(
+        "--hide-session-name",
         action="store_true",
-        help="Enable Swagger API documentation at /apidocs.",
+        help="Hide the karaoke session name shown under the splash screen logo.",
         required=False,
     )
-    parser.add_argument(
-        "--streaming-format",
-        help=f"Video streaming format: 'hls' (HLS with fMP4 segments) or 'mp4' (pushes mp4 directly to the browser - legacy format that might work better on some configurations). (default: {default_streaming_format})",
-        choices=["hls", "mp4"],
-        default=default_streaming_format,
-        required=False,
-    )
-
-    # --- Preference arguments (default=None, use PreferenceManager.DEFAULTS for help text) ---
-
-    parser.add_argument(
-        "-v",
-        "--volume",
-        help=f"Set initial player volume. A value between 0 and 1. (default: {_DEFAULTS['volume']})",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "-n",
-        "--normalize-audio",
-        help="Normalize volume. May cause performance issues on slower devices",
+    splash.add_argument(
+        "--hide-logo",
         action="store_true",
+        help="Hide the logo in the centre of the splash screen.",
         required=False,
     )
-    parser.add_argument(
+    splash.add_argument(
+        "--hide-overlay",
+        action="store_true",
+        help="Hide all overlays that show on top of video, including current/next song, pikaraoke QR code and IP",
+        required=False,
+    )
+    splash.add_argument(
+        "--hide-notifications",
+        action="store_true",
+        help="Hide notifications from the splash screen.",
+        required=False,
+    )
+    splash.add_argument(
+        "--show-splash-clock",
+        action="store_true",
+        help="Show the digital clock on the splash screen.",
+        required=False,
+    )
+    splash.add_argument(
         "-s",
         "--splash-delay",
         help=f"Delay during splash screen between songs (in secs). (default: {_DEFAULTS['splash_delay']})",
@@ -236,7 +255,7 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         type=int,
         required=False,
     )
-    parser.add_argument(
+    splash.add_argument(
         "-t",
         "--screensaver-timeout",
         help=f"Delay before the screensaver begins (in secs). Set to 0 to disable screensaver. (default: {_DEFAULTS['screensaver_timeout']})",
@@ -244,56 +263,70 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         type=int,
         required=False,
     )
-    parser.add_argument(
-        "--hide-url",
+    splash.add_argument(
+        "--keep-awake",
         action="store_true",
-        help="Hide URL and QR code from the splash screen.",
+        help="Prevent the host machine from sleeping while PiKaraoke is running. Especially useful when headless, where no local player window keeps the system awake.",
         required=False,
     )
-    parser.add_argument(
-        "--hide-session-name",
-        action="store_true",
-        help="Hide the karaoke session name shown under the splash screen logo.",
+
+    background = parser.add_argument_group("Background music and video")
+    background.add_argument(
+        "--bg-music-path",
+        nargs="+",
+        help="Path to a custom directory for the splash screen background music. Directory must contain mp3 files which will be randomized in a playlist.",
+        default=None,
         required=False,
     )
-    parser.add_argument(
-        "--hide-logo",
-        action="store_true",
-        help="Hide the logo in the centre of the splash screen.",
+    background.add_argument(
+        "--bg-video-path",
+        nargs="+",
+        help="Path to a background video mp4 file. Will play in the background of the splash screen.",
+        default=None,
         required=False,
     )
-    parser.add_argument(
-        "--hide-overlay",
+    background.add_argument(
+        "--disable-bg-music",
         action="store_true",
-        help="Hide all overlays that show on top of video, including current/next song, pikaraoke QR code and IP",
+        help="Disable background music on splash screen",
         required=False,
     )
-    parser.add_argument(
-        "--hide-notifications",
+    background.add_argument(
+        "--disable-bg-video",
         action="store_true",
-        help="Hide notifications from the splash screen.",
+        help="Disable background video on splash screen",
         required=False,
     )
-    parser.add_argument(
-        "--show-splash-clock",
-        action="store_true",
-        help="Show the digital clock on the splash screen.",
+    background.add_argument(
+        "--bg-music-volume",
+        help=f"Set the volume of background music on splash screen. A value between 0 and 1. (default: {_DEFAULTS['bg_music_volume']})",
+        default=None,
         required=False,
     )
-    parser.add_argument(
-        "--high-quality",
-        action="store_true",
-        help="Download higher quality video. May cause CPU, download speed, and other performance issues",
+
+    playback = parser.add_argument_group("Playback and audio")
+    playback.add_argument(
+        "-v",
+        "--volume",
+        help=f"Set initial player volume. A value between 0 and 1. (default: {_DEFAULTS['volume']})",
+        default=None,
         required=False,
     )
-    parser.add_argument(
+    playback.add_argument(
+        "-n",
+        "--normalize-audio",
+        help="Normalize volume. May cause performance issues on slower devices",
+        action="store_true",
+        required=False,
+    )
+    playback.add_argument(
         "-c",
         "--complete-transcode-before-play",
         action="store_true",
         help="Wait for ffmpeg video transcoding to fully complete before playback begins. Transcoding occurs when you have normalization on, play a cdg file, or change key. May improve performance and browser compatibility (Safari, Firefox), but will significantly increase the delay before playback begins. On modern hardware, the delay is likely negligible.",
         required=False,
     )
-    parser.add_argument(
+    playback.add_argument(
         "-b",
         "--buffer-size",
         help=f"Buffer size for transcoded video (in kilobytes). Increase if you experience songs cutting off early. Higher size will transcode more of the file before streaming it to the client. This will increase the delay before playback begins. This value is ignored if --complete-transcode-before-play was specified. (default: {_DEFAULTS['buffer_size']})",
@@ -301,64 +334,43 @@ def parse_pikaraoke_args() -> argparse.Namespace:
         type=int,
         required=False,
     )
-    parser.add_argument(
-        "--disable-bg-music",
-        action="store_true",
-        help="Disable background music on splash screen",
-        required=False,
-    )
-    parser.add_argument(
-        "--bg-music-volume",
-        help=f"Set the volume of background music on splash screen. A value between 0 and 1. (default: {_DEFAULTS['bg_music_volume']})",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "--disable-bg-video",
-        action="store_true",
-        help="Disable background video on splash screen",
-        required=False,
-    )
-    parser.add_argument(
-        "--disable-score",
-        help="Disable the score screen after each song",
-        action="store_true",
-        required=False,
-    )
-    parser.add_argument(
-        "--limit-user-songs-by",
-        help=f"Limit the number of songs a user can add to queue. User name 'Pikaraoke' is always unlimited (default: {_DEFAULTS['limit_user_songs_by']} = unlimited)",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
+    playback.add_argument(
         "--avsync",
         help=f"Use avsync (in seconds) if the audio and video streams are out of sync. (negative = advances audio | positive = delays audio) (default: {_DEFAULTS['avsync']})",
         default=None,
         required=False,
     )
-    parser.add_argument(
+    playback.add_argument(
         "--cdg-pixel-scaling",
         help="Enable CDG pixel scaling to improve video rendering of CDG files. This may increase CPU usage and may cause performance issues on slower devices.",
         action="store_true",
         required=False,
     )
-    parser.add_argument(
-        "--enable-folder-browsing",
-        action="store_true",
-        help="Let users browse the song library by the folders it is stored in. Adds a Folders view to the Songs page when the library has subdirectories.",
+    playback.add_argument(
+        "--streaming-format",
+        help=f"Video streaming format: 'hls' (HLS with fMP4 segments) or 'mp4' (pushes mp4 directly to the browser - legacy format that might work better on some configurations). (default: {default_streaming_format})",
+        choices=["hls", "mp4"],
+        default=default_streaming_format,
         required=False,
     )
-    parser.add_argument(
+    playback.add_argument(
         "--enable-mic-passthrough",
         action="store_true",
         help="Enable experimental server-side microphone passthrough so singers can hear themselves through the karaoke speakers.",
         required=False,
     )
-    parser.add_argument(
-        "--dolphly",
+
+    queue = parser.add_argument_group("Queue")
+    queue.add_argument(
+        "--limit-user-songs-by",
+        help=f"Limit the number of songs a user can add to queue. User name 'Pikaraoke' is always unlimited (default: {_DEFAULTS['limit_user_songs_by']} = unlimited)",
+        default=None,
+        required=False,
+    )
+    queue.add_argument(
+        "--disable-score",
+        help="Disable the score screen after each song",
         action="store_true",
-        help="Enable top-secret DOLPHLY mode.",
         required=False,
     )
 


### PR DESCRIPTION
`pikaraoke --help` was 166 lines: a usage blob listing all 44 flags before describing any of them, then the whole lot under one `options:` heading. Hard to find anything in.

They now sit in seven groups — General, Server and network, Song library and downloads, Splash screen, Background music and video, Playback and audio, Queue — and the usage line is just `pikaraoke [OPTIONS]`.

Nothing about parsing changes. `add_argument_group()` only affects how the help is printed, and I diffed the parsed `Namespace` across nine sample command lines before and after to be sure.

The second commit fixes the `--ytdl-args` help. `--ytdl-args --no-cache-dir` fails with `expected one argument`, because argparse reads the dashes as another PiKaraoke flag — and quoting doesn't help, since the shell strips the quotes first. Only `--ytdl-args="..."` works, so the help now says so.

## Test plan

- [x] `--help` shows a one-line usage and seven headings, every flag listed once
- [x] Flags from different groups still work: `pikaraoke -p 8080 --headless --hide-url --volume 0.5`
- [x] `pikaraoke --ytdl-args="--sleep-requests 1.5" -l 10` downloads a song, with that argument in the logged yt-dlp command
