### PR TITLE
fix: put the download bar on one honest scale

### DIFF
--- a/pikaraoke/lib/download_manager.py
+++ b/pikaraoke/lib/download_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import subprocess
 import uuid
 from queue import Queue
@@ -17,6 +16,9 @@ from pikaraoke.lib.preference_manager import PreferenceManager
 from pikaraoke.lib.queue_manager import QueueManager
 from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.lib.youtube_dl import (
+    POSTPROCESS_PREFIX,
+    PROGRESS_PREFIX,
+    SIZE_PREFIX,
     build_ytdl_download_command,
     get_youtube_id_from_url,
 )
@@ -25,6 +27,41 @@ from pikaraoke.lib.youtube_dl import (
 # regardless of the format selected, and re-extracting from scratch is the only known
 # remedy. At that rate three attempts would still leave one download in eight failing.
 MAX_DOWNLOAD_ATTEMPTS = 5
+
+# The bar is one 0-100 scale of downloaded bytes; the video and audio passes are bands
+# on it. Seam between them until the real sizes arrive.
+_FALLBACK_VIDEO_END = 90.0
+
+
+def _selects_separate_streams(cmd: list[str]) -> bool:
+    """True when the format selector downloads video and audio as separate passes.
+
+    Read off the selector, not the high_quality preference, which only caps resolution.
+    """
+    try:
+        selector = cmd[cmd.index("-f") + 1]
+    except (ValueError, IndexError):
+        return False
+    return "+" in selector.split("/")[0]
+
+
+def _video_band_end(line: str, fallback: float) -> float:
+    """Place the video/audio seam by the formats' real sizes, e.g. "[12577843, 4205572]".
+
+    Progress lines only ever see their own pass, so this is the only whole-job figure.
+    """
+    try:
+        sizes = [int(n) for n in line[len(SIZE_PREFIX) :].strip().strip("[]").split(",")]
+    except ValueError:
+        return fallback
+    if len(sizes) != 2 or not sum(sizes):
+        return fallback
+    return round(100 * sizes[0] / sum(sizes), 1)
+
+
+# The progress templates share the stream yt-dlp's prose goes to, so a download killed
+# mid-transfer ends on one of these. They carry no diagnosis a person can read.
+_TEMPLATED_PREFIXES = (PROGRESS_PREFIX, POSTPROCESS_PREFIX, SIZE_PREFIX)
 
 
 def _summarise_ytdl_failure(output: str) -> str:
@@ -38,7 +75,11 @@ def _summarise_ytdl_failure(output: str) -> str:
         stripped = line.strip()
         if stripped.startswith("ERROR:"):
             return stripped.removeprefix("ERROR:").strip()
-    tail = [line.strip() for line in output.splitlines() if line.strip()]
+    tail = [
+        stripped
+        for line in output.splitlines()
+        if (stripped := line.strip()) and not stripped.startswith(_TEMPLATED_PREFIXES)
+    ]
     return tail[-1] if tail else "Unknown error"
 
 
@@ -281,12 +322,7 @@ class DownloadManager:
         _use_spare_capacity(process)
 
         output_buffer = []
-
-        # Regex to parse progress from yt-dlp stdout
-        # Example: [download]   0.0% of    4.62MiB at  396.66KiB/s ETA 00:12
-        progress_regex = re.compile(
-            r"\[download\]\s+(\d+\.?\d*)%\s+of\s+.*?\s+at\s+([^\s]+)\s+ETA\s+([^\s]+)"
-        )
+        video_end = _FALLBACK_VIDEO_END if _selects_separate_streams(cmd) else 100.0
 
         while True:
             line = process.stdout.readline()
@@ -294,12 +330,10 @@ class DownloadManager:
                 break
             if line:
                 output_buffer.append(line)
-                match = progress_regex.search(line)
-                if match and self.active_download:
-                    self.active_download["progress"] = float(match.group(1))
-                    self.active_download["status"] = "downloading"
-                    self.active_download["speed"] = match.group(2)
-                    self.active_download["eta"] = match.group(3)
+                if line.startswith(SIZE_PREFIX):
+                    video_end = _video_band_end(line, video_end)
+                else:
+                    self._apply_progress_line(line, video_end)
 
         rc = process.poll()
         output = "".join(output_buffer)
@@ -308,6 +342,42 @@ class DownloadManager:
             # so the winning attempt's output has to be kept as well.
             logging.debug(f"yt-dlp output: {output}")
         return rc, output
+
+    def _apply_progress_line(self, line: str, video_end: float) -> None:
+        """Fold one templated yt-dlp progress line into active_download."""
+        if not self.active_download:
+            return
+
+        if line.startswith(POSTPROCESS_PREFIX):
+            if line[len(POSTPROCESS_PREFIX) :].strip() == "Merger":
+                # Every byte is down; the last speed and ETA describe nothing by then.
+                self.active_download["progress"] = 100.0
+                self.active_download["status"] = "merging"
+                self.active_download["speed"] = "---"
+                self.active_download["eta"] = "--:--"
+            return
+
+        if not line.startswith(PROGRESS_PREFIX):
+            return
+        fields = line[len(PROGRESS_PREFIX) :].strip().split("|")
+        if len(fields) != 4:
+            return
+
+        percent_str, speed, eta, vcodec = (field.strip() for field in fields)
+        audio_pass = vcodec == "none"
+        self.active_download["status"] = "downloading audio" if audio_pass else "downloading"
+        self.active_download["speed"] = speed
+        self.active_download["eta"] = eta
+
+        try:
+            percent = float(percent_str.rstrip("%"))
+        except ValueError:
+            return  # "Unknown%": hold the last real percentage rather than reset the bar
+        if audio_pass:
+            start, span = video_end, 100.0 - video_end
+        else:
+            start, span = 0.0, video_end
+        self.active_download["progress"] = round(start + percent / 100 * span, 1)
 
     def _requeue(self, request: dict) -> bool:
         """Put a failed download back at the end of the queue.

--- a/pikaraoke/lib/download_manager.py
+++ b/pikaraoke/lib/download_manager.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 import uuid
 from queue import Queue
+from time import monotonic
 
 import psutil
 from gevent import Greenlet, spawn
@@ -31,6 +32,14 @@ MAX_DOWNLOAD_ATTEMPTS = 5
 # The bar is one 0-100 scale of downloaded bytes; the video and audio passes are bands
 # on it. Seam between them until the real sizes arrive.
 _FALLBACK_VIDEO_END = 90.0
+
+# A speed and an ETA describe the instant yt-dlp printed them. Between the two passes of
+# a "+" selector nothing is printed for as long as the next connection takes to open, and
+# the last pair goes on claiming a transfer that has already stopped.
+STALE_PROGRESS_SECONDS = 1.5
+
+# The only statuses that carry a rate, and so the only ones that can go stale.
+_RATE_BEARING_STATUSES = ("downloading", "downloading audio")
 
 
 def _selects_separate_streams(cmd: list[str]) -> bool:
@@ -164,11 +173,26 @@ class DownloadManager:
             Dict containing 'active' download info and list of 'pending' downloads.
         """
         return {
-            "active": self.active_download,
+            "active": self._active_download_status(),
             "pending": self.pending_downloads,
             "errors": self.download_errors,
             "max_attempts": MAX_DOWNLOAD_ATTEMPTS,
         }
+
+    def _active_download_status(self) -> dict | None:
+        """The active download as the UI reads it, with an expired rate marked stale.
+
+        The byte count behind the bar stays true through a silence; the speed and the
+        ETA do not, so the panel needs to know which of the two it is holding.
+        """
+        if not self.active_download:
+            return None
+        printed_at = self.active_download.get("progress_at")
+        active = {key: value for key, value in self.active_download.items() if key != "progress_at"}
+        active["stalled"] = self.active_download["status"] in _RATE_BEARING_STATUSES and (
+            printed_at is None or monotonic() - printed_at > STALE_PROGRESS_SECONDS
+        )
+        return active
 
     def remove_error(self, error_id: str) -> bool:
         """Remove an error from the list by ID.
@@ -368,6 +392,7 @@ class DownloadManager:
         self.active_download["status"] = "downloading audio" if audio_pass else "downloading"
         self.active_download["speed"] = speed
         self.active_download["eta"] = eta
+        self.active_download["progress_at"] = monotonic()
 
         try:
             percent = float(percent_str.rstrip("%"))
@@ -397,6 +422,9 @@ class DownloadManager:
             self.active_download["progress"] = 0.0
             self.active_download["status"] = "retrying"
             self.active_download["attempts"] = attempts
+            # The dead attempt's last speed and ETA describe nothing once it has stopped.
+            self.active_download["speed"] = "---"
+            self.active_download["eta"] = "--:--"
 
         self.download_queue.put(request)
         self.pending_downloads.append(request)

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -131,6 +131,22 @@ def upgrade_youtubedl() -> str:
     return youtubedl_version
 
 
+# Prefixes on the lines the templates below produce, read back by DownloadManager.
+PROGRESS_PREFIX = "[pk]|"
+POSTPROCESS_PREFIX = "[pk-post]|"
+SIZE_PREFIX = "[pk-size]|"
+
+# Pipe-delimited: speed and ETA render as "Unknown B/s" when yt-dlp has no estimate, so
+# whitespace splitting breaks exactly when the download is struggling.
+_DOWNLOAD_PROGRESS_TEMPLATE = (
+    f"download:{PROGRESS_PREFIX}%(progress._percent_str)s|%(progress._speed_str)s"
+    "|%(progress._eta_str)s|%(info.vcodec)s"
+)
+_POSTPROCESS_PROGRESS_TEMPLATE = f"postprocess:{POSTPROCESS_PREFIX}%(progress.postprocessor)s"
+# Both formats' sizes, emitted once before the first byte.
+_SIZE_PRINT_TEMPLATE = f"before_dl:{SIZE_PREFIX}%(requested_formats.:.filesize,filesize_approx)s"
+
+
 def build_ytdl_download_command(
     video_url: str,
     download_path: str,
@@ -166,6 +182,15 @@ def build_ytdl_download_command(
     args = [
         "-f",
         file_quality,
+        "--newline",
+        "--progress-template",
+        _DOWNLOAD_PROGRESS_TEMPLATE,
+        "--progress-template",
+        _POSTPROCESS_PROGRESS_TEMPLATE,
+        "--print",
+        _SIZE_PRINT_TEMPLATE,
+        # --print implies --quiet, which would silence the progress lines above.
+        "--no-quiet",
         "-o",
         dl_path,
         "-S",

--- a/pikaraoke/static/bulma-dark.css
+++ b/pikaraoke/static/bulma-dark.css
@@ -645,25 +645,6 @@ hr {
 }
 
 /* ===================================
-   PROGRESS BAR
-   =================================== */
-.progress {
-	border-radius: 290486px;
-}
-
-.progress::-webkit-progress-bar {
-	background-color: var(--dark-bg-tertiary);
-}
-
-.progress::-webkit-progress-value {
-	background-color: var(--dark-text-light);
-}
-
-.progress::-moz-progress-bar {
-	background-color: var(--dark-text-light);
-}
-
-/* ===================================
    PAGINATION
    =================================== */
 .pagination-previous,

--- a/pikaraoke/static/custom.css
+++ b/pikaraoke/static/custom.css
@@ -267,3 +267,49 @@ body.hide-cursor * {
   align-items: center;
   margin-top: 10px;
 }
+
+/* A div, not <progress>, so the fill can transition; the duration matches the poll. */
+.dl-bar {
+  background-color: var(--dark-bg-tertiary);
+  border-radius: 290486px;
+  height: 1rem;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.dl-bar-fill {
+  background-color: var(--dark-text-light);
+  border-radius: inherit;
+  height: 100%;
+  position: relative;
+  transition: width 500ms linear;
+  width: 0;
+}
+
+/* The resolve and the merge report no percentage, so a highlight travels instead of a
+   number advancing. It rides the empty track at the start and the full fill at the end,
+   hence the opposite contrast. transform keeps the animation off the Pi's CPU. */
+.dl-bar.is-waiting::after,
+.dl-bar-fill.is-merging::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  animation: dl-sheen 1.6s linear infinite;
+}
+
+/* Grey, not white: a white sweep on the empty track would read as real fill. */
+.dl-bar.is-waiting::after {
+  background: linear-gradient(90deg, transparent, var(--dark-border-light), transparent);
+  opacity: 0.4;
+}
+
+.dl-bar-fill.is-merging::after {
+  background: linear-gradient(90deg, transparent, var(--dark-bg-tertiary), transparent);
+  opacity: 0.45;
+}
+
+@keyframes dl-sheen {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}

--- a/pikaraoke/static/custom.css
+++ b/pikaraoke/static/custom.css
@@ -270,16 +270,20 @@ body.hide-cursor * {
 
 /* A div, not <progress>, so the fill can transition; the duration matches the poll. */
 .dl-bar {
-  background-color: var(--dark-bg-tertiary);
-  border-radius: 290486px;
-  height: 1rem;
+  /* The card is .has-background-dark, which Bulma resolves to #2c303a - and
+     --dark-bg-tertiary sits at 1.17:1 against that, so the empty track was invisible
+     until the fill covered it. This blends it toward --dark-border to clear the card
+     without leaving the theme's hue line. */
+  background-color: #454f50;
+  border-radius: 999px;
+  height: 8px;
   overflow: hidden;
   position: relative;
   width: 100%;
 }
 
 .dl-bar-fill {
-  background-color: var(--dark-text-light);
+  background-color: var(--dark-link);
   border-radius: inherit;
   height: 100%;
   position: relative;
@@ -287,29 +291,84 @@ body.hide-cursor * {
   width: 0;
 }
 
-/* The resolve and the merge report no percentage, so a highlight travels instead of a
-   number advancing. It rides the empty track at the start and the full fill at the end,
-   hence the opposite contrast. transform keeps the animation off the Pi's CPU. */
+/* Whenever no percentage is arriving - the resolve, the seam between the two passes,
+   the merge - a highlight travels instead of a number advancing. It rides the empty
+   track before the first byte and the fill after it, hence the opposite contrast.
+   transform keeps the animation off the Pi's CPU. */
 .dl-bar.is-waiting::after,
-.dl-bar-fill.is-merging::after {
+.dl-bar-fill.is-waiting::after {
   content: "";
   position: absolute;
   inset: 0;
   animation: dl-sheen 1.6s linear infinite;
 }
 
-/* Grey, not white: a white sweep on the empty track would read as real fill. */
+/* Grey, not the accent: a coloured sweep on the empty track would read as real fill. */
 .dl-bar.is-waiting::after {
   background: linear-gradient(90deg, transparent, var(--dark-border-light), transparent);
-  opacity: 0.4;
+  opacity: 0.35;
 }
 
-.dl-bar-fill.is-merging::after {
-  background: linear-gradient(90deg, transparent, var(--dark-bg-tertiary), transparent);
-  opacity: 0.45;
+.dl-bar-fill.is-waiting::after {
+  background: linear-gradient(90deg, transparent, #ffffff, transparent);
+  opacity: 0.28;
 }
 
 @keyframes dl-sheen {
   0% { transform: translateX(-100%); }
   100% { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dl-bar-fill {
+    transition: none;
+  }
+
+  .dl-bar.is-waiting::after,
+  .dl-bar-fill.is-waiting::after {
+    animation: none;
+    opacity: 0.2;
+  }
+}
+
+/* Wraps, unlike the .level.is-mobile it replaces: the phase and the three figures
+   need more room than a phone gives them. The auto margin is on the phase so the
+   figures stay grouped at the right, and so the rate stays right-aligned when it
+   drops to a second line. */
+.dl-meta {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 16px;
+  justify-content: flex-end;
+  margin-top: 10px;
+  min-height: 17px;
+}
+
+.dl-phase-group {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-right: auto;
+}
+
+.dl-phase {
+  color: var(--dark-text-light);
+}
+
+/* Tabular figures and a floor on the width: without both, the percentage and the
+   speed change width on every 500 ms poll and the whole row twitches. */
+.dl-percent {
+  color: var(--dark-text-secondary);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  min-width: 3.2em;
+  text-align: right;
+}
+
+.dl-meta-rate {
+  color: var(--dark-text-muted);
+  display: flex;
+  font-variant-numeric: tabular-nums;
+  gap: 12px;
 }

--- a/pikaraoke/templates/queue.html
+++ b/pikaraoke/templates/queue.html
@@ -170,6 +170,26 @@
   }
 
 
+  // yt-dlp's status is the machine state; these are what a person reads. Only the
+  // phases that report a number carry one: the merge holds a full bar with no
+  // percentage of its own, and printing "100%" beside it read as a hang.
+  var DOWNLOAD_PHASES = {
+      // {# MSG: Download phase shown while yt-dlp resolves the video, before any bytes arrive. #}
+      'starting': { label: {{ _('Preparing') | tojson }} },
+      // {# MSG: Download phase shown while a failed download waits to start again. The attempt tag says it is a retry. #}
+      'retrying': { label: {{ _('Preparing') | tojson }} },
+      // {# MSG: Download phase shown while the video stream is transferring. #}
+      'downloading': { label: {{ _('Downloading video') | tojson }}, percent: true, rate: true },
+      // {# MSG: Download phase shown while the separate audio stream is transferring. #}
+      'downloading audio': { label: {{ _('Downloading audio') | tojson }}, percent: true, rate: true },
+      // {# MSG: Download phase shown while ffmpeg combines the downloaded video and audio. #}
+      'merging': { label: {{ _('Merging') | tojson }} },
+      // {# MSG: Download phase shown once the download has finished. #}
+      'complete': { label: {{ _('Complete') | tojson }}, percent: true }
+  };
+  // {# MSG: Tag on the active download showing which attempt is running, e.g. "Retrying 2/5". #}
+  var RETRYING_LABEL = {{ _('Retrying') | tojson }};
+
   // Download progress polling. The bar draws a reported percentage and nothing else;
   // the phases yt-dlp cannot number animate in place instead of advancing.
   window.queuePage_renderActiveDownload = function(status) {
@@ -187,13 +207,16 @@
               <div class="box mb-4 has-background-dark">
                   <h4 class="title is-5 mb-2 dl-title"></h4>
                   <div class="dl-bar"><div class="dl-bar-fill"></div></div>
-                  <div class="level is-mobile is-size-7 mt-1">
-                      <div class="level-left">
-                          <span class="level-item text-muted"><b>{{ _('Status') | forceescape }}:</b>&nbsp;<span class="dl-status"></span></span>
-                      </div>
-                      <div class="level-right">
-                          <span class="level-item"><span class="dl-percent"></span>&nbsp;&nbsp;&nbsp;<b>{{ _('Speed') | forceescape }}:</b>&nbsp;<span class="dl-speed"></span>&nbsp;&nbsp;&nbsp;<b>{{ _('ETA') | forceescape }}:</b>&nbsp;<span class="dl-eta"></span></span>
-                      </div>
+                  <div class="dl-meta is-size-7">
+                      <span class="dl-phase-group">
+                          <span class="dl-phase"></span>
+                          <span class="tag is-info is-light is-rounded dl-attempt is-hidden"></span>
+                      </span>
+                      <span class="dl-percent"></span>
+                      <span class="dl-meta-rate">
+                          <span class="dl-speed"></span>
+                          <span>{{ _('ETA') | forceescape }}&nbsp;<span class="dl-eta"></span></span>
+                      </span>
                   </div>
               </div>`;
           host.querySelector('.dl-title').textContent = d.title;
@@ -201,15 +224,30 @@
           void host.querySelector('.dl-bar-fill').offsetWidth;
       }
 
+      // An unknown status still shows everything rather than blanking the readout.
+      var phase = DOWNLOAD_PHASES[d.status] || { label: d.status, percent: true, rate: true };
+
+      // The byte count survives a silence; the rate does not. A stalled download keeps
+      // its fill and its percentage and gives up the speed and the ETA.
+      var waiting = d.stalled || d.status === 'merging';
+
       var fill = host.querySelector('.dl-bar-fill');
       fill.style.width = d.progress + '%';
-      fill.classList.toggle('is-merging', d.status === 'merging');
+      fill.classList.toggle('is-waiting', waiting);
       host.querySelector('.dl-bar').classList
           .toggle('is-waiting', d.status === 'starting' || d.status === 'retrying');
 
-      var attempt = d.attempts > 0 ? ` (${d.attempts + 1}/${status.max_attempts})` : '';
-      host.querySelector('.dl-status').textContent = d.status + attempt;
-      host.querySelector('.dl-percent').textContent = Math.round(d.progress) + '%';
+      host.querySelector('.dl-phase').textContent = phase.label;
+
+      var attempt = host.querySelector('.dl-attempt');
+      attempt.classList.toggle('is-hidden', !d.attempts);
+      attempt.textContent = `${RETRYING_LABEL} ${d.attempts + 1}/${status.max_attempts}`;
+
+      var percent = host.querySelector('.dl-percent');
+      percent.classList.toggle('is-hidden', !phase.percent);
+      percent.textContent = Math.round(d.progress) + '%';
+
+      host.querySelector('.dl-meta-rate').classList.toggle('is-hidden', !phase.rate || waiting);
       host.querySelector('.dl-speed').textContent = d.speed;
       host.querySelector('.dl-eta').textContent = d.eta;
   };
@@ -610,7 +648,7 @@
 </div>
 {% endif %}
 
-<div id="downloads-section" style="display:none; margin-top: 30px; border-top: 1px solid #dbdbdb; padding-top: 20px;">
+<div id="downloads-section" style="display:none; margin-top: 30px; border-top: 1px solid var(--dark-border); padding-top: 20px;">
     <h3 class="title is-4">{{ _('Download queue') }}</h3>
     <div id="downloads-active"></div>
     <div id="downloads-rest"></div>

--- a/pikaraoke/templates/queue.html
+++ b/pikaraoke/templates/queue.html
@@ -170,7 +170,50 @@
   }
 
 
-  // Download Progress Polling
+  // Download progress polling. The bar draws a reported percentage and nothing else;
+  // the phases yt-dlp cannot number animate in place instead of advancing.
+  window.queuePage_renderActiveDownload = function(status) {
+      var host = document.getElementById('downloads-active');
+      var d = status.active;
+      if (!d) {
+          host.innerHTML = '';
+          host.removeAttribute('data-url');
+          return;
+      }
+
+      if (host.getAttribute('data-url') !== d.url) {
+          host.setAttribute('data-url', d.url);
+          host.innerHTML = `
+              <div class="box mb-4 has-background-dark">
+                  <h4 class="title is-5 mb-2 dl-title"></h4>
+                  <div class="dl-bar"><div class="dl-bar-fill"></div></div>
+                  <div class="level is-mobile is-size-7 mt-1">
+                      <div class="level-left">
+                          <span class="level-item text-muted"><b>{{ _('Status') | forceescape }}:</b>&nbsp;<span class="dl-status"></span></span>
+                      </div>
+                      <div class="level-right">
+                          <span class="level-item"><span class="dl-percent"></span>&nbsp;&nbsp;&nbsp;<b>{{ _('Speed') | forceescape }}:</b>&nbsp;<span class="dl-speed"></span>&nbsp;&nbsp;&nbsp;<b>{{ _('ETA') | forceescape }}:</b>&nbsp;<span class="dl-eta"></span></span>
+                      </div>
+                  </div>
+              </div>`;
+          host.querySelector('.dl-title').textContent = d.title;
+          // Flush the 0% start, or the first width lands with nothing to transition from.
+          void host.querySelector('.dl-bar-fill').offsetWidth;
+      }
+
+      var fill = host.querySelector('.dl-bar-fill');
+      fill.style.width = d.progress + '%';
+      fill.classList.toggle('is-merging', d.status === 'merging');
+      host.querySelector('.dl-bar').classList
+          .toggle('is-waiting', d.status === 'starting' || d.status === 'retrying');
+
+      var attempt = d.attempts > 0 ? ` (${d.attempts + 1}/${status.max_attempts})` : '';
+      host.querySelector('.dl-status').textContent = d.status + attempt;
+      host.querySelector('.dl-percent').textContent = Math.round(d.progress) + '%';
+      host.querySelector('.dl-speed').textContent = d.speed;
+      host.querySelector('.dl-eta').textContent = d.eta;
+  };
+
   window.queuePage_getDownloads = function() {
       // Clean up existing timer if any
       if (window.downloadPollTimer) {
@@ -185,30 +228,6 @@
       $.get('{{ url_for("queue.get_current_downloads") }}', function(data) {
           var status = JSON.parse(data);
           var html = "";
-
-          if (status.active) {
-              var d = status.active;
-              var progressClass = "is-info";
-              if (d.status === 'complete') progressClass = "is-success";
-              if (d.status === 'error') progressClass = "is-danger";
-              var attempt = d.attempts > 0 ? ` (${d.attempts + 1}/${status.max_attempts})` : '';
-
-              html += `
-                  <div class="box mb-4 has-background-dark">
-                      <h4 class="title is-5 mb-2">${d.title}</h4>
-                      <!-- inline style to ensure background visibility if theme overrides it -->
-                      <progress class="progress ${progressClass}" value="${d.progress}" max="100" style="background-color: #dbdbdb;">${d.progress}%</progress>
-                      <div class="level is-mobile is-size-7 mt-1">
-                          <div class="level-left">
-                              <span class="level-item text-muted"><b>Status:</b>&nbsp;${d.status}${attempt}</span>
-                          </div>
-                          <div class="level-right">
-                              <span class="level-item"><b>Speed:</b>&nbsp;${d.speed}&nbsp;&nbsp;&nbsp;<b>ETA:</b>&nbsp;${d.eta}</span>
-                          </div>
-                      </div>
-                  </div>
-              `;
-          }
 
           if (status.pending && status.pending.length > 0) {
               html += `<div class="content"><h5 class="title is-6 mb-2">{{ _('Pending downloads') | forceescape }}</h5>`;
@@ -246,12 +265,15 @@
               html += `</div>`;
           }
 
-          if (html) {
-              $("#downloads-container").html(html);
+          // Show the section first: a card built inside display:none has no layout,
+          // so its fill would land at full width with nothing to transition from.
+          if (status.active || html) {
               $("#downloads-section").fadeIn();
           } else {
               $("#downloads-section").fadeOut();
           }
+          window.queuePage_renderActiveDownload(status);
+          $("#downloads-rest").html(html);
 
           // Continue polling only if there are active items or pending downloads
           // Error items don't need constant polling
@@ -590,7 +612,8 @@
 
 <div id="downloads-section" style="display:none; margin-top: 30px; border-top: 1px solid #dbdbdb; padding-top: 20px;">
     <h3 class="title is-4">{{ _('Download queue') }}</h3>
-    <div id="downloads-container"></div>
+    <div id="downloads-active"></div>
+    <div id="downloads-rest"></div>
 </div>
 
 {% endblock %}

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -1,11 +1,13 @@
 """Unit tests for download_manager module."""
 
+from time import monotonic
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pikaraoke.lib.download_manager import (
     MAX_DOWNLOAD_ATTEMPTS,
+    STALE_PROGRESS_SECONDS,
     DownloadManager,
     _summarise_ytdl_failure,
 )
@@ -303,6 +305,23 @@ class TestDownloadManagerRetry:
         assert download_manager.download_errors == []
         assert download_manager.download_queue.get_nowait()["attempts"] == 1
         assert len(download_manager.pending_downloads) == 1
+
+    def test_retry_clears_the_stale_rate(self, download_manager):
+        """The dead attempt's speed and ETA would otherwise sit under a bar back at zero."""
+        download_manager.active_download = {
+            "progress": 62.0,
+            "status": "downloading",
+            "speed": "2.31MiB/s",
+            "eta": "0:04",
+            "attempts": 0,
+        }
+
+        assert download_manager._requeue(make_request()) is True
+
+        assert download_manager.active_download["progress"] == 0.0
+        assert download_manager.active_download["status"] == "retrying"
+        assert download_manager.active_download["speed"] == "---"
+        assert download_manager.active_download["eta"] == "--:--"
 
     @patch("flask_babel._", side_effect=lambda x: x)
     @patch("subprocess.Popen")
@@ -622,6 +641,66 @@ class TestDownloadProgress:
         )
         assert snapshots[-1]["status"] == "starting"
         assert snapshots[-1]["progress"] == 0.0
+
+
+class TestStalledProgress:
+    """The panel must stop reporting a rate once yt-dlp stops printing one.
+
+    The seam between the video and audio passes prints nothing while the next
+    connection opens, and the bar sat there showing the finished pass's speed and ETA.
+    """
+
+    @staticmethod
+    def downloading(seconds_ago: float, status: str = "downloading") -> dict:
+        return {
+            "title": "Song",
+            "progress": 75.0,
+            "status": status,
+            "speed": "2.31MiB/s",
+            "eta": "0:04",
+            "progress_at": monotonic() - seconds_ago,
+        }
+
+    def test_a_fresh_line_is_not_stale(self, download_manager):
+        download_manager.active_download = self.downloading(0.0)
+
+        assert download_manager.get_downloads_status()["active"]["stalled"] is False
+
+    def test_silence_marks_the_rate_stale(self, download_manager):
+        download_manager.active_download = self.downloading(STALE_PROGRESS_SECONDS + 0.5)
+
+        active = download_manager.get_downloads_status()["active"]
+
+        assert active["stalled"] is True
+        # The bytes are down either way, so the bar must not give up its place.
+        assert active["progress"] == 75.0
+
+    def test_the_audio_pass_can_stall_too(self, download_manager):
+        download_manager.active_download = self.downloading(
+            STALE_PROGRESS_SECONDS + 0.5, status="downloading audio"
+        )
+
+        assert download_manager.get_downloads_status()["active"]["stalled"] is True
+
+    def test_phases_that_report_no_rate_never_stall(self, download_manager):
+        """The merge already animates in place; marking it stalled would say it twice."""
+        for status in ("starting", "retrying", "merging", "complete"):
+            download_manager.active_download = self.downloading(60.0, status=status)
+
+            assert download_manager.get_downloads_status()["active"]["stalled"] is False, status
+
+    def test_the_internal_timestamp_stays_out_of_the_payload(self, download_manager):
+        download_manager.active_download = self.downloading(0.0)
+
+        assert "progress_at" not in download_manager.get_downloads_status()["active"]
+
+    def test_a_progress_line_refreshes_the_stamp(self, download_manager):
+        """Without this every reading past the first 1.5 s would read as stalled."""
+        download_manager.active_download = self.downloading(60.0)
+
+        download_manager._apply_progress_line("[pk]| 80.0%|3.10MiB/s|0:02|avc1.640028", 100.0)
+
+        assert download_manager.get_downloads_status()["active"]["stalled"] is False
 
 
 class TestDownloadManagerStatus:

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -479,6 +479,150 @@ class TestSummariseYtdlFailure:
     def test_empty_output(self):
         assert _summarise_ytdl_failure("") == "Unknown error"
 
+    def test_fallback_skips_the_progress_templates(self):
+        """A download killed mid-transfer ends on a bar line, which names no failure."""
+        killed = (
+            "[info] abc: Downloading 1 format(s): 136+140\n"
+            "[pk-size]|[12577843, 4205572]\n"
+            "[pk]| 43.2%|Unknown B/s|Unknown ETA|avc1.640028\n"
+        )
+        assert _summarise_ytdl_failure(killed) == "[info] abc: Downloading 1 format(s): 136+140"
+
+
+class TestDownloadProgress:
+    """Tests for folding yt-dlp's templated progress lines into the bar."""
+
+    TWO_PASS_CMD = ["yt-dlp", "-f", "bestvideo[height<=1080]+bestaudio/best[ext!=webm]", "url"]
+    ONE_PASS_CMD = ["yt-dlp", "-f", "mp4", "url"]
+
+    @staticmethod
+    def progress_line(percent="50.0%", speed="1.20MiB/s", eta="00:12", vcodec="avc1.640028"):
+        """One download line in the shape the --progress-template produces."""
+        return f"[pk]|{percent}|{speed}|{eta}|{vcodec}\n"
+
+    def run_lines(self, download_manager, cmd, lines):
+        """Feed lines through _run_ytdl, snapshotting active_download after each one."""
+        download_manager.active_download = {
+            "progress": 0.0,
+            "status": "starting",
+            "speed": "---",
+            "eta": "--:--",
+        }
+        remaining = list(lines) + [""]
+        snapshots = []
+
+        def readline():
+            snapshots.append(dict(download_manager.active_download))
+            return remaining.pop(0)
+
+        process = MagicMock()
+        process.stdout.readline.side_effect = readline
+        process.poll.return_value = 0
+        with patch("subprocess.Popen", return_value=process):
+            download_manager._run_ytdl(cmd)
+        snapshots.append(dict(download_manager.active_download))
+        return snapshots
+
+    def test_two_passes_share_one_scale(self, download_manager):
+        """The audio pass resumes where the video pass stopped instead of rewinding."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            [
+                self.progress_line("0.0%"),
+                self.progress_line("100.0%"),
+                self.progress_line("0.0%", vcodec="none"),
+                self.progress_line("100.0%", vcodec="none"),
+            ],
+        )
+        progress = [snap["progress"] for snap in snapshots]
+        assert progress == sorted(progress)
+        assert 90.0 in progress and progress[-1] == 100.0
+
+    def test_single_pass_reaches_the_top_of_the_scale(self, download_manager):
+        """With no audio pass, the video runs the whole scale on its own."""
+        snapshots = self.run_lines(
+            download_manager, self.ONE_PASS_CMD, [self.progress_line("100.0%")]
+        )
+        assert snapshots[-1]["progress"] == 100.0
+
+    def test_audio_pass_is_named_by_vcodec(self, download_manager):
+        """vcodec is the discriminator, not a percentage that reset."""
+        snapshots = self.run_lines(
+            download_manager, self.TWO_PASS_CMD, [self.progress_line("50.0%", vcodec="none")]
+        )
+        assert snapshots[-1]["status"] == "downloading audio"
+        assert snapshots[-1]["progress"] == 95.0
+
+    def test_missing_estimates_survive_the_split(self, download_manager):
+        """The speed carries a space when yt-dlp is guessing, so the delimiter is a pipe."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            [self.progress_line("10.0%", speed="Unknown B/s", eta="Unknown")],
+        )
+        assert snapshots[-1]["speed"] == "Unknown B/s"
+        assert snapshots[-1]["eta"] == "Unknown"
+        assert snapshots[-1]["progress"] == 9.0
+
+    def test_unparseable_percent_holds_the_bar(self, download_manager):
+        """A percentage yt-dlp cannot compute must not drop the bar back to zero."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            [self.progress_line("50.0%"), self.progress_line("Unknown%", speed="10MiB/s")],
+        )
+        assert snapshots[-1]["progress"] == 45.0
+        assert snapshots[-1]["speed"] == "10MiB/s"
+
+    def test_merge_holds_a_full_bar(self, download_manager):
+        """Every byte is down by the merge, which reports no percentage of its own."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            [self.progress_line("50.0%", vcodec="none"), "[pk-post]|Merger\n"],
+        )
+        assert snapshots[-1]["progress"] == 100.0
+        assert snapshots[-1]["status"] == "merging"
+        assert snapshots[-1]["speed"] == "---"
+        assert snapshots[-1]["eta"] == "--:--"
+
+    def test_real_sizes_place_the_seam(self, download_manager):
+        """The formats' byte counts replace the guessed split between the passes."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            [
+                "[pk-size]|[12577843, 4205572]\n",
+                self.progress_line("100.0%"),
+                self.progress_line("100.0%", vcodec="none"),
+            ],
+        )
+        progress = [snap["progress"] for snap in snapshots]
+        # Video is 75% of 16.8MB, so the seam sits well below the 90.0 fallback.
+        assert 74.9 in progress
+        assert progress == sorted(progress)
+        assert progress[-1] == 100.0
+
+    def test_unusable_sizes_keep_the_fallback_seam(self, download_manager):
+        """A single-file download has no requested_formats, so yt-dlp prints NA."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            ["[pk-size]|NA\n", self.progress_line("100.0%")],
+        )
+        assert snapshots[-1]["progress"] == 90.0
+
+    def test_other_output_is_ignored(self, download_manager):
+        """yt-dlp's prose still flows past; only the templated lines count."""
+        snapshots = self.run_lines(
+            download_manager,
+            self.TWO_PASS_CMD,
+            ["[youtube] test123: Downloading android vr player API JSON\n"],
+        )
+        assert snapshots[-1]["status"] == "starting"
+        assert snapshots[-1]["progress"] == 0.0
+
 
 class TestDownloadManagerStatus:
     """Tests for DownloadManager.get_downloads_status method."""

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -9,6 +9,9 @@ import requests
 
 from pikaraoke.lib.youtube_dl import (
     _PREVIEW_ATTEMPTS,
+    POSTPROCESS_PREFIX,
+    PROGRESS_PREFIX,
+    SIZE_PREFIX,
     _serves_bytes,
     build_ytdl_download_command,
     get_stream_url,
@@ -145,6 +148,28 @@ class TestBuildYtdlDownloadCommand:
         tiers = cmd[cmd.index("-f") + 1].split("/")
         assert tiers[1] == f"best[ext!=webm][height<={height}]"
         assert tiers[2] == "best[ext!=webm]"
+
+    @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
+    def test_progress_templates(self, mock_js):
+        """The download panel reads these templates, not yt-dlp's prose."""
+        cmd = build_ytdl_download_command(
+            video_url="https://www.youtube.com/watch?v=test123",
+            download_path="/songs",
+        )
+        assert "--newline" in cmd
+        templates = [cmd[i + 1] for i, arg in enumerate(cmd) if arg == "--progress-template"]
+        assert len(templates) == 2
+        download, postprocess = templates
+        assert download.startswith(f"download:{PROGRESS_PREFIX}")
+        # The discriminator for which pass of a "+" selector is running.
+        assert "%(info.vcodec)s" in download
+        assert postprocess == f"postprocess:{POSTPROCESS_PREFIX}%(progress.postprocessor)s"
+        # Both formats' sizes, printed before the first byte; no progress line carries them.
+        size = cmd[cmd.index("--print") + 1]
+        assert size.startswith(f"before_dl:{SIZE_PREFIX}")
+        assert "requested_formats" in size
+        # --print implies --quiet, which silences every progress line above it.
+        assert "--no-quiet" in cmd
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_with_proxy(self, mock_js):


### PR DESCRIPTION
Last part of tidying up the changes that make downloading more robust.

A `+` format selector runs two sequential downloads, and each reported its own 0-100% into a single progress field. The bar filled, snapped back to zero, filled again, then sat at 100% for the whole ffmpeg merge. It read as a crash and a restart, and no restyling fixes it because the number itself was wrong.

Progress now arrives as data through `--progress-template` rather than being scraped from yt-dlp's prose, and `--print before_dl` gives both formats' byte counts before the first byte, so the seam between the video and audio bands is the true size ratio rather than a guess.

The bar only ever draws a percentage yt-dlp reported. The resolve and the merge report none — on a Pi the idle-priority merge runs for tens of seconds — so those animate a travelling highlight in place instead of claiming a number. The fill is a `div` rather than `<progress>` so its width can transition across the 500 ms poll, which is why `<progress>`'s `bulma-dark` rules go with it.

## Test plan

- [X] Queue a download. The bar fills once, left to right, and never snaps back at the video/audio seam.
- [X] Before the first byte and during the merge, a highlight travels in place and the status reads `starting`, then `merging`.
- [X] The bar is white on a dark track, as before.
- [X] Download with high quality off. The bar behaves the same, both settings now fetching separate streams.
- [X] Queue a dead URL. The error card names the error, not a progress line.
