### PR TITLE
fix: give headings a consistent scale and a single owner

### DIFF
--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -236,7 +236,8 @@ def _render_edit_page(k, song_path: str, new_name: str, referrer: str, error: st
     return render_template(
         "edit.html",
         site_title=get_site_name(),
-        title="Rename Song",
+        # MSG: Title of the page where a song can be renamed.
+        title=_("Rename Song"),
         song=song_path,
         # What is on disk, which on a failed save is precisely what did not change.
         raw_stem=k.song_manager.filename_from_path(song_path, tidy=False),

--- a/pikaraoke/routes/home.py
+++ b/pikaraoke/routes/home.py
@@ -20,7 +20,8 @@ def home():
     return render_template(
         "home.html",
         site_title=site_name,
-        title="Home",
+        # MSG: Title of the home page, which shows the song playing now.
+        title=_("Now Playing"),
         transpose_value=k.playback_controller.now_playing_transpose,
         admin=is_admin(),
         is_transpose_enabled=k.is_transpose_enabled,

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -40,7 +40,8 @@ def info():
     return render_template(
         "info.html",
         site_title=site_name,
-        title="Info",
+        # MSG: Title of the settings and system information page.
+        title=_("Information"),
         url=url,
         admin=is_admin(),
         admin_password=admin_password,

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -41,7 +41,7 @@ def info():
         "info.html",
         site_title=site_name,
         # MSG: Title of the settings and system information page.
-        title=_("Information"),
+        title=_("Settings"),
         url=url,
         admin=is_admin(),
         admin_password=admin_password,

--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -61,7 +61,8 @@ def queue():
         "queue.html",
         queue=k.queue_manager.queue,
         site_title=site_name,
-        title="Queue",
+        # MSG: Title of the queue page.
+        title=_("Queue"),
         admin=is_admin(),
     )
 

--- a/pikaraoke/routes/sessions.py
+++ b/pikaraoke/routes/sessions.py
@@ -75,7 +75,8 @@ def sessions():
     return render_template(
         "sessions.html",
         site_title=get_site_name(),
-        title="Sessions",
+        # MSG: Title of the session management page.
+        title=_("Sessions"),
         page_size=SESSIONS_PAGE_SIZE,
         # The API rejects anything longer, so the page enforces the same cap
         # rather than letting the host type a name that is refused on submit.
@@ -90,7 +91,8 @@ def history(query):
     return render_template(
         "history.html",
         site_title=get_site_name(),
-        title="Play History",
+        # MSG: Title of the page logging everything that has been sung.
+        title=_("Play History"),
         page_size=PLAYS_PAGE_SIZE,
         # Deleting an entry is a host action; queuing a song back up is not.
         admin=is_admin(),
@@ -111,7 +113,8 @@ def rankings(query):
     return render_template(
         "rankings.html",
         site_title=get_site_name(),
-        title="Rankings",
+        # MSG: Title of the most-played songs and most active singers page.
+        title=_("Rankings"),
         top_songs=k.play_history.get_top_songs(query["songs"], session_uuid),
         top_performers=k.play_history.get_singers(
             session_uuid, limit=query["performers"], completed_only=True

--- a/pikaraoke/static/custom.css
+++ b/pikaraoke/static/custom.css
@@ -67,6 +67,30 @@ input {
   font-size: 16px !important;
 }
 
+/* Sections step down from the page heading rather than matching it: Bulma's
+   own scale starts an h2 at 1.75em. Bold, not Bulma's 800, which the theme
+   loads no face for. */
+.content h2 {
+  font-size: 1.5em;
+}
+.content h3 {
+  font-size: 1.25em;
+}
+.content h4 {
+  font-size: 1.125em;
+}
+.content h5,
+.content h6 {
+  font-size: 1em;
+}
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+  font-weight: 700;
+}
+
 table {
   table-layout: fixed;
   width: 100%;

--- a/pikaraoke/static/custom.css
+++ b/pikaraoke/static/custom.css
@@ -91,6 +91,27 @@ input {
   font-weight: 700;
 }
 
+/* The heading row: the page title, and optionally one action held against the
+   right edge. Baseline rather than centre, so that action sits on the title's
+   own text line instead of floating halfway up it. */
+.page-header {
+  /* What .title:not(:last-child) used to give the header it replaced. */
+  margin-bottom: var(--bulma-block-spacing);
+}
+.page-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+/* Matched on .title, not h1: Bulma spaces a .title from what follows it, which
+   inside a row is height rather than space, and its selector outranks an h1
+   one. Regular weight because the sections below carry the emphasis. */
+.page-heading .title {
+  font-weight: 400;
+  margin-bottom: 0;
+}
+
 table {
   table-layout: fixed;
   width: 100%;

--- a/pikaraoke/templates/base.html
+++ b/pikaraoke/templates/base.html
@@ -543,7 +543,13 @@
     </div>
 
     <div class="box" style="margin-top: 5px;">
-      <header class="title">
+      {# Written once here rather than per page: the heading is chrome, and its
+         text is the same string the <title> tag uses. #}
+      <header class="page-header">
+        <div class="page-heading">
+          <h1 class="title">{% block heading %}{{ title }}{% endblock %}</h1>
+          {% block heading_action %}{% endblock %}
+        </div>
         {% block header %}{% endblock %}
       </header>
       <div class="content">

--- a/pikaraoke/templates/batch-song-renamer.html
+++ b/pikaraoke/templates/batch-song-renamer.html
@@ -129,8 +129,6 @@
 	});
 </script>
 
-{% endblock %} {% block header %} {# MSG: Page title for the page where the user can batch rename songs. #}
-<h1>{% block title %}{% trans %}Batch Song Renamer{% endtrans %}{% endblock %}</h1>
 {% endblock %} {% block content %} {# MSG: Message about the wait for loading the songs #}
 <p class="is-italic has-text-warning">
 	{% trans %}The loading process may take a few seconds, as the song titles are compared online. Loading time may vary

--- a/pikaraoke/templates/edit.html
+++ b/pikaraoke/templates/edit.html
@@ -94,11 +94,6 @@
 </script>
 {% endblock %}
 
-{% block header %}
-{# MSG: Page title for the page where a song can be renamed. #}
-<h1>{% block title %}{% trans %}Rename Song{% endtrans %}{% endblock %}</h1>
-{% endblock %}
-
 {% block content %}
 
 <div class="field">

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -208,20 +208,18 @@
 	});
 </script>
 
-{% endblock %} {% block header %}
-{# The admin action shares the heading's row at every width rather than floating
-   over it, so it lines up against the same right edge as the content below. #}
-<div id="songs-heading">
-	<h1>
-		{% block title %}{{title}}{% if letter %}<span id="letter-heading">: "{{ letter.upper() }}"</span>{% endif %}{% endblock %}
-	</h1>
-	{% if admin %}
-	<a class="batch-edit-btn" href="{{ url_for('batch_song_renamer.browse')}}" title="Bulk rename"
-		><i class="icon icon-edit"></i>{# MSG: Button to open the batch song renamer page. #} {% trans %}Bulk rename{%
-		endtrans %}</a
-	>
-	{% endif %}
-</div>
+{% endblock %} {% block heading %}{{ title }}{% if letter %}<span id="letter-heading">: "{{ letter.upper() }}"</span>{% endif %}{% endblock %}
+
+{% block heading_action %}
+{% if admin %}
+<a class="batch-edit-btn" href="{{ url_for('batch_song_renamer.browse')}}" title="Bulk rename"
+	><i class="icon icon-edit"></i>{# MSG: Button to open the batch song renamer page. #} {% trans %}Bulk rename{%
+	endtrans %}</a
+>
+{% endif %}
+{% endblock %}
+
+{% block header %}
 {# MSG: Subtitle under the Songs heading, explaining that this page lists songs already downloaded. #}
 <p class="subtitle is-6">{% trans %}Available in the library{% endtrans %}</p>
 <style>
@@ -259,17 +257,6 @@
 		overflow-wrap: anywhere;
 	}
 
-	#songs-heading {
-		display: flex;
-		justify-content: space-between;
-		/* Baseline, not center: the link should sit on the heading's text line
-		   rather than float halfway up a much taller h1. */
-		align-items: baseline;
-		gap: 1rem;
-	}
-	#songs-heading h1 {
-		margin-bottom: 0;
-	}
 	.batch-edit-btn {
 		font-size: 0.875rem;
 		white-space: nowrap;

--- a/pikaraoke/templates/history.html
+++ b/pikaraoke/templates/history.html
@@ -302,7 +302,6 @@
 {% endblock %}
 
 {% block header %}
-<h1>{% block title %}{{ title }}{% endblock %}</h1>
 <style>
 	.history-table th.sortable {
 		cursor: pointer;

--- a/pikaraoke/templates/home.html
+++ b/pikaraoke/templates/home.html
@@ -230,17 +230,15 @@
 		{% endif %}
 	});
 </script>
-{% endblock %} {% block header %}
-<h1>
-	{% block title %} {# MSG: Header showing the currently playing song. #} {% trans %}Now Playing{% endtrans %}
-	<img
-		style="display: none"
-		class="playing_gif control-box"
-		width="40"
-		src="{{  url_for('static', filename='images/now-playing.png') }}"
-	/>{% endblock %}
-</h1>
-{% endblock %} {% block content %}
+{% endblock %} {% block heading %}{{ title }}
+<img
+	style="display: none"
+	class="playing_gif control-box"
+	width="40"
+	src="{{  url_for('static', filename='images/now-playing.png') }}"
+/>{% endblock %}
+
+{% block content %}
 
 <p class="is-size-4 has-text-warning" id="now-playing">&nbsp;</p>
 

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -333,7 +333,7 @@
 
 	{% if not admin and admin_password != none %}
 		{# MSG: Title of the admin section. #}
-		<h1>{% trans %}Admin{% endtrans %}</h1>
+		<h2>{% trans %}Admin{% endtrans %}</h2>
 
 		<div class="card">
 			<div class="card-content">
@@ -360,7 +360,7 @@
 	{% if admin %}
 
 		{# MSG: Title of the song library section. #}
-		<h1>{% trans %}Song Library{% endtrans %}</h1>
+		<h2>{% trans %}Song Library{% endtrans %}</h2>
 
 		<div class="card">
 			<header class="card-header py-3 px-5 collapsible-header is-collapsed">
@@ -446,13 +446,13 @@
 		</div>
 
 		{# MSG: Title of the user preferences section. #}
-		<h1>{% trans %}User Preferences{% endtrans %}</h1>
+		<h2>{% trans %}User Preferences{% endtrans %}</h2>
 
 		<div class="card">
 			<header class="card-header py-3 px-5 collapsible-header is-collapsed">
 				<div class="media-content">
 					{# MSG: Title text for the splash screen settings section of preferences #}
-					<h3 class="title mb-0">{% trans %}Splash screen settings{% endtrans %}</h3>
+					<h3 class="mb-0">{% trans %}Splash screen settings{% endtrans %}</h3>
 
 				</div>
 			</header>
@@ -544,7 +544,7 @@
 
 			<header class="card-header py-3 px-5 collapsible-header is-collapsed">
 				<div class="media-content">
-					<h3 class="title mb-0">{% trans %}Audio{% endtrans %}</h3>
+					<h3 class="mb-0">{% trans %}Audio{% endtrans %}</h3>
 				</div>
 			</header>
 			<div class="card-content collapsible-content">
@@ -596,7 +596,7 @@
 			<header class="card-header py-3 px-5 collapsible-header is-collapsed">
 				<div class="media-content">
 				{# MSG: Title text for the Score Phrases section of preferences #}
-				<h3 class="title m-0">{% trans %}Score phrases{% endtrans %}</h3>
+				<h3 class="m-0">{% trans %}Score phrases{% endtrans %}</h3>
 
 			</div>
 		</header>
@@ -756,7 +756,7 @@
 		</div>
 
 		{# MSG: Title of the system data section. #}
-		<h1>{% trans %}System Data{% endtrans %}</h1>
+		<h2>{% trans %}System Data{% endtrans %}</h2>
 
 		<div class="card">
 			<header class="card-header py-3 px-5">
@@ -798,12 +798,12 @@
 		</div>
 
 		{# MSG: Title of the updates section. #}
-		<h1>{% trans %}Updates{% endtrans %}</h1>
+		<h2>{% trans %}Updates{% endtrans %}</h2>
 
 		<div class="card">
 			<header class="card-header py-3 px-5 collapsible-header is-collapsed">
 				{# MSG: Label for the YT-DLP update on the updates section #}
-				<h3 class="title mb-0">{% trans %}YT-DLP update{% endtrans %}</h3>
+				<h3 class="mb-0">{% trans %}YT-DLP update{% endtrans %}</h3>
 			</header>
 			<div class="card-content collapsible-content">
 				<div class="content">
@@ -831,12 +831,12 @@
 		{% if is_pi and not is_container %}
 
 			{# MSG: Title of the updates section. #}
-			<h1>{% trans %}Other{% endtrans %}</h1>
+			<h2>{% trans %}Other{% endtrans %}</h2>
 
 			<div class="card">
 				<header class="card-header py-3 px-5 collapsible-header is-collapsed">
 					{# MSG: Title for section containing a few other options on the Info page. #}
-					<h3 class="title mb-0">{% trans %}Expand Raspberry Pi filesystem{% endtrans %}</h3>
+					<h3 class="mb-0">{% trans %}Expand Raspberry Pi filesystem{% endtrans %}</h3>
 				</header>
 				<div class="card-content collapsible-content">
 					<div class="content">
@@ -857,7 +857,7 @@
 
 		{% if admin_password != none %}
 			{# MSG: Title of the admin section. #}
-			<h1>{% trans %}Admin{% endtrans %}</h1>
+			<h2>{% trans %}Admin{% endtrans %}</h2>
 
 			<div class="card">
 				<div class="card-content">
@@ -872,7 +872,7 @@
 		{% endif %}
 
 		{# MSG: Title of the section on shutting down / turning off the machine running Pikaraoke. #}
-		<h1>{% trans %}Shutdown{% endtrans %}</h1>
+		<h2>{% trans %}Shutdown{% endtrans %}</h2>
 
 		<div class="card">
 			<div class="card-content">

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -303,15 +303,6 @@
 	</script>
 {% endblock %}
 
-{% block header %}
-	<h1>
-		{% block title %}
-			{# MSG: Title of the information page. #}
-			{% trans %}Information{% endtrans %}
-		{% endblock %}
-	</h1>
-{% endblock %}
-
 {% block content %}
 
 	<div class="card">

--- a/pikaraoke/templates/queue.html
+++ b/pikaraoke/templates/queue.html
@@ -505,10 +505,6 @@
 
 {% endblock %}
 
-{% block header %}
-<h1 class>{% block title %}{% trans %}Queue{% endtrans %}{% endblock %}</h1>
-{% endblock %}
-
 {% block content %}
 
 <table class="table is-striped" id="auto-refresh" style="margin-bottom: 30px">

--- a/pikaraoke/templates/rankings.html
+++ b/pikaraoke/templates/rankings.html
@@ -116,7 +116,7 @@
 {% include 'partials/session_filter.html' %}
 
 {# MSG: Heading for the list of songs that have been sung the most times. #}
-<h2 class="subtitle">{% trans %}Top songs{% endtrans %}</h2>
+<h2>{% trans %}Top songs{% endtrans %}</h2>
 {% if top_songs %}
 <table class="rankings-table">
 	<colgroup>
@@ -164,7 +164,7 @@
 {% endif %}
 
 {# MSG: Heading for the list of people who have sung the most songs. #}
-<h2 class="subtitle">{% trans %}Top performers{% endtrans %}</h2>
+<h2>{% trans %}Top performers{% endtrans %}</h2>
 {% if top_performers %}
 <table class="rankings-table">
 	<colgroup>

--- a/pikaraoke/templates/rankings.html
+++ b/pikaraoke/templates/rankings.html
@@ -51,7 +51,6 @@
 {% endmacro %}
 
 {% block header %}
-<h1>{% block title %}{{ title }}{% endblock %}</h1>
 <style>
 	/* The global `table` rule already fixes the layout, which is what lines the
 	   play counts up down the page across both tables. */

--- a/pikaraoke/templates/search.html
+++ b/pikaraoke/templates/search.html
@@ -513,9 +513,6 @@
 	}
 </script>
 {% endblock %} {% block header %}
-{# Rendered from the route's title, matching files.html -- a hardcoded heading here
-   meant changing search.py only moved the browser tab text. #}
-<h1>{% block title %}{{title}}{% endblock %}</h1>
 {# MSG: Subtitle under the Add New heading, explaining that this page gets songs the machine does not have. #}
 <p class="subtitle is-6">{% trans %}Add new songs from YouTube{% endtrans %}</p>
 {% endblock %} {% block content %}

--- a/pikaraoke/templates/sessions.html
+++ b/pikaraoke/templates/sessions.html
@@ -622,7 +622,7 @@
 {% block content %}
 
 {# MSG: Heading for the section showing the session currently being recorded. #}
-<h2 class="subtitle">{% trans %}Current Session{% endtrans %}</h2>
+<h2>{% trans %}Current Session{% endtrans %}</h2>
 <div class="current-session">
 	<span class="current-session-name">
 		<i class="icon icon-mic-1"></i>
@@ -657,7 +657,7 @@
 </div>
 
 {# MSG: Heading for the list of past karaoke sessions. #}
-<h2 class="subtitle">{% trans %}Session History{% endtrans %}</h2>
+<h2>{% trans %}Session History{% endtrans %}</h2>
 
 {# Above the table it filters. Nothing sits on the left here, but the row still
    holds the checkbox to the right edge. #}

--- a/pikaraoke/templates/sessions.html
+++ b/pikaraoke/templates/sessions.html
@@ -444,7 +444,6 @@
 {% endblock %}
 
 {% block header %}
-<h1>{% block title %}{{ title }}{% endblock %}</h1>
 <style>
 	/* Flush with the table below rather than inset inside a notification box:
 	   this is the page's first line and has to line up with everything under it. */


### PR DESCRIPTION
Groundwork for UI work. Headings are now predictable, so a page can be restyled without first rediscovering why its title renders the way it does.

**Section headings outranked the page title.** Bulma's `.content` scale starts an `h2` at 1.75em/800 while the page title rendered at 2em/400, so "Top songs" read heavier than "Rankings" above it. Settings was worst: eight section headings were `<h1>`, nine on the page in total. `.content` now steps down — 24 / 20 / 18 / 16px at weight 700 — and Settings' sections are `<h2>`. Nine `class="title"` and `class="subtitle"` attributes were inert, since `.content h2` outranks `.subtitle` on specificity, and are removed rather than left to be copied.

**The page heading had no owner.** Every template wrote its own `<h1>`, wrapped in a `{% block title %}` that `base.html` never rendered. Three things were called "title" and had drifted apart: the Home tab said "Home" above a "Now Playing" heading, Settings said "Info" above "Information". `base.html` now renders the heading once from the same string the `<title>` tag uses; pages override `heading` for markup inside it, `heading_action` for one control beside it. Route titles become translatable.

Beyond type sizes, the only user-visible change is those two browser tabs now matching their headings.