### PR TITLE
fix: require POST for the playback control routes

### DIFF
--- a/pikaraoke/routes/controller.py
+++ b/pikaraoke/routes/controller.py
@@ -12,7 +12,7 @@ _ = flask_babel.gettext
 controller_bp = Blueprint("controller", __name__)
 
 
-@controller_bp.route("/skip")
+@controller_bp.route("/skip", methods=["POST"])
 def skip():
     """Skip the currently playing song."""
     k = get_karaoke_instance()
@@ -21,7 +21,7 @@ def skip():
     return redirect(url_for("home.home"))
 
 
-@controller_bp.route("/pause")
+@controller_bp.route("/pause", methods=["POST"])
 def pause():
     """Toggle pause/resume playback."""
     k = get_karaoke_instance()
@@ -33,7 +33,7 @@ def pause():
     return redirect(url_for("home.home"))
 
 
-@controller_bp.route("/transpose/<semitones>", methods=["GET"])
+@controller_bp.route("/transpose/<semitones>", methods=["POST"])
 def transpose(semitones):
     """Transpose (pitch shift) the current song."""
     k = get_karaoke_instance()
@@ -42,7 +42,7 @@ def transpose(semitones):
     return redirect(url_for("home.home"))
 
 
-@controller_bp.route("/restart")
+@controller_bp.route("/restart", methods=["POST"])
 def restart():
     """Restart the current song from the beginning."""
     k = get_karaoke_instance()
@@ -51,7 +51,7 @@ def restart():
     return redirect(url_for("home.home"))
 
 
-@controller_bp.route("/volume/<volume>")
+@controller_bp.route("/volume/<volume>", methods=["POST"])
 def volume(volume):
     """Set the playback volume."""
     k = get_karaoke_instance()
@@ -60,7 +60,7 @@ def volume(volume):
     return redirect(url_for("home.home"))
 
 
-@controller_bp.route("/vol_up")
+@controller_bp.route("/vol_up", methods=["POST"])
 def vol_up():
     """Increase volume by 10%."""
     k = get_karaoke_instance()
@@ -69,7 +69,7 @@ def vol_up():
     return redirect(url_for("home.home"))
 
 
-@controller_bp.route("/vol_down")
+@controller_bp.route("/vol_down", methods=["POST"])
 def vol_down():
     """Decrease volume by 10%."""
     k = get_karaoke_instance()

--- a/pikaraoke/routes/queue.py
+++ b/pikaraoke/routes/queue.py
@@ -31,13 +31,6 @@ class ReorderForm(Schema):
     )
 
 
-class EnqueueQuery(Schema):
-    song = fields.String(required=True, metadata={"description": "Path to the song file"})
-    user = fields.String(
-        load_default="", metadata={"description": "Name of the user adding the song"}
-    )
-
-
 class EnqueueForm(Schema):
     song_to_add = fields.String(required=True, metadata={"description": "Path to the song file"})
     song_added_by = fields.String(
@@ -185,17 +178,10 @@ def _do_enqueue(song: str, user: str) -> str:
     return json.dumps({"song": song_title, "success": rc})
 
 
-@queue_bp.route("/enqueue", methods=["GET"])
-@queue_bp.arguments(EnqueueQuery, location="query")
-def enqueue(query):
-    """Add a song to the queue (used by the file browser)."""
-    return _do_enqueue(query["song"], query["user"])
-
-
 @queue_bp.route("/enqueue", methods=["POST"])
 @queue_bp.arguments(EnqueueForm, location="form")
 def enqueue_form(form):
-    """Add a song to the queue (used by the search page)."""
+    """Add a song to the queue."""
     return _do_enqueue(form["song_to_add"], form["song_added_by"])
 
 

--- a/pikaraoke/templates/home.html
+++ b/pikaraoke/templates/home.html
@@ -89,7 +89,7 @@
 			"input",
 			debounce(function (event) {
 				const value = this.value;
-				$.get(window.pikaraokeConfig.basePath + "/volume/" + value);
+				$.post(window.pikaraokeConfig.basePath + "/volume/" + value);
 			}, 500)
 		);
 
@@ -102,29 +102,29 @@
 			}
 			r = confirm(window.translations.confirmTranspose.replace("{label}", getSemitonesLabel(value)));
 			if (r) {
-				$.get(window.pikaraokeConfig.basePath + "/transpose/" + value);
+				$.post(window.pikaraokeConfig.basePath + "/transpose/" + value);
 			}
 			slider.value = 0;
 			output.innerHTML = getSemitonesLabel(slider.value);
 		});
 
 		$("#pause-resume").click(function () {
-			$.get(window.pikaraokeConfig.basePath + "/pause");
+			$.post(window.pikaraokeConfig.basePath + "/pause");
 			togglePausePlayButton();
 		});
 
 		$("#vol-up").click(function () {
-			$.get(window.pikaraokeConfig.basePath + "/vol_up");
+			$.post(window.pikaraokeConfig.basePath + "/vol_up");
 		});
 
 		$("#vol-down").click(function () {
-			$.get(window.pikaraokeConfig.basePath + "/vol_down");
+			$.post(window.pikaraokeConfig.basePath + "/vol_down");
 		});
 
 		$("#restart").click(function () {
 			r = confirm(window.translations.confirmRestartTrack);
 			if (r) {
-				$.get(window.pikaraokeConfig.basePath + "/restart");
+				$.post(window.pikaraokeConfig.basePath + "/restart");
 			}
 		});
 
@@ -134,7 +134,7 @@
 				{{ _("Are you sure you want to skip this track? If you didn't add this song, ask permission first!") | tojson }}
 			);
 			if (r) {
-				$.get(window.pikaraokeConfig.basePath + "/skip");
+				$.post(window.pikaraokeConfig.basePath + "/skip");
 			}
 		});
 

--- a/pikaraoke/templates/queue.html
+++ b/pikaraoke/templates/queue.html
@@ -460,7 +460,7 @@
 
   // Execute playback action and close modal
   window.executePlaybackAction = function(action) {
-      $.get(window.pikaraokeConfig.basePath + '/' + action);
+      $.post(window.pikaraokeConfig.basePath + '/' + action);
       window.closeNowPlayingOptions();
   };
 
@@ -489,13 +489,6 @@
       $(document).on('click', '.now-playing-options-btn', function(e) {
           e.preventDefault();
           openNowPlayingOptions();
-      });
-
-      // Playback controls handler (still used for any inline buttons if needed)
-      $(document).on('click', '.playback-btn', function(e) {
-          e.preventDefault();
-          var action = $(this).data('action');
-          $.get(window.pikaraokeConfig.basePath + '/' + action);
       });
   });
 

--- a/tests/unit/test_state_changing_methods.py
+++ b/tests/unit/test_state_changing_methods.py
@@ -12,6 +12,7 @@ if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "3.0.0"
 
 from pikaraoke.routes.admin import admin_bp
+from pikaraoke.routes.controller import controller_bp
 from pikaraoke.routes.files import files_bp
 from pikaraoke.routes.preferences import preferences_bp
 from pikaraoke.routes.queue import queue_bp
@@ -28,13 +29,20 @@ STATE_CHANGING_ENDPOINTS = {
     "files.delete_file",
     "queue.add_random",
     "queue.queue_edit",
+    "controller.skip",
+    "controller.pause",
+    "controller.restart",
+    "controller.transpose",
+    "controller.volume",
+    "controller.vol_up",
+    "controller.vol_down",
 }
 
 
 @pytest.fixture
 def url_map():
     app = Flask(__name__)
-    for blueprint in (admin_bp, files_bp, preferences_bp, queue_bp):
+    for blueprint in (admin_bp, controller_bp, files_bp, preferences_bp, queue_bp):
         app.register_blueprint(blueprint)
     return app.url_map
 

--- a/tests/unit/test_state_changing_methods.py
+++ b/tests/unit/test_state_changing_methods.py
@@ -1,7 +1,10 @@
-"""The host-only routes that change state must not answer GET.
+"""The routes that change state must not answer GET.
 
-SameSite=Lax still attaches the admin cookie to a top-level GET navigation, so
-a route that mutates on GET can be fired by a link on any page the host visits.
+For the host-only ones the reason is the admin cookie: SameSite=Lax still
+attaches it to a top-level GET navigation, so a route that mutates on GET can be
+fired by a link on any page the host visits. The routes open to the room borrow
+no privilege, but a state change still does not belong on the verb that link
+prefetchers, previews and proxy retries are free to replay unasked.
 """
 
 import pytest
@@ -28,6 +31,7 @@ STATE_CHANGING_ENDPOINTS = {
     "preferences.clear_preferences",
     "files.delete_file",
     "queue.add_random",
+    "queue.enqueue_form",
     "queue.queue_edit",
     "controller.skip",
     "controller.pause",


### PR DESCRIPTION
The seven playback controls change state on `GET` — `/skip`, `/pause`, `/restart`, `/transpose/<n>`, `/volume/<n>`, `/vol_up` and `/vol_down`. They are the last state-changing `GET`s after #886.

This precedes the work in #893 and #894.

On its own this buys nothing, since they are still ungated and there is no privilege to steal yet. It is the safe half of the order: briefly POST-only and ungated is no worse than today, whereas gating first would leave them privileged and reachable by a link.

Every caller was already AJAX, so no markup moves — seven `$.get` become `$.post` in `home.html` and one in `queue.html`.

Also deletes the `.playback-btn` handler in `queue.html`, which binds to a class no markup carries, like the dead handlers #886 removed.

Also drops `GET /enqueue` and its `EnqueueQuery` schema, missed by #886 because it sits in `routes/queue.py`. Deleted rather than converted: nothing calls it, and a POST route no caller posts to is still dead code.

`tests/unit/test_state_changing_methods.py` goes from eleven endpoints to nineteen.

## Test plan

Run with `--admin-password` set and log in as admin.

- [x] Home page, Player Control: restart, play/pause and skip all work, and the restart and skip confirmations still appear and still do nothing when cancelled
- [x] Home page: the volume slider changes the volume, and the up and down buttons work
- [x] Home page: transpose confirms, applies, and resets the slider to zero
- [x] Queue page: open the now-playing options modal and check restart, pause and skip
- [x] `http://<host>:5555/skip` typed into the address bar returns 405 instead of skipping the song
