### PR TITLE
feat: set the admin password without restarting

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -8,6 +8,7 @@ from gevent import monkey, spawn
 
 monkey.patch_all()
 
+import datetime
 import logging
 import os
 import sys
@@ -21,17 +22,13 @@ from flask_socketio import SocketIO
 
 from pikaraoke import VERSION, karaoke
 from pikaraoke.constants import LANGUAGES
+from pikaraoke.lib.admin_auth import AdminAuth
 from pikaraoke.lib.args import parse_pikaraoke_args
 from pikaraoke.lib.browser import Browser
 from pikaraoke.lib.current_app import get_karaoke_instance, is_admin
 from pikaraoke.lib.ffmpeg import is_ffmpeg_installed
 from pikaraoke.lib.file_resolver import delete_tmp_dir
-from pikaraoke.lib.get_platform import (
-    get_data_directory,
-    get_platform,
-    has_js_runtime,
-    is_windows,
-)
+from pikaraoke.lib.get_platform import get_platform, has_js_runtime, is_windows
 from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.lib.url_prefix import BasePathMiddleware
 from pikaraoke.lib.youtube_dl import upgrade_youtubedl
@@ -65,7 +62,11 @@ babel = Babel()
 
 
 app = Flask(__name__)
-app.secret_key = os.urandom(24)
+
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+# Not SESSION_COOKIE_SECURE: on plain HTTP the browser would never send it back.
+app.permanent_session_lifetime = datetime.timedelta(days=90)
 app.jinja_env.add_extension("jinja2.ext.i18n")
 app.config["BABEL_TRANSLATION_DIRECTORIES"] = "translations"
 app.config["JSON_SORT_KEYS"] = False
@@ -311,8 +312,21 @@ def main() -> None:
     k.events.on("download_started", _broadcast_in_context("download_started"))
     k.events.on("download_stopped", _broadcast_in_context("download_stopped"))
 
+    admin_auth = AdminAuth(k.preferences)
+    app.secret_key = admin_auth.secret_key
+    app.config["ADMIN_AUTH"] = admin_auth
+
+    # Passing the flag persists it; omitting it keeps the stored one, empty clears it.
+    if args.admin_password is not None:
+        admin_auth.set_password(args.admin_password)
+
+    if not admin_auth.is_password_set():
+        logging.info(
+            "No admin password set: everyone on the network can control playback and "
+            "shut down the system. Set one on the info page."
+        )
+
     # expose shared configuration variables to the flask app
-    app.config["ADMIN_PASSWORD"] = args.admin_password
     app.config["SITE_NAME"] = "PiKaraoke"
 
     # Expose some functions to jinja templates. The session globals are bound at

--- a/pikaraoke/lib/admin_auth.py
+++ b/pikaraoke/lib/admin_auth.py
@@ -1,0 +1,65 @@
+"""Admin password storage and the server's cookie-signing key."""
+
+import hashlib
+import hmac
+import secrets
+
+from pikaraoke.lib.preference_manager import PreferenceManager
+
+# Login only, never per request: ~90ms on a desktop, roughly 0.3s on a Pi 4.
+_PBKDF2_ITERATIONS = 100_000
+
+# Its own config.ini section, so it is never mistaken for something to hand-edit
+# and never cleared by "reset all preferences".
+_SECTION = "SECRETS"
+
+
+class AdminAuth:
+    """Owns whether an admin password is set, and verifies attempts against it."""
+
+    def __init__(self, preferences: PreferenceManager) -> None:
+        self._preferences = preferences
+        if not self._get("secret_key"):
+            self._set("secret_key", secrets.token_hex(32))
+
+    @property
+    def secret_key(self) -> str:
+        """Flask's session-signing key, generated once and reused across restarts."""
+        return self._get("secret_key")
+
+    @property
+    def session_token(self) -> str:
+        """Identifies the current password, so changing it logs every device out."""
+        return self._get("session_token")
+
+    def is_password_set(self) -> bool:
+        """True when admin mode is locked down. False means everyone is an admin."""
+        return bool(self._get("password_hash"))
+
+    def set_password(self, password: str | None) -> None:
+        """Set the admin password, or clear it with None or an empty string."""
+        if password:
+            salt = secrets.token_bytes(16)
+            self._set("password_hash", f"{salt.hex()}:{self._derive(password, salt).hex()}")
+        else:
+            self._set("password_hash", "")
+        self._set("session_token", secrets.token_hex(16))
+
+    def verify(self, password: str) -> bool:
+        """True if the password matches the stored hash."""
+        stored = self._get("password_hash")
+        if not stored:
+            return False
+        salt, _, expected = stored.partition(":")
+        return hmac.compare_digest(
+            self._derive(password, bytes.fromhex(salt)), bytes.fromhex(expected)
+        )
+
+    def _derive(self, password: str, salt: bytes) -> bytes:
+        return hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, _PBKDF2_ITERATIONS)
+
+    def _get(self, key: str) -> str:
+        return self._preferences.get(key, "", section=_SECTION)
+
+    def _set(self, key: str, value: str) -> None:
+        self._preferences.set(key, value, section=_SECTION)

--- a/pikaraoke/lib/args.py
+++ b/pikaraoke/lib/args.py
@@ -140,7 +140,9 @@ def parse_pikaraoke_args() -> argparse.Namespace:
     )
     server.add_argument(
         "--admin-password",
-        help="Administrator password, for locking down certain features of the web UI such as queue editing, player controls, song editing, and system shutdown. If unspecified, everyone is an admin.",
+        help="Administrator password for the web UI: player controls, song editing, shutdown. Saved when passed, so it also resets a forgotten one; pass it with no value to clear it. Unset, everyone is an admin.",
+        nargs="?",
+        const="",
         default=None,
         required=False,
     )

--- a/pikaraoke/lib/current_app.py
+++ b/pikaraoke/lib/current_app.py
@@ -7,25 +7,21 @@ import sys
 import time
 from typing import Any
 
-from flask import current_app, request
+from flask import current_app, request, session
 from flask_socketio import emit
 
 from pikaraoke.karaoke import Karaoke
+from pikaraoke.lib.admin_auth import AdminAuth
 
 
 def is_admin() -> bool:
-    """Determine if the current app's admin password matches the admin cookie value
-    This function checks if the provided password is `None` or if it matches
-    the value of the "admin" cookie in the current Flask request. If the password
-    is `None`, the function assumes the user is an admin. If the "admin" cookie
-    is present and its value matches the provided password, the function returns `True`.
-    Otherwise, it returns `False`.
-    Returns:
-        bool: `True` if the password matches the admin cookie or if the password is `None`,
-              `False` otherwise.
+    """Whether this request is authenticated as the admin.
+
+    With no admin password set everyone is an admin -- the right default for a box
+    on a home TV. Otherwise it takes a signed session established by /auth.
     """
-    password = get_admin_password()
-    return password is None or request.cookies.get("admin") == password
+    auth = get_admin_auth()
+    return not auth.is_password_set() or session.get("admin") == auth.session_token
 
 
 def get_karaoke_instance() -> Karaoke:
@@ -37,13 +33,9 @@ def get_karaoke_instance() -> Karaoke:
     return current_app.config["KARAOKE_INSTANCE"]
 
 
-def get_admin_password() -> str:
-    """Get the admin password from the current app's configuration
-    This function returns the admin password stored in the current app's configuration.
-    Returns:
-        str: The admin password stored in the current app's configuration.
-    """
-    return current_app.config["ADMIN_PASSWORD"]
+def get_admin_auth() -> AdminAuth:
+    """Get the current app's admin authentication store."""
+    return current_app.config["ADMIN_AUTH"]
 
 
 def get_site_name() -> str:

--- a/pikaraoke/lib/preference_manager.py
+++ b/pikaraoke/lib/preference_manager.py
@@ -133,8 +133,8 @@ class PreferenceManager:
             with open(self.config_file_path, "w", encoding="utf-8") as conf:
                 self._config_obj.write(conf)
 
-            # Auto-sync target object if registered
-            if self._target is not None:
+            # Only user preferences map to attributes; other sections would invent them.
+            if self._target is not None and section == "USERPREFERENCES":
                 default = self.DEFAULTS.get(preference)
                 typed_val = str(val) if isinstance(default, str) else self._convert_value(val)
                 setattr(self._target, preference, typed_val)

--- a/pikaraoke/routes/admin.py
+++ b/pikaraoke/routes/admin.py
@@ -1,6 +1,5 @@
 """Admin routes for system control and authentication."""
 
-import datetime
 import os
 import subprocess
 import sys
@@ -8,17 +7,23 @@ import threading
 import time
 
 import flask_babel
-from flask import flash, jsonify, make_response, redirect, url_for
+from flask import flash, jsonify, redirect, session, url_for
 from flask_smorest import Blueprint
 from marshmallow import Schema, fields
 
 from pikaraoke.karaoke import Karaoke
-from pikaraoke.lib.current_app import get_admin_password, get_karaoke_instance, is_admin
+from pikaraoke.lib.current_app import get_admin_auth, get_karaoke_instance, is_admin
 from pikaraoke.lib.youtube_dl import get_youtubedl_version, upgrade_youtubedl
 
 _ = flask_babel.gettext
 
 admin_bp = Blueprint("admin", __name__)
+
+
+class AdminPasswordForm(Schema):
+    admin_password = fields.String(
+        load_default="", metadata={"description": "New admin password; empty clears it"}
+    )
 
 
 class AuthForm(Schema):
@@ -161,41 +166,53 @@ def expand_fs():
 @admin_bp.arguments(AuthForm, location="form")
 def auth(form):
     """Authenticate as admin."""
-    admin_password = get_admin_password()
-    p = form["admin_password"]
     next_url = form["next"]
 
     # Validate next_url to prevent open redirect vulnerabilities
     if not next_url.startswith("/"):
         next_url = "/"
 
-    if p == admin_password:
-        resp = make_response(redirect(next_url))
-        expire_date = datetime.datetime.now()
-        expire_date = expire_date + datetime.timedelta(days=90)
-        # Not secure=True: PiKaraoke serves plain HTTP on a LAN, so the browser
-        # would never send the cookie back.
-        resp.set_cookie(
-            "admin",
-            admin_password,
-            expires=expire_date,
-            httponly=True,
-            samesite="Lax",
-        )
+    admin_auth = get_admin_auth()
+    if admin_auth.verify(form["admin_password"]):
+        session["admin"] = admin_auth.session_token
+        session.permanent = True
         # MSG: Message shown after logging in as admin successfully
         flash(_("Admin mode granted!"), "is-success")
     else:
-        resp = make_response(redirect(next_url))
         # MSG: Message shown after failing to login as admin
         flash(_("Incorrect admin password!"), "is-danger")
-    return resp
+    return redirect(next_url)
+
+
+@admin_bp.route("/admin_password", methods=["POST"])
+@admin_bp.arguments(AdminPasswordForm, location="form")
+def set_admin_password(form):
+    """Set, change or clear the admin password without restarting."""
+    if not is_admin():
+        # MSG: Message shown after trying to change the admin password without permission.
+        flash(_("You don't have permission to change the admin password"), "is-danger")
+        return redirect(url_for("info.info"))
+
+    # No current-password field: an admin session can already shut the box down.
+    password = form["admin_password"]
+    admin_auth = get_admin_auth()
+    admin_auth.set_password(password)
+    if password:
+        # set_password logged every device out; keep the one that just set it.
+        session["admin"] = admin_auth.session_token
+        session.permanent = True
+        # MSG: Message shown after setting a new admin password.
+        flash(_("Admin password set. Other devices will need to log in again."), "is-success")
+    else:
+        # MSG: Message shown after clearing the admin password, making everyone an admin.
+        flash(_("Admin password cleared. Everyone is an admin again."), "is-warning")
+    return redirect(url_for("info.info"))
 
 
 @admin_bp.route("/logout")
 def logout():
     """Log out of admin mode."""
-    resp = make_response(redirect(url_for("info.info")))
-    resp.set_cookie("admin", "", httponly=True, samesite="Lax")
+    session.pop("admin", None)
     # MSG: Message shown after logging out as admin successfully
     flash(_("Logged out of admin mode!"), "is-success")
-    return resp
+    return redirect(url_for("info.info"))

--- a/pikaraoke/routes/admin.py
+++ b/pikaraoke/routes/admin.py
@@ -209,7 +209,7 @@ def set_admin_password(form):
     return redirect(url_for("info.info"))
 
 
-@admin_bp.route("/logout")
+@admin_bp.route("/logout", methods=["POST"])
 def logout():
     """Log out of admin mode."""
     session.pop("admin", None)

--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -9,7 +9,7 @@ from pikaraoke import VERSION
 from pikaraoke.constants import ITUNES_COUNTRIES, LANGUAGES, per_page_options
 from pikaraoke.lib import keep_awake
 from pikaraoke.lib.current_app import (
-    get_admin_password,
+    get_admin_auth,
     get_karaoke_instance,
     get_site_name,
     is_admin,
@@ -28,7 +28,6 @@ def info():
     k = get_karaoke_instance()
     site_name = get_site_name()
     url = k.url
-    admin_password = get_admin_password()
     is_linux_platform = is_linux()
 
     preferred_language = k.preferences.get("preferred_language", "en")
@@ -44,7 +43,7 @@ def info():
         title=_("Settings"),
         url=url,
         admin=is_admin(),
-        admin_password=admin_password,
+        admin_password_set=get_admin_auth().is_password_set(),
         platform=k.platform,
         os_version=k.os_version,
         ffmpeg_version=k.ffmpeg_version,

--- a/pikaraoke/static/spa-navigation.js
+++ b/pikaraoke/static/spa-navigation.js
@@ -223,7 +223,6 @@
             basePath + '/quit',
             basePath + '/shutdown',
             basePath + '/reboot',
-            basePath + '/logout',
             basePath + '/login',
             basePath + '/update_ytdl',
             basePath + '/refresh',

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -879,8 +879,10 @@
 								{# MSG: Button which removes the administrator password, making everyone an admin. #}
 								<button class="button is-danger is-outlined">{% trans %}Clear password{% endtrans %}</button>
 							</form>
-							{# MSG: Link which will log out the user from admin mode. #}
-							<a class="button is-primary" href="{{ url_for('admin.logout') }}">{% trans %}Log out{% endtrans %}</a>
+							<form action="{{ url_for('admin.logout') }}" method="post">
+								{# MSG: Button which logs the user out of admin mode. #}
+								<button class="button is-primary">{% trans %}Log out{% endtrans %}</button>
+							</form>
 						</div>
 					{% endif %}
 				</div>

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -322,7 +322,7 @@
 		</div>
 	</div>
 
-	{% if not admin and admin_password != none %}
+	{% if not admin and admin_password_set %}
 		{# MSG: Title of the admin section. #}
 		<h2>{% trans %}Admin{% endtrans %}</h2>
 
@@ -335,7 +335,7 @@
 						<input type="hidden" name="next" value="{{ request.path }}" />
 						<div class="field has-addons mb-2">
 							<div class="control" style="width: 100%; max-width: 350px">
-								<input type="password" name="admin_password" class="input" />
+								<input type="password" name="admin_password" class="input" autocomplete="current-password" />
 							</div>
 							<div class="control">
 								{# MSG: Text on submit button for the admin login form. #}
@@ -343,6 +343,8 @@
 							</div>
 						</div>
 					</form>
+					{# MSG: Tells a locked-out host how to reset a forgotten admin password. #}
+					<p class="is-size-7 has-text-grey">{% trans %}Forgotten it? Restart PiKaraoke with --admin-password to set a new one.{% endtrans %}</p>
 				</div>
 			</div>
 		</div>
@@ -846,21 +848,44 @@
 
 		{% endif %}
 
-		{% if admin_password != none %}
-			{# MSG: Title of the admin section. #}
-			<h2>{% trans %}Admin{% endtrans %}</h2>
+		{# MSG: Title of the admin section. #}
+		<h2>{% trans %}Admin{% endtrans %}</h2>
 
-			<div class="card">
-				<div class="card-content">
-					<div class="content">
-						{# MSG: Message for the log out user from admin mode button. #}
-						<p>{% trans %}Click here to logout from admin mode.{% endtrans %}</p>
-						{# MSG: Link which will log out the user from admin mode. #}
-						<a class="button is-primary" href="{{ url_for('admin.logout') }}">{% trans %}Log out{% endtrans %}</a>
-					</div>
+		<div class="card">
+			<div class="card-content">
+				<div class="content">
+					{% if admin_password_set %}
+						{# MSG: Explains the admin password field when a password is already set. #}
+						<p>{% trans %}Change the administrator password. Every other device will need to log in again.{% endtrans %}</p>
+					{% else %}
+						{# MSG: Explains the admin password field when no password has been set. #}
+						<p>{% trans %}Everyone on the network is an admin. Set a password to keep the player controls, song editing and shutdown to yourself.{% endtrans %}</p>
+					{% endif %}
+					<form action="{{ url_for('admin.set_admin_password') }}" method="post">
+						<div class="field has-addons mb-2">
+							<div class="control" style="width: 100%; max-width: 350px">
+								<input type="password" name="admin_password" class="input" autocomplete="new-password" />
+							</div>
+							<div class="control">
+								{# MSG: Button which saves a new administrator password. #}
+								<button class="button is-rounded is-primary">{% trans %}Save password{% endtrans %}</button>
+							</div>
+						</div>
+					</form>
+					{% if admin_password_set %}
+						<div class="buttons">
+							<form action="{{ url_for('admin.set_admin_password') }}" method="post">
+								<input type="hidden" name="admin_password" value="" />
+								{# MSG: Button which removes the administrator password, making everyone an admin. #}
+								<button class="button is-danger is-outlined">{% trans %}Clear password{% endtrans %}</button>
+							</form>
+							{# MSG: Link which will log out the user from admin mode. #}
+							<a class="button is-primary" href="{{ url_for('admin.logout') }}">{% trans %}Log out{% endtrans %}</a>
+						</div>
+					{% endif %}
 				</div>
 			</div>
-		{% endif %}
+		</div>
 
 		{# MSG: Title of the section on shutting down / turning off the machine running Pikaraoke. #}
 		<h2>{% trans %}Shutdown{% endtrans %}</h2>

--- a/tests/unit/test_admin_auth.py
+++ b/tests/unit/test_admin_auth.py
@@ -1,0 +1,96 @@
+"""Tests for admin password storage and verification."""
+
+import pytest
+
+from pikaraoke.lib.admin_auth import AdminAuth
+from pikaraoke.lib.preference_manager import PreferenceManager
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    return str(tmp_path / "config.ini")
+
+
+@pytest.fixture
+def auth(config_path):
+    return AdminAuth(PreferenceManager(config_path))
+
+
+class TestSecretKey:
+    def test_it_survives_a_restart(self, auth, config_path):
+        assert auth.secret_key == AdminAuth(PreferenceManager(config_path)).secret_key
+
+    def test_it_is_long_enough_to_sign_with(self, auth):
+        assert len(auth.secret_key) >= 32
+
+
+class TestPassword:
+    def test_none_is_set_initially(self, auth):
+        assert not auth.is_password_set()
+
+    def test_verify_is_false_when_no_password_is_set(self, auth):
+        assert not auth.verify("anything")
+
+    def test_the_correct_password_verifies(self, auth):
+        auth.set_password("hunter2")
+
+        assert auth.is_password_set()
+        assert auth.verify("hunter2")
+
+    def test_an_incorrect_password_does_not(self, auth):
+        auth.set_password("hunter2")
+
+        assert not auth.verify("hunter3")
+        assert not auth.verify("")
+
+    def test_it_survives_a_restart(self, auth, config_path):
+        auth.set_password("hunter2")
+
+        assert AdminAuth(PreferenceManager(config_path)).verify("hunter2")
+
+    def test_the_password_is_not_stored_verbatim(self, auth, config_path):
+        auth.set_password("hunter2")
+
+        assert "hunter2" not in open(config_path, encoding="utf-8").read()
+
+    def test_the_same_password_hashes_differently_each_time(self, auth, config_path):
+        auth.set_password("hunter2")
+        first = PreferenceManager(config_path).get("password_hash", "", section="SECRETS")
+        auth.set_password("hunter2")
+        second = PreferenceManager(config_path).get("password_hash", "", section="SECRETS")
+
+        assert first != second
+
+    def test_an_empty_password_clears_it(self, auth):
+        auth.set_password("hunter2")
+        auth.set_password("")
+
+        assert not auth.is_password_set()
+        assert not auth.verify("hunter2")
+
+    def test_none_clears_it_too(self, auth):
+        auth.set_password("hunter2")
+        auth.set_password(None)
+
+        assert not auth.is_password_set()
+
+
+class TestSessionToken:
+    def test_it_changes_when_the_password_changes(self, auth):
+        auth.set_password("hunter2")
+        before = auth.session_token
+        auth.set_password("hunter3")
+
+        assert auth.session_token != before
+
+    def test_it_changes_when_the_password_is_cleared(self, auth):
+        auth.set_password("hunter2")
+        before = auth.session_token
+        auth.set_password("")
+
+        assert auth.session_token != before
+
+    def test_it_survives_a_restart(self, auth, config_path):
+        auth.set_password("hunter2")
+
+        assert AdminAuth(PreferenceManager(config_path)).session_token == auth.session_token

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -1,6 +1,6 @@
 """Tests for admin authentication routes."""
 
-from unittest.mock import patch
+import datetime
 
 import pytest
 import werkzeug
@@ -10,15 +10,28 @@ from flask_babel import Babel
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "3.0.0"
 
+from pikaraoke.lib.admin_auth import AdminAuth
+from pikaraoke.lib.preference_manager import PreferenceManager
 from pikaraoke.routes.admin import admin_bp
 
-ROUTE_PREFIX = "pikaraoke.routes.admin"
+PASSWORD = "hunter2"
 
 
 @pytest.fixture
-def app():
+def auth(tmp_path):
+    store = AdminAuth(PreferenceManager(str(tmp_path / "config.ini")))
+    store.set_password(PASSWORD)
+    return store
+
+
+@pytest.fixture
+def app(auth):
     test_app = Flask(__name__)
-    test_app.secret_key = "test"
+    test_app.secret_key = auth.secret_key
+    test_app.config["ADMIN_AUTH"] = auth
+    test_app.config["SESSION_COOKIE_HTTPONLY"] = True
+    test_app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+    test_app.permanent_session_lifetime = datetime.timedelta(days=90)
     Babel(test_app)
     test_app.register_blueprint(admin_bp)
     test_app.add_url_rule("/info", "info.info", lambda: "")
@@ -30,32 +43,75 @@ def client(app):
     return app.test_client()
 
 
-def _set_cookie_header(response):
-    return response.headers["Set-Cookie"]
+def _login(client, password=PASSWORD):
+    return client.post("/auth", data={"admin_password": password, "next": "/info"})
 
 
 class TestAdminCookieAttributes:
-    """The admin cookie carries the attributes that blunt cross-site requests."""
+    """The session cookie carries the attributes that blunt cross-site requests."""
 
     def test_login_cookie_is_httponly_and_samesite_lax(self, client):
-        with patch(f"{ROUTE_PREFIX}.get_admin_password", return_value="hunter2"):
-            response = client.post("/auth", data={"admin_password": "hunter2", "next": "/"})
+        header = _login(client).headers["Set-Cookie"]
 
-        header = _set_cookie_header(response)
         assert "HttpOnly" in header
         assert "SameSite=Lax" in header
 
     def test_login_cookie_is_not_secure(self, client):
         """PiKaraoke serves plain HTTP on a LAN; a Secure cookie would never come back."""
-        with patch(f"{ROUTE_PREFIX}.get_admin_password", return_value="hunter2"):
-            response = client.post("/auth", data={"admin_password": "hunter2", "next": "/"})
+        assert "Secure" not in _login(client).headers["Set-Cookie"]
 
-        assert "Secure" not in _set_cookie_header(response)
+    def test_login_cookie_does_not_contain_the_password(self, client):
+        assert PASSWORD not in _login(client).headers["Set-Cookie"]
 
-    def test_logout_cookie_matches_the_login_attributes(self, client):
-        with patch(f"{ROUTE_PREFIX}.get_admin_password", return_value="hunter2"):
-            response = client.get("/logout")
 
-        header = _set_cookie_header(response)
-        assert "HttpOnly" in header
-        assert "SameSite=Lax" in header
+class TestLogin:
+    def test_correct_password_establishes_the_session(self, client, auth):
+        _login(client)
+
+        with client.session_transaction() as session:
+            assert session["admin"] == auth.session_token
+
+    def test_incorrect_password_does_not(self, client):
+        _login(client, "wrong")
+
+        with client.session_transaction() as session:
+            assert "admin" not in session
+
+    def test_logout_drops_the_session(self, client):
+        _login(client)
+        client.get("/logout")
+
+        with client.session_transaction() as session:
+            assert "admin" not in session
+
+
+class TestSetAdminPassword:
+    def test_admin_can_change_it_and_stays_logged_in(self, client, auth):
+        _login(client)
+
+        client.post("/admin_password", data={"admin_password": "new-one"})
+
+        assert auth.verify("new-one")
+        with client.session_transaction() as session:
+            assert session["admin"] == auth.session_token
+
+    def test_changing_it_logs_other_devices_out(self, client, app):
+        other = app.test_client()
+        _login(other)
+
+        _login(client)
+        client.post("/admin_password", data={"admin_password": "new-one"})
+
+        assert other.get("/library_stats").status_code == 403
+
+    def test_an_empty_password_clears_it(self, client, auth):
+        _login(client)
+
+        client.post("/admin_password", data={"admin_password": ""})
+
+        assert not auth.is_password_set()
+
+    def test_a_non_admin_cannot_change_it(self, client, auth):
+        client.post("/admin_password", data={"admin_password": "new-one"})
+
+        assert auth.verify(PASSWORD)

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -79,7 +79,7 @@ class TestLogin:
 
     def test_logout_drops_the_session(self, client):
         _login(client)
-        client.get("/logout")
+        client.post("/logout")
 
         with client.session_transaction() as session:
             assert "admin" not in session

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -94,3 +94,19 @@ class TestParsePikaraokeArgs:
         monkeypatch.setattr("sys.argv", ["pikaraoke", "--skip-ytdl-upgrade"])
         args = parse_pikaraoke_args()
         assert args.skip_youtubedl_upgrade is True
+
+    def test_omitting_admin_password_keeps_the_stored_one(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["pikaraoke"])
+        args = parse_pikaraoke_args()
+        assert args.admin_password is None
+
+    def test_admin_password_with_no_value_clears_it(self, monkeypatch):
+        """A bare flag, because not every shell can pass an empty string."""
+        monkeypatch.setattr("sys.argv", ["pikaraoke", "--admin-password"])
+        args = parse_pikaraoke_args()
+        assert args.admin_password == ""
+
+    def test_admin_password_sets_it(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["pikaraoke", "--admin-password", "hunter2"])
+        args = parse_pikaraoke_args()
+        assert args.admin_password == "hunter2"

--- a/tests/unit/test_sessions_routes.py
+++ b/tests/unit/test_sessions_routes.py
@@ -18,7 +18,9 @@ from unittest.mock import MagicMock, patch
 
 from flask_babel import Babel
 
+from pikaraoke.lib.admin_auth import AdminAuth
 from pikaraoke.lib.play_history_manager import SESSION_NAME_MAX_LENGTH
+from pikaraoke.lib.preference_manager import PreferenceManager
 from pikaraoke.routes.sessions import sessions_bp
 from pikaraoke.routes.sessions_api import sessions_api_bp
 
@@ -26,10 +28,17 @@ ADMIN_PASSWORD = "secret"
 
 
 @pytest.fixture
-def app():
+def admin_auth(tmp_path):
+    store = AdminAuth(PreferenceManager(str(tmp_path / "config.ini")))
+    store.set_password(ADMIN_PASSWORD)
+    return store
+
+
+@pytest.fixture
+def app(admin_auth):
     test_app = Flask(__name__)
-    test_app.secret_key = "test"
-    test_app.config["ADMIN_PASSWORD"] = ADMIN_PASSWORD
+    test_app.secret_key = admin_auth.secret_key
+    test_app.config["ADMIN_AUTH"] = admin_auth
     test_app.config["SITE_NAME"] = "PiKaraoke"
     Babel(test_app)
     test_app.register_blueprint(sessions_api_bp)
@@ -47,9 +56,10 @@ def client(app):
 
 
 @pytest.fixture
-def admin_client(app):
+def admin_client(app, admin_auth):
     c = app.test_client()
-    c.set_cookie("admin", ADMIN_PASSWORD)
+    with c.session_transaction() as session:
+        session["admin"] = admin_auth.session_token
     return c
 
 

--- a/tests/unit/test_state_changing_methods.py
+++ b/tests/unit/test_state_changing_methods.py
@@ -23,6 +23,8 @@ STATE_CHANGING_ENDPOINTS = {
     "admin.shutdown",
     "admin.reboot",
     "admin.expand_fs",
+    "admin.logout",
+    "admin.set_admin_password",
     "preferences.change_preferences",
     "preferences.clear_preferences",
     "files.delete_file",


### PR DESCRIPTION
**Why:** the admin password could only be set with `--admin-password` at launch, so changing or clearing one meant editing whatever starts PiKaraoke — a shortcut, a service file, an autostart entry.

*It was the last setting that could only be changed by relaunching, so a typical install now needs no CLI argument beyond* `--headless`.

Implements #893, the first of two security steps. Held as a draft until #895 lands, which makes the playback controls POST-only. Step 2 is #894: deny by default, so a new route is closed unless it is marked public.

## What changed

The password is now a salted PBKDF2-SHA256 hash in a `[SECRETS]` section of `config.ini`, set, changed or cleared from the Info page. `--admin-password` keeps the same precedence the other 35 preferences use: an explicit value wins and is persisted, omitting the flag keeps what was set before, passing it empty clears it.

Login establishes a signed session rather than handing the password back as a cookie, which previously sat in every browser in plaintext for 90 days. The session carries a token identifying the current password, so changing it logs every other device out but not the device that made the change. The signing key is now persisted rather than regenerated each launch, so logins and `session["lang"]` survive a restart. `/logout` answers POST rather than GET, joining the routes #886 converted: `SameSite=Lax` deliberately still attaches the cookie to a top-level GET navigation, so a link on any page the host visits could otherwise end their session.

A new `AdminAuth` class owns hashing and verification, and delegates storage to `PreferenceManager`.

## Notes for review

- **Everyone is logged out once on upgrade**, since the old plaintext cookie is no longer read.
- **`--admin-password` now persists** rather than applying for one run, which makes it the way to reset a password nobody remembers.
- **No current-password field** on the change form: an admin session already lets you shut the box down and delete songs.
- **`PreferenceManager.set()` now syncs to its target object only for `USERPREFERENCES`**, so writing a secret cannot invent attributes on `Karaoke`.

## Test plan

- [x] With no password set everyone is an admin, and the Info page offers to set one
- [x] Setting a password takes effect with no restart, and that device stays logged in
- [x] A second logged-in device is logged out and must enter the new password
- [x] Clearing the password makes everyone an admin again
- [x] The Log out button still works, and `http://<host>:5555/logout` typed into the address bar returns 405
- [x] Restarting keeps the password and keeps this browser logged in
- [x] `--admin-password newpass` resets a forgotten one; a bare `--admin-password` clears it
