### PR TITLE
docs: fix the dead links in the README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,12 +22,12 @@ Love PiKaraoke? This project is independently maintained and free for everyone t
 
 - [Supported Devices / OS / Platforms](#supported-devices--os--platforms)
 - [Quick Install](#quick-install)
-- [Manual Installation](#manual-installation)
+- [Manual Installation](#manual-installation-advanced-users)
 - [Usage](#usage)
 - [Docker](#docker-instructions)
 - [Screenshots](#screenshots)
 - [Developing pikaraoke](#developing-pikaraoke)
-- [Troubleshooting](#troubleshooting)
+- [Troubleshooting](#troubleshooting-and-guides)
 
 ## Supported Devices / OS / Platforms
 
@@ -152,6 +152,6 @@ See the [Pikaraoke development guide](https://github.com/vicwomg/pikaraoke/wiki/
 
 ## Troubleshooting and guides
 
-See the [TROUBLESHOOTING wiki](https://github.com/vicwomg/pikaraoke/wiki/FAQ-&-Troubleshooting) for help with issues.
+See the [Troubleshooting wiki](https://github.com/vicwomg/pikaraoke/wiki/Troubleshooting) for help with issues.
 
 There are also some great guides [on the wiki](https://github.com/vicwomg/pikaraoke/wiki/) to running pikaraoke in all manner of bizarre places including Android, Chromecast, and embedded TVs!


### PR DESCRIPTION
**Why:** someone whose PiKaraoke will not start clicks the troubleshooting link in the README and lands on GitHub's "create this page" screen rather than the guide. Two entries in the table of contents also jump nowhere. After this all three go where they say.

The wiki's combined FAQ-&-Troubleshooting page has been split into a FAQ page and a Troubleshooting page. GitHub does not redirect a renamed wiki page, so the README's only help link has been dead since the split. It now points at Troubleshooting. The development guide link a few lines above still resolves, and so does the bare wiki link at the end of that section.

The other two are older. A heading anchor is generated from the whole heading, so "Manual installation" becoming "Manual installation (advanced users)", and "Troubleshooting" becoming "Troubleshooting and guides", each left the contents entry pointing at an anchor that no longer exists. The entries now carry the full anchors; their labels stay short, and the headings are untouched because the wiki links to them.

The wiki has separately gained a home page that works as a contents page, and a sidebar indexing every guide, so a reader who lands anywhere in it can find the rest. Nothing in the README needs to say so.
