### PR TITLE
perf: read config.ini once, not on every get

### DIFF
--- a/pikaraoke/lib/preference_manager.py
+++ b/pikaraoke/lib/preference_manager.py
@@ -76,6 +76,11 @@ class PreferenceManager:
         else:
             self.config_file_path = config_file_path
 
+        # Read once, silently ignoring a missing file. This is the only instance,
+        # in one process, and every write goes through set() or clear(), which
+        # keep _config_obj current without going back to disk.
+        self._config_obj.read(self.config_file_path, encoding="utf-8")
+
         logging.debug(f"Using config file: {self.config_file_path}")
 
     def _migrate_legacy_config(self) -> None:
@@ -96,9 +101,6 @@ class PreferenceManager:
         self, preference: str, default_value: Any = None, section: str = "USERPREFERENCES"
     ) -> Any:
         """Get a preference value, auto-converting to bool/int/float."""
-        # Silently ignores missing files
-        self._config_obj.read(self.config_file_path, encoding="utf-8")
-
         if not self._config_obj.has_section(section):
             return default_value
 


### PR DESCRIPTION
**Why:** the host starting a song on a Pi waits on ten full reparses of `config.ini` before playback begins, because every preference lookup went back to disk. After this they wait on one read taken at startup.

## What changed

- **`PreferenceManager` reads `config.ini` once, in `__init__`.** `get()` called `ConfigParser.read()` on every lookup, reparsing the whole file each time — 495us per call on a desktop, more on a Pi.
- **The disk was never the authority anyway.** There is one instance ([karaoke.py:189](../pikaraoke/karaoke.py#L189)) in one process, `set()` and `clear()` already update `_config_obj` before persisting, and `ConfigParser.read()` merges rather than replaces — so a key deleted on disk was never picked up by the old per-call read either.
- **`set()` and `clear()` keep their reads.** They are the write path, they run on a click rather than in a loop, and `set()`'s read is the fix for the bug that `test_set_preserves_existing_preferences_across_instances` guards.

Measured 495us -> 3.5us per call, on a 1064-byte config.

## The behaviour this gives up

Hand-editing `config.ini` while PiKaraoke runs now needs a restart to take effect. The Settings page is the intended editor, and `[SECRETS]` is already documented as not something to hand-edit.

## Test plan

- [x] Change a preference on the Settings page; it takes effect and survives a restart
- [x] Reset all preferences; the page falls back to defaults without a restart
- [x] Set an admin password, log out, log back in
- [x] Start a song and confirm playback settings still apply: volume, normalisation, buffer size
