### PR TITLE
fix: rename a song to another case without refusing

### DIFF
--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -17,6 +17,36 @@ from pikaraoke.lib.metadata_parser import (
 from pikaraoke.lib.song_list import SongList
 
 
+def rename_collides(song_path: str, target: str) -> bool:
+    """True when `target` is a different song's file, so a rename must refuse.
+
+    Asks `samefile` rather than comparing case: on NTFS and APFS a case-only
+    change makes the target "exist" when it is this very song, but on ext4 two
+    songs really can differ only in case, and that one is a clash.
+    """
+    if not os.path.isfile(target):
+        return False
+    try:
+        return not os.path.samefile(song_path, target)
+    except OSError:
+        # The song went away underneath us, so `target` is not ours to take.
+        return True
+
+
+def _rename_path(src: str, dst: str) -> None:
+    """os.rename, hopping via a temp name when `dst` is `src` in another case.
+
+    NTFS and APFS do not see `A` -> `a` as a move. The temp suffix sits after
+    the media extension so a concurrent scan cannot index the hop.
+    """
+    if src != dst and os.path.exists(dst) and os.path.samefile(src, dst):
+        temp = f"{dst}.pikaraoke-tmp"
+        os.rename(src, temp)
+        os.rename(temp, dst)
+    else:
+        os.rename(src, dst)
+
+
 class SongManager:
     """Manages the song library and file operations.
 
@@ -265,10 +295,10 @@ class SongManager:
         companions = self._get_companion_files(song_path)
         dirpath = os.path.dirname(song_path)
         new_path = self.rename_target(song_path, new_name)
-        os.rename(song_path, new_path)
+        _rename_path(song_path, new_path)
         for companion in companions:
             companion_ext = os.path.splitext(companion)[1]
-            os.rename(companion, os.path.join(dirpath, new_name + companion_ext))
+            _rename_path(companion, os.path.join(dirpath, new_name + companion_ext))
         self.songs.rename(song_path, new_path)
         self._db.update_path(song_path, new_path)
         # A rename is the user correcting the name, not a display preference, so

--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -17,17 +17,20 @@ from pikaraoke.lib.metadata_parser import (
 from pikaraoke.lib.song_list import SongList
 
 
-def rename_collides(song_path: str, target: str) -> bool:
-    """True when `target` is a different song's file, so a rename must refuse.
+def _is_same_file(src: str, dst: str) -> bool:
+    """True when `dst` exists and is `src` itself, as a case-only rename's target is.
 
-    Asks `samefile` rather than comparing case: on NTFS and APFS a case-only
+    Asks the filesystem rather than comparing case: on NTFS and APFS a case-only
     change makes the target "exist" when it is this very song, but on ext4 two
     songs really can differ only in case, and that one is a clash.
     """
-    if not os.path.isfile(target):
-        return False
+    return os.path.isfile(dst) and os.path.samefile(src, dst)
+
+
+def rename_collides(song_path: str, target: str) -> bool:
+    """True when `target` is a different song's file, so a rename must refuse."""
     try:
-        return not os.path.samefile(song_path, target)
+        return os.path.isfile(target) and not _is_same_file(song_path, target)
     except OSError:
         # The song went away underneath us, so `target` is not ours to take.
         return True
@@ -39,7 +42,7 @@ def _rename_path(src: str, dst: str) -> None:
     NTFS and APFS do not see `A` -> `a` as a move. The temp suffix sits after
     the media extension so a concurrent scan cannot index the hop.
     """
-    if src != dst and os.path.exists(dst) and os.path.samefile(src, dst):
+    if src != dst and _is_same_file(src, dst):
         temp = f"{dst}.pikaraoke-tmp"
         os.rename(src, temp)
         os.rename(temp, dst)

--- a/pikaraoke/routes/files.py
+++ b/pikaraoke/routes/files.py
@@ -15,6 +15,7 @@ from pikaraoke.constants import ITUNES_COUNTRIES, per_page_options
 from pikaraoke.karaoke import SongInUseError
 from pikaraoke.lib.current_app import get_karaoke_instance, get_site_name, is_admin
 from pikaraoke.lib.metadata_parser import youtube_id_suffix
+from pikaraoke.lib.song_manager import rename_collides
 
 _ = flask_babel.gettext
 
@@ -302,7 +303,7 @@ def rename_file(form):
     # A song already named what you asked for is done, not a collision with itself.
     if target == old_name:
         return redirect(referrer)
-    if os.path.isfile(target):
+    if rename_collides(old_name, target):
         # MSG: Message shown after trying to rename a song to a name already in use.
         error = _("A song called '%s' already exists.") % os.path.basename(target)
         return _render_edit_page(k, old_name, new_name, referrer, error)

--- a/tests/unit/test_files_routes.py
+++ b/tests/unit/test_files_routes.py
@@ -452,6 +452,14 @@ class TestRenameFailuresKeepYourWork:
         assert "already exists" in response.data.decode()
         k.rename_song.assert_not_called()
 
+    def test_changing_only_the_case_is_not_a_collision(self, client, app, existing_song):
+        """On NTFS and APFS the target 'exists' only because it is this very song."""
+        k = _karaoke_for_rename()
+        new_name = existing_song.stem.upper()
+        response = self._submit(client, k, existing_song, new_file_name=new_name)
+        assert response.status_code == 302
+        k.rename_song.assert_called_once_with(str(existing_song), new_name)
+
     def test_saving_the_name_it_already_has_is_not_a_collision(self, client, app, existing_song):
         """A song that already fits the naming convention is done, not in conflict with itself."""
         k = _karaoke_for_rename()

--- a/tests/unit/test_song_manager.py
+++ b/tests/unit/test_song_manager.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pikaraoke.lib.events import EventSystem
-from pikaraoke.lib.song_manager import SongManager
+from pikaraoke.lib.song_manager import SongManager, rename_collides
 
 
 def _native(path: Path) -> str:
@@ -155,6 +155,15 @@ class TestRename:
         assert not song.exists()
         assert (tmp_path / "New Name---abc.mp4").exists()
 
+    def test_renames_a_song_to_the_same_name_in_another_case(self, tmp_path, mock_db):
+        """NTFS and APFS do not see this as a move, so rename hops via a temp name."""
+        song = tmp_path / "old name---abc.mp4"
+        song.write_text("fake")
+        sm = SongManager(str(tmp_path), db=mock_db, events=EventSystem())
+        sm.songs.add_if_valid(_native(song))
+        sm.rename(_native(song), "Old Name---abc")
+        assert [f.name for f in tmp_path.iterdir()] == ["Old Name---abc.mp4"]
+
     def test_renames_cdg_companion(self, tmp_path, mock_db):
         song = tmp_path / "Old---abc.mp4"
         cdg = tmp_path / "Old---abc.cdg"
@@ -211,6 +220,33 @@ class TestRename:
         sm.rename(_native(subfolder / "Old---abc.mp3"), "New---abc")
 
         assert (subfolder / "New---abc.cdg").exists()
+
+
+class TestRenameCollides:
+    """Only a *different* song's file is a clash. Meaningful on NTFS and APFS."""
+
+    def test_a_free_name_does_not_collide(self, tmp_path):
+        song = tmp_path / "Old.mp4"
+        song.write_text("fake")
+        assert not rename_collides(_native(song), _native(tmp_path / "New.mp4"))
+
+    def test_another_song_collides(self, tmp_path):
+        song = tmp_path / "Old.mp4"
+        taken = tmp_path / "Taken.mp4"
+        song.write_text("fake")
+        taken.write_text("fake")
+        assert rename_collides(_native(song), _native(taken))
+
+    def test_changing_only_the_case_does_not_collide(self, tmp_path):
+        """The target 'exists' on a case-insensitive filesystem because it is this song."""
+        song = tmp_path / "Old.mp4"
+        song.write_text("fake")
+        assert not rename_collides(_native(song), _native(tmp_path / "OLD.mp4"))
+
+    def test_a_vanished_song_cannot_claim_the_target(self, tmp_path):
+        taken = tmp_path / "Taken.mp4"
+        taken.write_text("fake")
+        assert rename_collides(_native(tmp_path / "Gone.mp4"), _native(taken))
 
 
 class TestRenameTarget:

--- a/tests/unit/test_song_manager.py
+++ b/tests/unit/test_song_manager.py
@@ -223,7 +223,7 @@ class TestRename:
 
 
 class TestRenameCollides:
-    """Only a *different* song's file is a clash. Meaningful on NTFS and APFS."""
+    """Only a different song's file is a clash, whatever the filesystem makes of case."""
 
     def test_a_free_name_does_not_collide(self, tmp_path):
         song = tmp_path / "Old.mp4"


### PR DESCRIPTION
**Why:** the host who wants `dolly parton - jolene` to read `Dolly Parton - Jolene` can do it from the edit page. Today, on Windows and macOS, that rename is refused as "A song called ... already exists" — the song colliding with itself.

- **`rename_collides()` in `song_manager.py`** asks `os.path.samefile()` rather than `os.path.isfile()`. On NTFS and APFS the target "exists" because it *is* this song; on ext4 two songs really can differ only in case, and that one is still a clash. One predicate, so the check cannot drift from the write.
- **`_rename_path()` hops via a temp name** when the destination resolves to the source. Applied to companions too, so a `.cdg` or `.ass` follows its song through the hop.
- **The edit page points at the predicate**, replacing the bare `isfile` test. The "already named that" early return is unchanged.
- **Tests cover both filesystems' behaviour** — the assertions hold on ext4 and catch the bug on NTFS. `test_changing_only_the_case_is_not_a_collision` fails without the fix.

The batch renamer has carried this technique inline since before `SongManager` owned renaming, guarded by a `.lower()` string comparison that suppresses the clash check outright — on ext4 it renames one song over another. That copy retires when the route moves onto `SongManager`, in a follow-up branch.

## Test plan

- [x] Edit page: rename a song changing only capitalisation — it saves, and the browse list shows the new case
- [x] Edit page: rename a song to a *different* existing song's name — still refused with "already exists"
- [x] Rename a CDG song with a `.cdg` alongside it, changing only case — both files follow
- [x] An ordinary rename to a wholly new name still works
