### PR TITLE
fix: stop the batch renamer dropping YouTube ids

### DIFF
--- a/pikaraoke/routes/batch_song_renamer.py
+++ b/pikaraoke/routes/batch_song_renamer.py
@@ -5,6 +5,7 @@ import unicodedata
 
 import flask_babel
 from flask import (
+    Response,
     jsonify,
     redirect,
     render_template,
@@ -127,8 +128,8 @@ def _names_match(name: str, correct_name: str | None) -> bool:
     return normalized_name == normalized_correct
 
 
-def _error_response(message: str) -> dict:
-    return {"success": False, "message": message, "categoryClass": "is-danger"}
+def _error(message: str) -> Response:
+    return jsonify({"success": False, "message": message, "categoryClass": "is-danger"})
 
 
 @batch_song_renamer_bp.route("/batch-song-renamer", methods=["GET"])
@@ -239,36 +240,28 @@ def rename_song(form):
 
     if k.is_song_in_use(old_name):
         # MSG: Message shown after trying to edit a song that is queued or playing.
-        return jsonify(
-            _error_response(
-                _("Error: Can't edit this song because it is queued or playing") + ": " + old_name
-            )
+        return _error(
+            _("Error: Can't edit this song because it is queued or playing: %s") % old_name
         )
 
     target = k.song_manager.rename_target(old_name, new_name)
     if rename_collides(old_name, target):
         # MSG: Message shown after trying to rename a file to a name that already exists.
-        return jsonify(
-            _error_response(
-                _("Error renaming file: '%s' to '%s', Filename already exists")
-                % (old_name, os.path.basename(target))
-            )
+        return _error(
+            _("Error renaming file: '%s' to '%s', Filename already exists")
+            % (old_name, os.path.basename(target))
         )
 
     try:
         new_path = k.rename_song(old_name, new_name)
     except SongInUseError:
         # MSG: Message shown when the song being renamed started playing mid-edit.
-        return jsonify(
-            _error_response(
-                _(
-                    "This song started playing while you were editing it. Rename it when it finishes."
-                )
-            )
+        return _error(
+            _("This song started playing while you were editing it. Rename it when it finishes.")
         )
     except OSError as e:
         logging.error(f"Error renaming file: {e}")
         # MSG: Message shown after a rename failed. Followed by the system error.
-        return jsonify(_error_response(_("Error renaming file: %s") % e))
+        return _error(_("Error renaming file: %s") % e)
 
     return jsonify({"success": True, "new_file_name": new_path})

--- a/pikaraoke/routes/batch_song_renamer.py
+++ b/pikaraoke/routes/batch_song_renamer.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import re
-import time
 import unicodedata
 
 import flask_babel
@@ -16,8 +16,10 @@ from flask_paginate import Pagination
 from flask_smorest import Blueprint
 from marshmallow import Schema, fields
 
+from pikaraoke.karaoke import SongInUseError
 from pikaraoke.lib.current_app import get_karaoke_instance, get_site_name, is_admin
-from pikaraoke.lib.metadata_parser import clear_song_name_cache, get_song_correct_name
+from pikaraoke.lib.metadata_parser import get_song_correct_name, youtube_id_suffix
+from pikaraoke.lib.song_manager import rename_collides
 
 _ = flask_babel.gettext
 
@@ -230,44 +232,43 @@ def get_songs_to_rename(query):
 def rename_song(form):
     """Rename a song file."""
     k = get_karaoke_instance()
-
-    if "new_name" not in form or "old_name" not in form:
-        # MSG: Message shown after trying to edit a song without specifying the filename.
-        return jsonify(_error_response(_("Error: No filename parameters were specified!")))
-
-    new_name = form["new_name"].strip()
     old_name = form["old_name"]
+    # The proposal is a display name. The YouTube id lives only in the
+    # filename, and nothing can recover it once a rename drops it.
+    new_name = form["new_name"].strip() + youtube_id_suffix(old_name)
 
-    if k.queue_manager.is_song_in_queue(old_name):
-        # MSG: Message shown after trying to edit a song that is in the queue.
+    if k.is_song_in_use(old_name):
+        # MSG: Message shown after trying to edit a song that is queued or playing.
         return jsonify(
             _error_response(
-                _("Error: Can't edit this song because it is in the current queue: ") + old_name
+                _("Error: Can't edit this song because it is queued or playing") + ": " + old_name
             )
         )
 
-    file_extension = os.path.splitext(old_name)[1]
-    old_filename = k.song_manager.filename_from_path(old_name, remove_youtube_id=False)
-    new_full_path = os.path.join(k.song_manager.download_path, new_name + file_extension)
-    is_case_only_rename = old_filename.lower() == new_name.lower() and old_filename != new_name
-
-    # Block renaming to an existing file (unless it's just a case change)
-    if os.path.isfile(new_full_path) and not is_case_only_rename:
+    target = k.song_manager.rename_target(old_name, new_name)
+    if rename_collides(old_name, target):
         # MSG: Message shown after trying to rename a file to a name that already exists.
         return jsonify(
             _error_response(
                 _("Error renaming file: '%s' to '%s', Filename already exists")
-                % (old_name, new_name + file_extension)
+                % (old_name, os.path.basename(target))
             )
         )
 
-    if is_case_only_rename:
-        # Two-step rename for case-insensitive filesystems (e.g. Windows)
-        temp_name = f"{new_name}_temp_{int(time.time() * 1000)}"
-        k.song_manager.rename(old_name, temp_name)
-        temp_path = os.path.join(k.song_manager.download_path, temp_name + file_extension)
-        k.song_manager.rename(temp_path, new_name)
-    else:
-        k.song_manager.rename(old_name, new_name)
+    try:
+        new_path = k.rename_song(old_name, new_name)
+    except SongInUseError:
+        # MSG: Message shown when the song being renamed started playing mid-edit.
+        return jsonify(
+            _error_response(
+                _(
+                    "This song started playing while you were editing it. Rename it when it finishes."
+                )
+            )
+        )
+    except OSError as e:
+        logging.error(f"Error renaming file: {e}")
+        # MSG: Message shown after a rename failed. Followed by the system error.
+        return jsonify(_error_response(_("Error renaming file: %s") % e))
 
-    return jsonify({"success": True, "new_file_name": new_full_path})
+    return jsonify({"success": True, "new_file_name": new_path})

--- a/tests/unit/test_batch_renamer.py
+++ b/tests/unit/test_batch_renamer.py
@@ -1,6 +1,54 @@
 """Unit tests for batch_song_renamer route-level logic."""
 
-from pikaraoke.routes.batch_song_renamer import _names_match
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import werkzeug
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "3.0.0"
+
+from pikaraoke.karaoke import SongInUseError
+from pikaraoke.lib.metadata_parser import sanitize_filename
+from pikaraoke.routes.batch_song_renamer import _names_match, batch_song_renamer_bp
+from tests.conftest import make_route_app
+
+
+@pytest.fixture
+def app():
+    return make_route_app(batch_song_renamer_bp, [("/browse", "files.browse")])
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _renamed(path, name):
+    return str(Path(path).parent / (sanitize_filename(name) + Path(path).suffix))
+
+
+def _karaoke_for_rename(in_use=()):
+    """A karaoke stand-in answering only what the rename route asks it."""
+    k = MagicMock()
+    k.is_song_in_use.side_effect = lambda path: path in in_use
+    # Explicitly false: the queue is what the route used to ask, and it does
+    # not hold the song being played. Only is_song_in_use may refuse here.
+    k.queue_manager.is_song_in_queue.return_value = False
+    k.song_manager.rename_target.side_effect = _renamed
+    k.rename_song.side_effect = _renamed
+    return k
+
+
+def _accept(client, k, old_name, new_name):
+    """POST the accept button's form, as the page's jQuery does."""
+    with patch("pikaraoke.routes.batch_song_renamer.get_karaoke_instance", return_value=k):
+        response = client.post(
+            "/batch-song-renamer/rename-song",
+            data={"old_name": old_name, "new_name": new_name},
+        )
+    return response.get_json()
 
 
 class TestNamesMatch:
@@ -29,3 +77,72 @@ class TestNamesMatch:
 
     def test_empty_strings(self):
         assert _names_match("", "") is True
+
+
+class TestAcceptingASuggestion:
+    """The accept button renames through the same path as the edit page."""
+
+    def test_the_youtube_id_survives(self, client, tmp_path):
+        """Dropping it costs re-download dedup and play-history identity, unrecoverably."""
+        song = str(tmp_path / "Whatever (Official Video)---dQw4w9WgXcQ.mp4")
+        k = _karaoke_for_rename()
+
+        body = _accept(client, k, song, "Rick Astley - Never Gonna Give You Up")
+
+        assert body["success"] is True
+        k.rename_song.assert_called_once_with(
+            song, "Rick Astley - Never Gonna Give You Up---dQw4w9WgXcQ"
+        )
+
+    def test_the_song_stays_in_its_subfolder(self, client, tmp_path):
+        """It used to be rebuilt under download_path, so the reply named a path that was not there."""
+        folder = tmp_path / "Pop"
+        folder.mkdir()
+        song = str(folder / "Old---dQw4w9WgXcQ.mp4")
+        k = _karaoke_for_rename()
+
+        body = _accept(client, k, song, "New Name")
+
+        assert Path(body["new_file_name"]).parent == folder
+
+    def test_a_playing_song_is_refused(self, client, tmp_path):
+        """is_song_in_queue misses it: the queue no longer holds the song being played."""
+        song = str(tmp_path / "Old---dQw4w9WgXcQ.mp4")
+        k = _karaoke_for_rename(in_use=(song,))
+
+        body = _accept(client, k, song, "New Name")
+
+        assert body["success"] is False
+        k.rename_song.assert_not_called()
+
+    def test_a_name_collision_is_refused(self, client, tmp_path):
+        song = str(tmp_path / "Old---dQw4w9WgXcQ.mp4")
+        Path(song).write_text("fake")
+        (tmp_path / "Taken---dQw4w9WgXcQ.mp4").write_text("fake")
+        k = _karaoke_for_rename()
+
+        body = _accept(client, k, song, "Taken")
+
+        assert body["success"] is False
+        assert "already exists" in body["message"]
+        k.rename_song.assert_not_called()
+
+    def test_a_song_that_starts_playing_mid_rename_is_reported(self, client, tmp_path):
+        song = str(tmp_path / "Old---dQw4w9WgXcQ.mp4")
+        k = _karaoke_for_rename()
+        k.rename_song.side_effect = SongInUseError(song)
+
+        body = _accept(client, k, song, "New Name")
+
+        assert body["success"] is False
+
+    def test_a_filesystem_failure_is_reported_not_raised(self, client, tmp_path):
+        """A restricted charset mount raises on a non-ASCII name; it used to 500."""
+        song = str(tmp_path / "Old---dQw4w9WgXcQ.mp4")
+        k = _karaoke_for_rename()
+        k.rename_song.side_effect = OSError("Invalid argument")
+
+        body = _accept(client, k, song, "Céline Dion - Pour que tu m'aimes encore")
+
+        assert body["success"] is False
+        assert "Invalid argument" in body["message"]


### PR DESCRIPTION
**Why:** an admin who accepts a suggested name on the batch renamer keeps the song's YouTube id. Today every accept strips it, and nothing puts it back: re-download dedup, the `youtube_id` column on the next scan and play-history identity all go with it, none of them recoverable from the filename afterwards.

The route predates `rename_target()`, `rename_collides()` and `Karaoke.rename_song()`, and had grown its own version of each. Every defect below comes from one of those copies rather than from the logic it duplicates, so the fix is to delete them and call what the edit page calls.

- **The YouTube id is re-appended** with `youtube_id_suffix()`, as `/files/edit` has always done. The accept button posts a display name; the id exists only in the filename.
- **`rename_target()` picks the destination**, so a song filed in a subfolder stays there. The hand-built path joined `download_path`, checked the wrong directory for a clash, skipped sanitizing, and returned that path to the browser, which wrote it back into the row — a second accept then aimed at a file that was never written.
- **`rename_collides()` answers the clash question.** It retires the inline two-step hop, whose `.lower()` comparison suppressed the clash check outright, so on ext4 it renamed one song over another.
- **`Karaoke.rename_song()` applies it** under the playback lock, carrying any queue entry across. `SongInUseError` and `OSError` are reported to the page; an `OSError` used to reach it as a 500 mid-library.
- **`is_song_in_use()` replaces `is_song_in_queue()`**, which misses the one song a queue never holds: the one playing.
- **Two dead branches go:** a missing-parameter guard the schema already rejects with a 422, and an unused `clear_song_name_cache` import.
- **The four refusal paths share one helper.** `_error_response` returned a dict every call site then wrapped in `jsonify`, three calls deep; `_error` returns the response itself. The in-use message uses `%s` rather than concatenation, so locales that space punctuation differently can place the colon.

Six route tests cover the accept button; all six fail against the previous route.

## Test plan

- [x] Accept a suggestion for a YouTube-sourced song — the new filename keeps its `---id` suffix
- [x] Accept a suggestion for a song in a subfolder — it stays in that folder, and a second accept on the same row works
- [x] Accept a name another song already has — refused with "already exists", nothing renamed
- [x] Queue a song, then accept a suggestion for it — refused, and the same for the song currently playing
- [x] Accept a suggestion for an uploaded song with no YouTube id — renames cleanly
