### PR TITLE
fix: stop a raced rename overwriting a song

### DIFF
--- a/pikaraoke/lib/song_manager.py
+++ b/pikaraoke/lib/song_manager.py
@@ -292,12 +292,19 @@ class SongManager:
         Args:
             song_path: Full path to the current song file.
             new_name: New filename (without extension).
+
+        Raises:
+            FileExistsError: `new_name` is already another song's file.
         """
         new_name = sanitize_filename(new_name)
         logging.info(f"Renaming song: '{song_path}' to: {new_name}")
         companions = self._get_companion_files(song_path)
         dirpath = os.path.dirname(song_path)
         new_path = self.rename_target(song_path, new_name)
+        # The caller's pre-check races: POSIX os.rename replaces an existing
+        # target silently, so the last word on a clash has to be here.
+        if rename_collides(song_path, new_path):
+            raise FileExistsError(f"'{os.path.basename(new_path)}' already exists")
         _rename_path(song_path, new_path)
         for companion in companions:
             companion_ext = os.path.splitext(companion)[1]

--- a/tests/unit/test_song_manager.py
+++ b/tests/unit/test_song_manager.py
@@ -164,6 +164,23 @@ class TestRename:
         sm.rename(_native(song), "Old Name---abc")
         assert [f.name for f in tmp_path.iterdir()] == ["Old Name---abc.mp4"]
 
+    def test_a_song_already_at_the_target_is_never_overwritten(self, tmp_path, mock_db):
+        """The route checks first, but that check is outside the lock this runs under."""
+        song = tmp_path / "Old---abc.mp4"
+        taken = tmp_path / "Taken---def.mp4"
+        song.write_text("fake")
+        taken.write_text("keep me")
+        sm = SongManager(str(tmp_path), db=mock_db, events=EventSystem())
+        sm.songs.add_if_valid(_native(song))
+
+        with pytest.raises(FileExistsError) as excinfo:
+            sm.rename(_native(song), "Taken---def")
+
+        # Our refusal, not the one os.rename raises for itself on Windows only.
+        assert "'Taken---def.mp4' already exists" in str(excinfo.value)
+        assert taken.read_text() == "keep me"
+        assert song.exists()
+
     def test_renames_cdg_companion(self, tmp_path, mock_db):
         song = tmp_path / "Old---abc.mp4"
         cdg = tmp_path / "Old---abc.cdg"


### PR DESCRIPTION
**Why:** an admin renaming a song on the Pi can currently destroy a different song and never be told; after this they get an error message and both files survive.

- `SongManager.rename` re-checks `rename_collides` against the target it is about to write, and raises `FileExistsError` on a clash. Both rename routes already catch `OSError`, so the refusal surfaces on the edit page and in the batch renamer's toast with no route changes.
- The check runs inside `Karaoke.rename_song`'s playback lock, which is what makes it authoritative. The routes' existing pre-checks stay: outside the lock they are a UX check producing a better-worded message and preserving the typed name, and they still handle every non-raced clash.
- The window this closes is narrow but silent on the platform that matters. `os.rename` raises `FileExistsError` on Windows, so a clash there was already reported; on Linux and the Pi it replaces the destination without a word, so two admins renaming at once — or a download completing on that name between check and rename — lost a song with no log line and no error.

## Test plan

- [x] Rename a song from the edit page to a free name. It moves, and the flash names the new file.
- [x] Rename a song to a name another song already has. The edit page comes back with "A song called 'X' already exists." and the name you typed still in the box.
- [x] Accept a suggestion in the batch renamer that collides with an existing song. The toast reports it and neither file changes.
- [x] Rename a song to the same name in another case (`old name` to `Old Name`). Still succeeds.
- [x] Rename a song that has a `.cdg` or `.ass` companion. Both files follow.
