### PR TITLE
chore: update translations

### DIFF
--- a/build_scripts/update_translations.py
+++ b/build_scripts/update_translations.py
@@ -208,9 +208,14 @@ def translate_entry(entry: polib.POEntry, translator: GoogleTranslator) -> str |
         return None
 
 
-def auto_translate() -> None:
-    """Find untranslated and fuzzy entries in all .po files and translate them."""
+def auto_translate() -> dict[str, list[tuple[str, str]]]:
+    """Find untranslated and fuzzy entries in all .po files and translate them.
+
+    Returns the one-word strings written, keyed by msgid, for `report_one_word`.
+    """
     print("\n--- Auto-translate ---")
+
+    one_word: dict[str, list[tuple[str, str]]] = {}
 
     for locale, google_code in LOCALE_TO_GOOGLE.items():
         po_path = TRANSLATIONS_DIR / locale / "LC_MESSAGES" / "messages.po"
@@ -253,6 +258,8 @@ def auto_translate() -> None:
                         if existing
                         else AUTO_TRANSLATED_COMMENT
                     )
+                if len(entry.msgid.split()) == 1:
+                    one_word.setdefault(entry.msgid, []).append((locale, result))
                 translated_count += 1
                 print(".", end="", flush=True)
         except KeyboardInterrupt:
@@ -263,6 +270,26 @@ def auto_translate() -> None:
         print()  # newline after dots
         po.save(str(po_path))
         print(f"  {locale}: translated {translated_count}/{len(entries_to_translate)} entries")
+
+    return one_word
+
+
+def report_one_word(one_word: dict[str, list[tuple[str, str]]]) -> None:
+    """Print the one-word strings across locales, for review.
+
+    `_validate_placeholders` checks structure, not sense, and a msgid with no
+    sentence around it is where the sense goes wrong: a run returned "ETA" as the
+    name of a Thai government agency.
+    """
+    if not one_word:
+        return
+
+    print("\n--- Review: one-word strings ---")
+    for msgid in sorted(one_word):
+        print(f"\n  {msgid}")
+        for locale, msgstr in sorted(one_word[msgid]):
+            print(f"    {locale:12} {msgstr}")
+    print(f"\n  {len(one_word)} to check. Longer strings carry their own context; these do not.")
 
 
 def compile_translations() -> None:
@@ -279,6 +306,9 @@ def compile_translations() -> None:
 
 
 def main() -> None:
+    # The review report prints Thai and CJK, which a cp1252 Windows console cannot encode.
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
     parser = argparse.ArgumentParser(description="Automated translation workflow for PiKaraoke")
     parser.add_argument(
         "--extract-po-only",
@@ -306,10 +336,12 @@ def main() -> None:
         if not args.keep_obsolete:
             prune_obsolete()
 
+    one_word: dict[str, list[tuple[str, str]]] = {}
     if not args.extract_po_only:
-        auto_translate()
+        one_word = auto_translate()
 
     compile_translations()
+    report_one_word(one_word)
     print("\nDone!")
 
 

--- a/pikaraoke/_TRANSLATION.md
+++ b/pikaraoke/_TRANSLATION.md
@@ -66,6 +66,12 @@ python build_scripts/update_translations.py --keep-obsolete
 Auto-translated entries are marked with an `# auto-translated` translator
 comment. Search for this comment to find entries that need human review.
 
+The run ends by listing every one-word string it translated, side by side
+across locales. Those are where machine translation goes wrong: a longer
+string carries its own context, but a bare label does not, and a run
+returned `ETA` as the name of a Thai government agency. Read that list
+before committing.
+
 Obsolete entries (`#~` prefixed, left behind when a `msgid` is removed or
 changed beyond recognition) are pruned automatically during the update step.
 Pass `--keep-obsolete` to retain them.

--- a/pikaraoke/messages.pot
+++ b/pikaraoke/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,39 +31,39 @@ msgstr ""
 msgid "Volume: %s"
 msgstr ""
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr ""
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr ""
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr ""
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr ""
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr ""
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr ""
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr ""
 
@@ -100,19 +100,19 @@ msgstr ""
 msgid "Pause: %s"
 msgstr ""
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr ""
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr ""
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr ""
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr ""
 
@@ -156,165 +156,191 @@ msgid "Failed to prepare stream"
 msgstr ""
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr ""
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr ""
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr ""
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr ""
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr ""
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr ""
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr ""
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr ""
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr ""
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr ""
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr ""
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr ""
 
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr ""
+
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr ""
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr ""
 
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr ""
 
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr ""
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
 
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr ""
-
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr ""
-
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr ""
-
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr ""
-
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr ""
-
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr ""
-
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr ""
-
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or "
-"deleted from another device."
-msgstr ""
-
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr ""
-
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
 msgstr ""
 
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr ""
 
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr ""
+
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr ""
+
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr ""
+
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr ""
+
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr ""
+
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr ""
+
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr ""
+
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or "
+"deleted from another device."
+msgstr ""
+
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr ""
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
+msgstr ""
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr ""
+
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
 msgstr ""
 
 #: routes/info.py:116
@@ -331,79 +357,105 @@ msgstr ""
 msgid "You don't have permission to clear preferences"
 msgstr ""
 
-#: routes/queue.py:80
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr ""
+
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr ""
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr ""
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr ""
 
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr ""
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr ""
 
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr ""
 
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr ""
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr ""
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr ""
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr ""
 
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr ""
 
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr ""
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr ""
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr ""
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr ""
 
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr ""
 
 #. Message shown when a non-admin tries to open a host-only history page
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
+msgstr ""
+
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr ""
+
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr ""
+
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
 msgstr ""
 
 #. Error when starting a session without supplying a name
@@ -434,16 +486,16 @@ msgstr ""
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr ""
 
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr ""
 
@@ -529,39 +581,32 @@ msgstr ""
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 
-#. Confirmation dialog when removing a song from the queue. {title} is replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr ""
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr ""
 
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr ""
 
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr ""
 
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr ""
 
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used"
 " in classical Western music, equal to a twelfth of an octave or half a "
@@ -570,20 +615,20 @@ msgstr ""
 
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
 msgstr ""
 
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr ""
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -591,45 +636,18 @@ msgstr ""
 
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr ""
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr ""
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr ""
-
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr ""
-
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr ""
-
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr ""
-
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr ""
-
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are "
 "compared online. Loading time may vary\n"
@@ -637,19 +655,19 @@ msgid ""
 msgstr ""
 
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
 msgstr ""
 
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr ""
 
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -657,12 +675,12 @@ msgstr ""
 
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr ""
 
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr ""
 
@@ -677,100 +695,95 @@ msgstr ""
 msgid "No suggestion!"
 msgstr ""
 
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr ""
-
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr ""
 
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr ""
 
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr ""
 
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr ""
 
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr ""
 
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr ""
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr ""
 
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr ""
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr ""
 
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr ""
 
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr ""
 
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr ""
 
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr ""
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr ""
 
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr ""
 
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr ""
 
 #. Button which changes how the songs are sorted so they become sorted by name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr ""
 
 #. Button which changes how the songs are sorted so they become sorted by date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr ""
 
@@ -781,13 +794,13 @@ msgstr ""
 
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr ""
 
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr ""
 
@@ -801,44 +814,44 @@ msgstr ""
 msgid "Playing"
 msgstr ""
 
-#: templates/history.html:182 templates/queue.html:164 templates/queue.html:326
+#: templates/history.html:182 templates/queue.html:164 templates/queue.html:386
 #: templates/sessions.html:153
 msgid "Options"
 msgstr ""
 
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr ""
 
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr ""
 
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr ""
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr ""
 
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr ""
 
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr ""
 
@@ -865,46 +878,41 @@ msgid ""
 "ask permission first!"
 msgstr ""
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr ""
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr ""
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr ""
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr ""
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr ""
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr ""
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr ""
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr ""
 
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr ""
 
@@ -939,7 +947,7 @@ msgstr ""
 
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
 
@@ -947,7 +955,7 @@ msgstr ""
 msgid "Scanning..."
 msgstr ""
 
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr ""
 
@@ -968,322 +976,322 @@ msgstr ""
 msgid "Library sync complete"
 msgstr ""
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr ""
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr ""
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr ""
 
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr ""
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr ""
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr ""
 
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid "Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr ""
 
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr ""
 
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr ""
 
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr ""
 
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr ""
 
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr ""
 
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr ""
 
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr ""
 
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr ""
 
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr ""
 
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr ""
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr ""
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr ""
 
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr ""
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr ""
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr ""
 
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr ""
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr ""
 
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr ""
 
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr ""
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr ""
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr ""
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set"
 " to 0 to disable it."
 msgstr ""
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr ""
 
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr ""
 
-#: templates/info.html:555
+#: templates/info.html:548
 msgid "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
 
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr ""
 
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr ""
 
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr ""
 
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr ""
 
-#: templates/info.html:582
+#: templates/info.html:575
 msgid "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
 
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr ""
 
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr ""
 
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr ""
 
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr ""
 
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr ""
 
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr ""
 
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr ""
 
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr ""
 
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr ""
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr ""
 
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr ""
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr ""
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr ""
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr ""
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
 msgstr ""
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU"
 " usage)"
 msgstr ""
 
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke"
 " Version HD\")"
 msgstr ""
 
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
 msgstr ""
 
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr ""
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before "
 "sending it to the splash screen. "
@@ -1291,110 +1299,110 @@ msgstr ""
 
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr ""
 
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
 msgstr ""
 
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate "
 "(macOS)."
 msgstr ""
 
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr ""
 
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr ""
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr ""
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr ""
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr ""
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr ""
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr ""
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr ""
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr ""
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr ""
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr ""
 
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr ""
 
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr ""
 
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr ""
 
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr ""
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr ""
 
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr ""
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1406,13 +1414,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr ""
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file "
 "permissions.\n"
@@ -1420,19 +1428,19 @@ msgid ""
 msgstr ""
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr ""
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr ""
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card "
 "is larger than 4GB,\n"
@@ -1441,24 +1449,43 @@ msgid ""
 "\t\t\t\t\t\t\tThis will reboot the system."
 msgstr ""
 
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in"
+" again."
 msgstr ""
 
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr ""
+
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr ""
+
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr ""
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr ""
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1466,17 +1493,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr ""
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr ""
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr ""
 
@@ -1524,101 +1551,135 @@ msgstr ""
 msgid "Start a session to queue for singers"
 msgstr ""
 
-#: templates/queue.html:214
-msgid "Pending downloads"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
 msgstr ""
 
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+msgid "Downloading video"
+msgstr ""
+
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+msgid "Downloading audio"
+msgstr ""
+
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr ""
+
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr ""
+
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr ""
 
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr ""
+
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr ""
+
+#: templates/queue.html:276
 msgid "Queued"
 msgstr ""
 
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr ""
 
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr ""
 
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr ""
 
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr ""
 
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr ""
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr ""
 
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr ""
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr ""
 
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> random songs"
 msgstr ""
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr ""
 
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr ""
 
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr ""
 
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr ""
 
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr ""
 
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr ""
 
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr ""
 
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr ""
 
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr ""
 
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr ""
 
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr ""
 
@@ -1634,22 +1695,22 @@ msgstr ""
 
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr ""
 
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr ""
 
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr ""
 
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr ""
 
@@ -1660,52 +1721,52 @@ msgid "Adding..."
 msgstr ""
 
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr ""
 
 #. Subtitle under the Add New heading, explaining that this page gets songs the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr ""
 
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr ""
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr ""
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr ""
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr ""
 
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr ""
 
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr ""
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1713,14 +1774,14 @@ msgid ""
 msgstr ""
 
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 msgstr ""
 
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to"
 " watch it."
@@ -1793,73 +1854,73 @@ msgid "Show these plays"
 msgstr ""
 
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr ""
 
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr ""
 
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr ""
 
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr ""
 
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr ""
 
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr ""
 
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr ""
 
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr ""
 
 #. Menu item which makes an old session the one new songs are recorded against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr ""
 
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr ""
 
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr ""
 
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr ""
 
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr ""
 

--- a/pikaraoke/translations/de_DE/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/de_DE/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-13 22:53-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: de_DE <LL@li.org>\n"
@@ -32,39 +32,39 @@ msgstr "Transponieren um %s Halbtöne: %s"
 msgid "Volume: %s"
 msgstr "Lautstärke: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Heruntergeladen und in die Warteschlange eingereiht (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Video wird heruntergeladen: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Video wird heruntergeladen: %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Fehler beim Herunterladen des Liedes: "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Heruntergeladen und in die Warteschlange eingereiht: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Heruntergeladen: %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Fehler beim Hinzufügen des Liedes zur Warteschlange: "
 
@@ -104,19 +104,19 @@ msgstr "Fortsetzen: %s"
 msgid "Pause: %s"
 msgstr "Pause: %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Die Einstellungen wurden erfolgreich geändert"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Etwas ist schiefgelaufen! Die Einstellungen wurden nicht geändert"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Die Einstellungen wurden erfolgreich zurückgesetzt"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr ""
 "Etwas ist schiefgelaufen! Die Einstellungen wurden nicht zurückgesetzt"
@@ -165,169 +165,125 @@ msgid "Failed to prepare stream"
 msgstr "Stream konnte nicht vorbereitet werden"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "yt-dlp wird aktualisiert! Dies sollte ein bis zwei Minuten dauern..."
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Keine Berechtigung, yt-dlp zu aktualisieren"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Pikaraoke wird jetzt beendet!"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Keine Berechtigung, das Programm zu beenden"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "System wird jetzt heruntergefahren!"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Keine Berechtigung, das System herunterzufahren"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "System wird jetzt neu gestartet!"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Keine Berechtigung, das System neu zu starten"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Dateisystem wird erweitert und das System wird neu gestartet!"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
 "Dateisystem kann auf Nicht-Raspberry-Pi-Geräten nicht erweitert werden!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Keine Berechtigung, das Dateisystem zu ändern"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Admin-Modus aktiviert!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Falsches Admin-Passwort!"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "Sie sind nicht berechtigt, das Administratorkennwort zu ändern"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "Admin-Passwort festgelegt. Andere Geräte müssen sich erneut anmelden."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "Admin-Passwort gelöscht. Jeder ist wieder ein Admin."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Admin-Modus verlassen!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Akzeptieren Sie den vorgeschlagenen Namen"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Batch-Song-Umbenennung"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Fehler: Keine Dateinamenparameter angegeben!"
-
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Fehler: Dieses Lied kann nicht bearbeitet werden, da es in der aktuellen "
-"Warteschlange ist: "
+"Fehler: Dieses Lied kann nicht bearbeitet werden, da es sich in der "
+"Warteschlange befindet oder abgespielt wird: %s"
 
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 "Fehler beim Umbenennen der Datei: '%s' in '%s', Dateiname existiert bereits"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Lieder"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Sie sind nicht berechtigt, Songs zu löschen"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Fehler: Dieses Lied kann nicht gelöscht werden, da es sich in der "
-"Warteschlange befindet oder abgespielt wird"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Lied gelöscht: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Sie sind nicht berechtigt, Songs umzubenennen"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Dieses Lied wird abgespielt. Benennen Sie es um, wenn es fertig ist."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Geben Sie einen Namen für dieses Lied ein."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Dieses Lied ist nicht mehr in der Bibliothek. Möglicherweise wurde es "
-"umbenannt oder von einem anderen Gerät gelöscht."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Ein Lied namens „%s“ existiert bereits."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -337,16 +293,92 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Fehler beim Umbenennen der Datei: %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Lieder"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Sie sind nicht berechtigt, Songs zu löschen"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Fehler: Dieses Lied kann nicht gelöscht werden, da es sich in der "
+"Warteschlange befindet oder abgespielt wird"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Lied gelöscht: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Song umbenennen"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Sie sind nicht berechtigt, Songs umzubenennen"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Dieses Lied wird abgespielt. Benennen Sie es um, wenn es fertig ist."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Geben Sie einen Namen für dieses Lied ein."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Dieses Lied ist nicht mehr in der Bibliothek. Möglicherweise wurde es "
+"umbenannt oder von einem anderen Gerät gelöscht."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Ein Lied namens „%s“ existiert bereits."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Datei umbenannt: %s in %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Jetzt läuft"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Einstellungen"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -362,80 +394,86 @@ msgstr "Keine Berechtigung, Einstellungen zu ändern"
 msgid "You don't have permission to clear preferences"
 msgstr "Keine Berechtigung, Einstellungen zu löschen"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Warteschlange"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Sie sind nicht berechtigt, zufällige Songs hinzuzufügen"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "%s zufällige Titel hinzugefügt"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Nicht genügend Lieder zum Hinzufügen!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Nicht autorisiert"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Warteschlange wurde geleert!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "An den Anfang der Warteschlange verschoben"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Ans Ende der Warteschlange verschoben"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "In der Warteschlange nach oben verschoben"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "In der Warteschlange nach unten verschoben"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Aus der Warteschlange entfernt"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Fehler beim Verschieben an den Anfang der Warteschlange"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Fehler beim Verschieben an das Ende der Warteschlange"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Fehler beim Verschieben in der Warteschlange nach oben"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Fehler beim Verschieben in der Warteschlange nach unten"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Fehler beim Entfernen aus der Warteschlange"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Neu hinzufügen"
 
@@ -444,6 +482,29 @@ msgstr "Neu hinzufügen"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Sie haben keine Berechtigung, diese Seite anzuzeigen"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Sitzungen"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Spielverlauf"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Ranglisten"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -479,8 +540,8 @@ msgstr "Gespielt bei"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Künstler"
 
@@ -488,8 +549,8 @@ msgstr "Künstler"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Lied"
 
@@ -583,25 +644,15 @@ msgstr ""
 "Sind Sie sicher, dass Sie die GESAMTE Warteschlange löschen möchten? Geben "
 "Sie „OK“ ein, um fortzufahren"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr ""
-"Sind Sie sicher, dass Sie {title} aus der Warteschlange löschen möchten?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Dieses Lied wirklich aus der Bibliothek löschen?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} Halbtöne"
@@ -609,20 +660,20 @@ msgstr "{value} Halbtöne"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Dieses Lied transponieren: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Möchten Sie diesen Titel wirklich neu starten?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -634,7 +685,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -644,13 +695,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Fehler"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -661,50 +712,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Aktuelle Sitzung: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Startseite"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Warteschlange"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Ranglisten"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Spielverlauf"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Sitzungen"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Einstellungen"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -714,7 +734,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -724,13 +744,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Nur Songs zum Umbenennen anzeigen"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -741,12 +761,12 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Alle Lieder anzeigen"
 
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Lieder werden geladen..."
 
@@ -764,117 +784,111 @@ msgid "No suggestion!"
 msgstr "Kein Vorschlag!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Song umbenennen"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Aktueller Dateiname"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Neuer Dateiname"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Automatische Formatierung"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Künstler/Titel tauschen"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Von iTunes vorschlagen"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes-Suchland"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Speichern"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Stornieren"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Dieses Lied löschen"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Massenumbenennung"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Verfügbar in der Bibliothek"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Alle Ordner"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Suche nach Titel, Künstler..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Löschen"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Alle Lieder"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Ordner"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Alphabetisch sortieren"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Nach Datum sortieren"
 
@@ -887,14 +901,14 @@ msgstr "Diesen Eintrag aus dem Spielprotokoll löschen?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Es wurde noch nichts gespielt."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Gespielt"
 
@@ -912,48 +926,48 @@ msgstr "Spielen"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Optionen"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Alle Interpreten anzeigen"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Ausblenden übersprungen"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Status"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Zur Warteschlange hinzufügen"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Dieses Lied ist nicht mehr in der Bibliothek"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
@@ -982,47 +996,42 @@ msgstr ""
 "Bist du sicher, dass du dieses Lied überspringen möchtest? Wenn du diesen "
 "Song nicht selbst hinzugefügt hast, frage um Erlaubnis!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Jetzt läuft"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Nächstes Lied"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Player-Steuerung"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Lied neu starten"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Abspielen/Pause"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Aktuelles Lied stoppen"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Tonart ändern"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Ändern"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Mikrofone"
 
@@ -1060,7 +1069,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1073,7 +1082,7 @@ msgid "Scanning..."
 msgstr "Scannen..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Aktualisieren"
 
@@ -1099,184 +1108,188 @@ msgstr "Spielverlauf gelöscht"
 msgid "Library sync complete"
 msgstr "Bibliothekssynchronisierung abgeschlossen"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Information"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL von %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Praktischer URL-QR-Code, um ihn mit einem Freund zu teilen:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Admin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Administratorpasswort eingeben"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Anmelden"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Vergessen? Starten Sie PiKaraoke mit --admin-password neu, um ein neues "
+"festzulegen."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Songbibliothek"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Bibliothek"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Lieder in der Bibliothek:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Jetzt synchronisieren"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Gleicht die Bibliothek mit dem Songverzeichnis im Hintergrund ab."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Umbenennung"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Künstler – Titel"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Titel – Künstler"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Reihenfolge der von iTunes vorgeschlagenen Songnamen"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Den gesamten Verlauf zurücksetzen"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Löscht jede Sitzung und jedes aufgezeichnete Spiel. Dies kann nicht "
 "rückgängig gemacht werden."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Benutzereinstellungen"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Einstellungen für den Begrüßungsbildschirm"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Hintergrundvideo deaktivieren"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Hintergrundmusik deaktivieren"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Bewertungsbildschirm nach jedem Lied deaktivieren"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Benachrichtigungen ausblenden"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Splash-Uhr anzeigen"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "URL und QR-Code ausblenden"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Blenden Sie das Logo auf dem Begrüßungsbildschirm aus"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Blenden Sie den Sitzungsnamen auf dem Begrüßungsbildschirm aus"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Alle Overlays ausblenden, einschließlich 'Jetzt läuft', 'Als Nächstes' und "
 "QR-Code"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Standardlautstärke der Videos (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Lautstärke der Hintergrundmusik (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1285,17 +1298,17 @@ msgstr ""
 " setzen."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Die Verzögerung in Sekunden vor dem Start des nächsten Liedes"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1303,27 +1316,27 @@ msgstr ""
 "weitergeleitet."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latenz"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Echounterdrückung"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Experimental"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(reduziert Feedback, erhöht die Latenz)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1331,24 +1344,24 @@ msgstr ""
 "nicht installiert."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Unter Linux/Raspberry Pi installieren Sie es mit:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "und starten Sie PiKaraoke neu."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Bewerten Sie Phrasen"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 "Fügen Sie in jedes Feld eine Phrase pro Zeile ein und klicken Sie auf "
@@ -1356,68 +1369,68 @@ msgstr ""
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Sätze mit NIEDRIGER Punktzahl (Punktzahl < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Könnte besser sein..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID-Score-Sätze (30 > Score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Das war ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Phrasen mit HOHER Punktzahl (60 < Punktzahl)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Wunderbar..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Spracheinstellungen"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Bevorzugte Sprache (Neustart erforderlich)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Servereinstellungen"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Audio-Lautstärke normalisieren"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Videos in hoher Qualität herunterladen"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1427,7 +1440,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1437,7 +1450,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1447,7 +1460,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1457,7 +1470,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1466,7 +1479,7 @@ msgstr ""
 "(negativ = Audio vorrücken | positiv = Audio verzögern)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limit an Liedern, die ein Benutzer zur Warteschlange hinzufügen kann (0 = "
@@ -1474,14 +1487,14 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Faire Warteschlange aktivieren (Round-Robin-Modus sorgt dafür, dass sich die"
 " Benutzer abwechseln)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1492,13 +1505,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Standardlieder pro Seite."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1508,7 +1521,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1517,98 +1530,98 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr ""
 "Halten Sie den Server wach: wird auf dieser Plattform nicht unterstützt."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Halten Sie den Server wach, während PiKaraoke läuft"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Einstellungen löschen"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Systemstatistiken"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Systeminfo"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Plattform:"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "OS-Version:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp-Version:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg-Version:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke-Version:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Systemstatistiken"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Laden..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Festplattennutzung:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Erinnerung:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Aktualisierungen"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP-Update"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1622,13 +1635,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "yt-dlp aktualisieren"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1637,19 +1650,19 @@ msgstr ""
 "fehlschlagen. Pikaraoke-Log auf Fehler überprüfen."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Sonstiges"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Raspberry Pi-Dateisystem erweitern"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1661,25 +1674,52 @@ msgstr ""
 "Das System startet hierzu neu."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Klicken Sie hier, um sich vom Administratormodus abzumelden."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Ändern Sie das Administratorkennwort. Jedes andere Gerät muss sich erneut "
+"anmelden."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Jeder im Netzwerk ist ein Administrator. Legen Sie ein Passwort fest, um die"
+" Steuerung des Players, die Songbearbeitung und das Herunterfahren für sich "
+"zu behalten."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Passwort speichern"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Passwort löschen"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Abmelden"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Herunterfahren"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1689,17 +1729,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Pikaraoke beenden"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "System neustarten"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "System herunterfahren"
 
@@ -1756,60 +1796,102 @@ msgid "Start a session to queue for singers"
 msgstr "Starten Sie eine Sitzung, um sich für Sänger anzumelden"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Ausstehende Downloads"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Vorbereiten"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Video herunterladen"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Audio herunterladen"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Zusammenführen"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Abgeschlossen"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Erneuter Versuch"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Ausstehende Downloads"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "In der Warteschlange"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Download-Fehler"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Wiederholen"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Zurückweisen"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Zum Neuanordnen ziehen"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "Die Warteschlange ist leer"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Spielen"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1819,60 +1901,60 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> zufällige Songs hinzu"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Alles löschen"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Als nächstes spielen"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Nach oben verschieben"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Nach oben bewegen"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Nach unten bewegen"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Nach unten bewegen"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Umbenennen"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Aus der Warteschlange entfernen"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Neustart"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Überspringen"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Download-Warteschlange"
 
@@ -1891,25 +1973,25 @@ msgstr "Rang"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Spielt"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Top-Songs"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Top-Performer"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Bisher hat niemand gesungen."
 
@@ -1922,7 +2004,7 @@ msgstr "Hinzufügen..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "In der Bibliothek"
 
@@ -1930,49 +2012,49 @@ msgstr "In der Bibliothek"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Fügen Sie neue Songs von YouTube hinzu"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Durchsuchen Sie YouTube nach Titel, Künstler ..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Suche"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Nicht-Karaoke-Treffer einbeziehen"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Erweitert"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Fügen Sie eine YouTube-URL ein:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Für später speichern"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1981,7 +2063,7 @@ msgstr "Suche auf Youtube nach <small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1991,7 +2073,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2085,86 +2167,86 @@ msgstr "Zeigen Sie diese Stücke"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Aktuelle Sitzung"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Benennen Sie diese Sitzung..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Sitzung starten"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Sitzung beenden"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Sitzungsverlauf"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Automatisch gestartet ausblenden"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sitzung"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Begonnen"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Aktiv werden"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "CSV exportieren"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Liste exportieren (Text)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Klare Spielzüge"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Sitzung löschen"
 

--- a/pikaraoke/translations/es_VE/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/es_VE/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: frederick.chang@hotmail.com\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-07-19 03:30-0400\n"
 "Last-Translator: FREDERICK CHANG <frederick.chang@hotmail.com>\n"
 "Language-Team: \n"
@@ -32,39 +32,39 @@ msgstr "Cambiando a %s semitonos: %s"
 msgid "Volume: %s"
 msgstr "Volumen: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Descargada y agregada a la cola (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Descargando vídeo: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Descargando vídeo: %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Error al descargar la canción: "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Descargada y agregada a la cola: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Descargado: %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Error al colocar la canción a la cola: "
 
@@ -104,19 +104,19 @@ msgstr "Reanudar: %s"
 msgid "Pause: %s"
 msgstr "Pausa: %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Tus preferencias se han modificado correctamente"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Algo ha ocurrido. Sus preferencias no se han modificado"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Tus preferencias se han borrado correctamente"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Algo ha ocurrido. Tus preferencias no se han borrado"
 
@@ -163,167 +163,128 @@ msgid "Failed to prepare stream"
 msgstr "No se pudo preparar la transmisión"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Actualizando yt-dlp! Deberia de tomar un minuto o dos... "
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "No tienes el permiso para actualizar yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Salir del pikaraoke ya!"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "No tienes permisos para salir"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Apagando el sistema ahora!"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "No tienes permiso para apagar"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Reiniciando el sistema ahora!"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "No tienes permisos para reiniciar"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Expandiendo los archivos de sistema y reiniciando el sistema ahora!"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "No se puede expandir fs en dispositivos que no sean de raspberry pi!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "No tienes permisos para cambiar el tamaño del sistema de archivos"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Modo Administrados Otorgado!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Contraseña Incorrecta del Administrador!"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "No tienes permiso para cambiar la contraseña de administrador"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Contraseña de administrador establecida. Otros dispositivos deberán iniciar "
+"sesión nuevamente."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr ""
+"Contraseña de administrador borrada. Todo el mundo vuelve a ser "
+"administrador."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Cerró la sesión en modo administrador!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Aceptar nombre sugerido"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Renombrador de canciones por lotes"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Error: No se especificaron parámetros de nombre de archivo!"
-
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Error: No se puede editar esta canción porque está actualmente en la cola: "
+"Error: No se puede editar esta canción porque está en cola o "
+"reproduciéndose: %s"
 
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 "Error renombrando archivo: '%s' to '%s', El nombre del archivo ya existe"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Canciones"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "No tienes permiso para eliminar canciones."
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Error: no se puede eliminar esta canción porque está en cola o "
-"reproduciéndose"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Canción borrada: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "No tienes permiso para cambiar el nombre de las canciones."
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Esta canción está sonando. Cambie el nombre cuando termine."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Introduce un nombre para esta canción."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Esta canción ya no está en la biblioteca. Es posible que se le haya cambiado"
-" el nombre o se haya eliminado de otro dispositivo."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Ya existe una canción llamada '%s'."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -333,16 +294,92 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Error al cambiar el nombre del archivo: %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Canciones"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "No tienes permiso para eliminar canciones."
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Error: no se puede eliminar esta canción porque está en cola o "
+"reproduciéndose"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Canción borrada: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Cambiar nombre de canción"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "No tienes permiso para cambiar el nombre de las canciones."
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Esta canción está sonando. Cambie el nombre cuando termine."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Introduce un nombre para esta canción."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Esta canción ya no está en la biblioteca. Es posible que se le haya cambiado"
+" el nombre o se haya eliminado de otro dispositivo."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Ya existe una canción llamada '%s'."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Archivo renombrado: %s to %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Reproduciendo"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Ajustes"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -358,80 +395,86 @@ msgstr "No tienes permisos para cambiar estas preferencias"
 msgid "You don't have permission to clear preferences"
 msgstr "No tienes permisos para borrar estas preferencias"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Lista de Espera o Cola"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "No tienes permiso para agregar canciones aleatorias"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Agregada %s canciones aleatorias"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "¡Se acabaron las canciones!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "No autorizado"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "¡Se limpió la cola!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Movido al principio de la cola"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Movido al final de la cola"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Subió en la cola"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Movido hacia abajo en la cola"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Eliminada de la cola"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Error al pasar al principio de la cola"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Error al pasar al final de la cola"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Error al subir en la cola"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Error al bajar en la cola"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Error al eliminar de la cola"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Agregar nuevo"
 
@@ -440,6 +483,29 @@ msgstr "Agregar nuevo"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "No tienes permiso para ver esta página."
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Sesiones"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Historial de juego"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Clasificaciones"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -475,8 +541,8 @@ msgstr "Jugado en"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Ejecutante"
 
@@ -484,8 +550,8 @@ msgstr "Ejecutante"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Canción"
 
@@ -578,24 +644,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "¿Está seguro de que desea borrar TODA la cola? Escribe ok para continuar"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "¿Está seguro de que desea eliminar {title} de la cola?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Estas seguro que quieres eliminar esta canción de la librería?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} semitonos"
@@ -603,20 +660,20 @@ msgstr "{value} semitonos"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponer esta canción: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "¿Estás seguro de que quieres reiniciar esta pista?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -628,7 +685,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -638,13 +695,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Error"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -655,50 +712,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sesión actual: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Inicio"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Lista de Espera o Cola"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Clasificaciones"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Historial de juego"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Sesiones"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Ajustes"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -708,7 +734,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -718,13 +744,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Mostrar solo canciones para cambiar el nombre"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -735,12 +761,12 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Mostrar todas las canciones"
 
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Cargando canciones..."
 
@@ -757,117 +783,111 @@ msgid "No suggestion!"
 msgstr "Ninguna sugerencia!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Cambiar nombre de canción"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Nombre de archivo actual"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Nuevo nombre de archivo"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Formato automático"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Intercambiar artista/título"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Sugerir desde iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "País de búsqueda de iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Guardar"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Borrar esta canción"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "cambio de nombre masivo"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Disponible en la biblioteca"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Todas las carpetas"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Buscar por título, artista..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Borrar"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Todas las canciones"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Carpetas"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Ordenar alfabéticamente"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Ordenar por fecha"
 
@@ -880,14 +900,14 @@ msgstr "¿Eliminar esta entrada del registro de reproducción?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Aún no se ha jugado nada."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Jugó"
 
@@ -905,48 +925,48 @@ msgstr "Jugando"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Opciones"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Mostrar todos los artistas"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Ocultar omitido"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Estado"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Añadir a la cola"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Esta canción ya no está en la biblioteca."
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Eliminar entrada"
 
@@ -975,47 +995,42 @@ msgstr ""
 "¿Estás seguro de que quieres saltarte esta canción? Si no agregaste esta "
 "canción, ¡Pide Permiso Primero!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Reproduciendo"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Siguiente canción"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Control del Reproductor"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Reiniciar canción"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Reproducir/Pausar"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Detener la canción actual"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Cambiar Tono"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Cambiar"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "micrófonos"
 
@@ -1053,7 +1068,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1066,7 +1081,7 @@ msgid "Scanning..."
 msgstr "Exploración..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Refrescar"
 
@@ -1092,184 +1107,188 @@ msgstr "Historial de juego borrado"
 msgid "Library sync complete"
 msgstr "Sincronización de biblioteca completa"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Información"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL de %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Código QR del URL para compartir con un amigo:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Administración"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Ingrese la contraseña del administrador"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Acceso"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"¿Lo olvidaste? Reinicie PiKaraoke con --admin-password para configurar una "
+"nueva."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Biblioteca de canciones"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Biblioteca"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Canciones en la biblioteca:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Sincronizar ahora"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr ""
 "Concilia la biblioteca con el directorio de canciones en segundo plano."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Cambiar el nombre"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artista - Título"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Título - Artista"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Orden de los nombres de canciones sugeridos por iTunes"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Restablecer todo el historial"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Elimina cada sesión y cada jugada registrada. Esto no se puede deshacer."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Preferencias del usuario"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Configuración de la presentación de pantalla"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Desactivar el vídeo de fondo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Desactivar la música de fondo"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Desactivar la pantalla de puntuación después de cada canción"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Ocultar notificaciones"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Mostrar reloj de bienvenida"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Ocultar la URL y el código QR"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Ocultar el logo en la pantalla de inicio"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Ocultar el nombre de la sesión en la pantalla de inicio"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Ocultar todas las superposiciones, incluidas las de reproducción actual, "
 "próximamente y el código QR"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volumen predeterminado de los vídeos (mín. 0, máx. 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volumen de la música de fondo (mín. 0, máx. 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1278,17 +1297,17 @@ msgstr ""
 "pantalla. Establézcalo en 0 para desactivarlo."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "El retraso en segundos antes de comenzar la siguiente canción"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1296,27 +1315,27 @@ msgstr ""
 "altavoces."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Estado latente"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Cancelación de eco"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Experimental"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(reduce la retroalimentación, agrega latencia)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1324,90 +1343,90 @@ msgstr ""
 "audio necesarias no están instaladas."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "En Linux/Raspberry Pi, instálelo con:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "y reinicie PiKaraoke."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Frases de partitura"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Agregue una frase por línea en cada cuadro y presione guardar."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frases con puntuación BAJA (puntuación < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Podría ser mejor..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frases de puntuación MID (30 > puntuación < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Eso estuvo bien..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frases con puntuación ALTA (60 < puntuación)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Maravilloso..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Configuración de idioma"
 
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Idioma preferido (requiere reinicio)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Configuración del servidor"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normalizar el volumen del audio"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Descargar vídeos de alta calidad"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1418,7 +1437,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1428,7 +1447,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1438,7 +1457,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1448,7 +1467,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1457,7 +1476,7 @@ msgstr ""
 " audio | positivo = retrasa el audio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Límite de canciones que un usuario individual puede agregar a la cola (0 = "
@@ -1465,14 +1484,14 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Habilitar cola justa (el modo por turnos garantiza que los usuarios se "
 "turnen)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1483,13 +1502,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Canciones predeterminadas por página."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1499,7 +1518,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1508,97 +1527,97 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Mantener el servidor despierto: no es compatible con esta plataforma."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Mantenga el servidor despierto mientras PiKaraoke se está ejecutando"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Borrar preferencias"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Estadísticas del sistema"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Información del sistema"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Plataforma:"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Versión del Sistema Operativo:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp versión:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg versión:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versión:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Estadísticas del sistema"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "UPC:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Cargando..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Uso del disco:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Memoria:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Actualizaciones"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "Actualización de YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1611,13 +1630,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Actualizar yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1626,19 +1645,19 @@ msgstr ""
 "    Consulte el registro de pikaraoke en busca de errores."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Otros"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Expandir el sistema de archivos Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1649,25 +1668,51 @@ msgstr ""
 "    Esto reiniciará el sistema."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Haga clic aquí para cerrar sesión en el modo administrador."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Cambie la contraseña del administrador. Todos los demás dispositivos deberán"
+" iniciar sesión nuevamente."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Todos en la red son administradores. Establece una contraseña para mantener "
+"los controles del reproductor, la edición de canciones y el apagado para ti."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Guardar contraseña"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Borrar contraseña"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Finalizar la sesión"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Apagar"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1677,17 +1722,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Salir del pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Reiniciar el sistema"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Sistema de apagado"
 
@@ -1744,60 +1789,102 @@ msgid "Start a session to queue for singers"
 msgstr "Iniciar una sesión para hacer cola para cantantes."
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Descargas pendientes"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Preparando"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Descargando vídeo"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Descargando audio"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Fusionando"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Completado"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Reintentando"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Descargas pendientes"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "En cola"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Errores de descarga"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Fallido"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Rever"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Despedir"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Arrastra para reordenar"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "La cola esta vacia"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Jugar"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1807,60 +1894,60 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> canciones aleatorias"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Borrar todo"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Reproducir siguiente"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Mover hacia arriba"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Subir"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Mover hacia abajo"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Mover hacia abajo"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Rebautizar"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Quitar de la cola"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Reanudar"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Saltar"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Cola de descarga"
 
@@ -1879,25 +1966,25 @@ msgstr "Rango"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "juega"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Canciones más populares"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Mejores artistas"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Nadie ha cantado todavía."
 
@@ -1910,7 +1997,7 @@ msgstr "Añadiendo..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "en la biblioteca"
 
@@ -1918,49 +2005,49 @@ msgstr "en la biblioteca"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Agregar nuevas canciones de YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Busca en YouTube por título, artista..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Buscador"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Incluir videos que no sean de karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Avanzado"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Pega una URL de YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Guardar para más tarde"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1971,7 +2058,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1981,7 +2068,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2073,86 +2160,86 @@ msgstr "Muestra estas obras"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Sesión actual"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Nombra esta sesión..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Iniciar sesión"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Finalizar sesión"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Historial de sesiones"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Ocultar inicio automático"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sesión"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Comenzó"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Activar"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Exportar CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Lista de exportación (texto)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Jugadas claras"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Eliminar sesión"
 

--- a/pikaraoke/translations/fi_FI/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/fi_FI/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: minna.soudunsaari@gmail.com\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2024-05-08 18:57-0300\n"
 "Last-Translator: FULL NAME <minna.soudunsaari@gmail.com>\n"
 "Language-Team: fi_FI <LL@li.org>\n"
@@ -33,42 +33,42 @@ msgstr "Transponoidaan %s puolisävelellä: %s"
 msgid "Volume: %s"
 msgstr "Ääni kovemmalle: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Jonoon lisätty kappale (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Lataa: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Ladataan videota: %s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Virhe kappaleen lataamisessa:"
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Jonoon lisätty kappale: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Lataa: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Virhe kappaleen jonossa:"
 
@@ -112,22 +112,22 @@ msgid "Pause: %s"
 msgstr "Tauko: %s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Asetuksesi muutettiin onnistuneesti"
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Jotain meni pieleen! Asetuksiasi ei muutettu"
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Asetuksesi tyhjennettiin onnistuneesti"
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Jotain meni pieleen! Asetuksiasi ei tyhjennetty"
 
@@ -177,113 +177,130 @@ msgstr "Striimin valmistelu epäonnistui"
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Päivitetään yt-dlp! Pitäisi kestää minuutti tai kaksi..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Sinulla ei ole lupaa päivittää yt-dlp:ää"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Sammuta Pikaraoke"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Sinulla ei ole lupaa lopettaa"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Sammuta järjestelmä"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Sinulla ei ole lupaa sulkea"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Käynnistä järjestelmä uudelleen"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Sinulla ei ole lupaa käynnistää uudelleen"
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Laajenna tiedostojärjestelmää ja käynnistä järjestelmä uudelleen nyt!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "Fs:ää ei voi laajentaa muissa kuin Raspberry pi -laitteissa!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Sinulla ei ole oikeutta muuttaa tiedostojärjestelmän kokoa"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Järjestelmänvalvojan valtuudet myönnetty!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Väärä järjestelmänvalvoja-salasana!"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "Sinulla ei ole oikeutta muuttaa järjestelmänvalvojan salasanaa"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Järjestelmänvalvojan salasana asetettu. Muiden laitteiden on kirjauduttava "
+"uudelleen sisään."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr ""
+"Järjestelmänvalvojan salasana tyhjennetty. Jokainen on taas "
+"järjestelmänvalvoja."
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Kirjautunut ulos järjestelmänvalvojatilasta!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Hyväksy ehdotettu nimi"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Eräkappaleen uudelleennimeäjä"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Virhe: Tiedostonimen parametreja ei määritetty!"
-
-# auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Virhe: Tätä kappaletta ei voi muokata, koska se on nykyisessä jonossa:"
+"Virhe: Tätä kappaletta ei voi muokata, koska se on jonossa tai toistetaan: "
+"%s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
@@ -291,65 +308,7 @@ msgstr ""
 "olemassa"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Songs"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Sinulla ei ole lupaa poistaa kappaleita"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Virhe: Tätä kappaletta ei voi poistaa, koska se on jonossa tai toistetaan"
-
-# auto-translated
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Kappale poistettu: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Sinulla ei ole lupaa nimetä kappaleita uudelleen"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Tämä kappale soi. Nimeä se uudelleen, kun se on valmis."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Anna tälle kappaleelle nimi."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Tämä kappale ei ole enää kirjastossa. Se on saatettu nimetä uudelleen tai "
-"poistaa toisesta laitteesta."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Kappale nimeltä %s on jo olemassa."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -359,17 +318,93 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Virhe tiedoston uudelleennimeämisessä: %s"
 
 # auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Songs"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Sinulla ei ole lupaa poistaa kappaleita"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Virhe: Tätä kappaletta ei voi poistaa, koska se on jonossa tai toistetaan"
+
+# auto-translated
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Kappale poistettu: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Nimeä kappale uudelleen"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Sinulla ei ole lupaa nimetä kappaleita uudelleen"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Tämä kappale soi. Nimeä se uudelleen, kun se on valmis."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Anna tälle kappaleelle nimi."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Tämä kappale ei ole enää kirjastossa. Se on saatettu nimetä uudelleen tai "
+"poistaa toisesta laitteesta."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Kappale nimeltä %s on jo olemassa."
+
+# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Nimetty tiedosto uudelleen: %s nimeksi %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Soi tällä hetkellä"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Asetukset"
 
 # auto-translated
 #: routes/info.py:116
@@ -387,88 +422,94 @@ msgstr "Sinulla ei ole lupaa muuttaa asetuksia"
 msgid "You don't have permission to clear preferences"
 msgstr "Haluatko varmasti käynnistää karaokelaitteen uudestaan?"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Jono"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Sinulla ei ole lupaa lisätä satunnaisia ​​kappaleita"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Valitse %s kappaletta satunnaisesti"
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Kappaleet loppuivat!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Luvaton"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Tyhjennetty jono!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Siirretty jonon alkuun"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Siirretty jonon loppuun"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Siirretty ylös jonossa"
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Siirretty alas jonossa"
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Poistettu jonosta"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Virhe siirrettäessä jonon alkuun"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Virhe siirrettäessä jonon loppuun"
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Virhe siirrettäessä ylöspäin jonossa"
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Virhe siirrettäessä alas jonossa"
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Virhe poistettaessa jonosta"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Lisää Uusi"
 
@@ -477,6 +518,29 @@ msgstr "Lisää Uusi"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Sinulla ei ole lupaa tarkastella tätä sivua"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Istunnot"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Pelihistoria"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Rankingit"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -512,8 +576,8 @@ msgstr "Pelasi klo"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Esiintyjä"
 
@@ -521,8 +585,8 @@ msgstr "Esiintyjä"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Song"
 
@@ -629,24 +693,15 @@ msgstr ""
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Haluatko varmasti tyhjentää KOKO jonon? Kirjoita ok jatkaaksesi"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Haluatko varmasti poistaa kohteen {title} jonosta?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Oletko varma että haluat poistaa tämän kappaleen karaokelaitteelta?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} puolisävelet"
@@ -654,20 +709,20 @@ msgstr "{value} puolisävelet"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponoi tämä kappale: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Oletko varma, että haluat aloittaa tämän kappaleen uudelleen?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -679,7 +734,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -689,13 +744,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Virhe"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -706,50 +761,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Nykyinen istunto: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Kotisivu"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Jono"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Rankingit"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Pelihistoria"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Istunnot"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Asetukset"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -759,7 +783,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -769,13 +793,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Näytä vain uudelleennimettävät kappaleet"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -786,13 +810,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Näytä kaikki kappaleet"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Ladataan kappaleita..."
 
@@ -809,117 +833,111 @@ msgid "No suggestion!"
 msgstr "Ei ehdotuksia!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Nimeä kappale uudelleen"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Nykyinen tiedostonimi"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Uusi tiedostonimi"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Automaattinen muotoilu"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Vaihda artisti/nimike"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Ehdota iTunesista"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes-hakumaa"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Tallenna"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Peruuttaa"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Poista tämä kappale"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Joukkonimeä uudelleen"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Saatavilla kirjastossa"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Kaikki kansiot"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Hae nimen, esittäjän mukaan..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Tyhjennä"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Kaikki kappaleet"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Kansiot"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Lajittele aakkosjärjestyksessä"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Lajittele päivämäärän mukaan"
 
@@ -932,14 +950,14 @@ msgstr "Poistetaanko tämä merkintä soittolokista?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Mitään ei ole vielä pelattu."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Pelasi"
 
@@ -957,48 +975,48 @@ msgstr "Pelaaminen"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Vaihtoehdot"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Näytä kaikki esiintyjät"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Piilota ohitettu"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Status"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Lisää Jonoon"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Tämä kappale ei ole enää kirjastossa"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Poista merkintä"
 
@@ -1027,47 +1045,42 @@ msgstr ""
 "Haluatko varmasti skipata tämän kappaleen? Jos kappale ei ole itse "
 "lisäämäsi, kysythän ensin luvan!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Soi tällä hetkellä"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Seuraava kappale"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Soittimen säätimet"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Aloita kappale uudelleen"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Play/Pause"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Pysäytä Nykyinen Kappale"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Vaihda Sävelasteikkoa"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Vaihda"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Mikrofonit"
 
@@ -1105,7 +1118,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1118,7 +1131,7 @@ msgid "Scanning..."
 msgstr "Skannataan..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -1144,102 +1157,106 @@ msgstr "Pelihistoria tyhjennetty"
 msgid "Library sync complete"
 msgstr "Kirjaston synkronointi valmis"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informaatio."
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Kätevä URL QR-koodi kaverille jaettavaksi:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Admin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Kirjoita järjestelmänvalvojan salasana\""
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Kirjaudu sisään"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Unohditko sen? Käynnistä PiKaraoke uudelleen käyttämällä --admin-passwordia "
+"asettaaksesi uuden."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Laulukirjasto"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Kirjasto"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Kirjastossa olevat kappaleet:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Synkronoi nyt"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Täsmentää kirjaston taustalla olevan kappalehakemiston kanssa."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Nimetään uudelleen"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artisti - Otsikko"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Otsikko - Artisti"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "iTunesin ehdotettujen kappaleiden nimien järjestys"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Nollaa koko historia"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Poistaa jokaisen istunnon ja jokaisen tallennetun toiston. Tätä ei voi "
@@ -1247,70 +1264,70 @@ msgstr ""
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Käyttäjäasetukset"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Aloitusnäytön asetukset"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Poista taustavideo käytöstä"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Poista taustamusiikki käytöstä"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Poista tulosnäyttö käytöstä jokaisen kappaleen jälkeen"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Piilota ilmoitukset"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Näytä splash kello"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Piilota URL-osoite ja QR-koodi"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Piilota logo aloitusnäytössä"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Piilota istunnon nimi aloitusnäytössä"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Piilota kaikki peittokuvat, mukaan lukien nyt toistettava, seuraavaksi ja "
@@ -1318,20 +1335,20 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Videoiden oletusäänenvoimakkuus (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Taustamusiikin äänenvoimakkuus (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1341,140 +1358,140 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Viive sekunneissa ennen seuraavan kappaleen aloittamista"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "Palvelimella havaittu mikrofonit. Ääni ohjataan suoraan kaiuttimiin."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latenssi"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Kaiun poisto"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Kokeellinen"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(vähentää palautetta, lisää viivettä)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
 "Mikrofonituki ei ole saatavilla. Vaadittuja äänityökaluja ei ole asennettu."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Linux / Raspberry Pi, asenna se seuraavasti:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "ja käynnistä PiKaraoke uudelleen."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Pisteet lauseita"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 "Lisää yksi lause jokaiselle riville kuhunkin ruutuun ja paina Tallenna."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "MATALAPISTEET -lauseet (pisteet < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Voisi olla parempi..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Pistelauseet (30 > pisteet < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Se oli ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Korkeat pisteet -lauseet (60 < pisteet)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Ihanaa..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Kieliasetukset"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Ensisijainen kieli (vaatii uudelleenkäynnistyksen)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Palvelimen asetukset"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normalisoi äänenvoimakkuus"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Lataa korkealaatuisia videoita"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1484,7 +1501,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1494,7 +1511,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1504,7 +1521,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1514,7 +1531,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1524,7 +1541,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Raja kappaleita, joita yksittäinen käyttäjä voi lisätä jonoon (0 = "
@@ -1532,7 +1549,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Ota reilu jono käyttöön (kierrostila varmistaa, että käyttäjät "
@@ -1540,7 +1557,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1551,13 +1568,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Oletuskappaleet sivulla."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1567,7 +1584,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1576,104 +1593,104 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Pidä palvelin hereillä: ei tueta tällä alustalla."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Pidä palvelin hereillä PiKaraoken ollessa käynnissä"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Tyhjennä asetukset"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Järjestelmätiedot"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Järjestelmän Tiedot"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Alusta:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Käyttöjärjestelmän versio:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp -versio:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg-versio:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versio:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Järjestelmän tilastot"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Ladataan..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Levyn käyttö:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Muisti:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Päivitykset"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP päivitys"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1686,13 +1703,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Päivitä yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1701,19 +1718,19 @@ msgstr ""
 "    Tarkista pikaraoke-log virheet."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Muut"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Laajenna Raspberry Pi -tiedostojärjestelmää"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1724,25 +1741,51 @@ msgstr ""
 "    Tämä käynnistää järjestelmän uudelleen."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Napsauta tätä kirjautuaksesi ulos järjestelmänvalvojatilasta."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Vaihda järjestelmänvalvojan salasana. Jokaisen muun laitteen on "
+"kirjauduttava sisään uudelleen."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Kaikki verkon käyttäjät ovat järjestelmänvalvojia. Aseta salasana pitääksesi"
+" soittimen ohjaimet, kappaleiden muokkaamisen ja sammutuksen omaksesi."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Tallenna salasana"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Tyhjennä salasana"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Sammuta"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1752,17 +1795,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Sammuta Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Käynnistä järjestelmä uudelleen"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Sammuta järjestelmä"
 
@@ -1819,61 +1862,103 @@ msgid "Start a session to queue for singers"
 msgstr "Aloita istunto asettaaksesi jonoon laulajia"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Odottavat lataukset"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Valmistellaan"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Ladataan videota"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Ladataan ääntä"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Yhdistäminen"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Valmis"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Yritetään uudelleen"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Odottavat lataukset"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "Jonossa"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Latausvirheet"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Epäonnistui"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Yritä uudelleen"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Hylkää"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Järjestä uudelleen vetämällä"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "Jono on tyhjä"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Pelata"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Tauko"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1883,60 +1968,60 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> satunnaista kappaletta"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Tyhjennä kappalejono"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Pelaa seuraavaksi"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Siirrä alkuun"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Siirrä ylös"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Siirrä alas"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Siirrä alas"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Nimeä uudelleen"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Poista jonosta"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Käynnistä uudelleen"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Ohita"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Latausjono"
 
@@ -1955,25 +2040,25 @@ msgstr "Sijoitus"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Toistetaan"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Huippukappaleita"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Huippusuorittajat"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Kukaan ei ole vielä laulanut."
 
@@ -1986,7 +2071,7 @@ msgstr "Lisätään..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "Kirjastossa"
 
@@ -1994,49 +2079,49 @@ msgstr "Kirjastossa"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Lisää uusia kappaleita YouTubesta"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Hae YouTubesta nimen, esittäjän mukaan..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Etsi"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Sisällytä myös ei-karaoke versiot."
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Tarkemmat hakuvaihtoehdot"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Liitä YouTube-URL-osoite:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Säästä myöhempää käyttöä varten"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2045,7 +2130,7 @@ msgstr "Etsi Youtubesta <small><i>’%(search_term)s’</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2055,7 +2140,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2148,86 +2233,86 @@ msgstr "Näytä nämä näytelmät"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Nykyinen istunto"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Nimeä tämä istunto..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Aloita istunto"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Lopeta istunto"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Istuntohistoria"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Piilota automaattisesti käynnistynyt"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Istunto"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Aloitettu"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Aktivoi"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Vie CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Vie luettelo (teksti)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Selkeät toistot"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Poista istunto"
 

--- a/pikaraoke/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/fr_FR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-13 22:52-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: fr_FR <LL@li.org>\n"
@@ -32,39 +32,39 @@ msgstr "Transposition par %s demi-tons : %s"
 msgid "Volume: %s"
 msgstr "Volume : %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Téléchargé et mis en file d'attente (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Téléchargement de la vidéo : %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Téléchargement de la vidéo : %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Erreur lors du téléchargement d'une chanson : "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Téléchargé et mis en file d'attente : %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Téléchargé : %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Erreur lors de la mise en file d'attente d'une chanson : "
 
@@ -104,19 +104,19 @@ msgstr "Reprendre : %s"
 msgid "Pause: %s"
 msgstr "Pause : %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Vos préférences ont été modifiées avec succès"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Il y a eu un problème ! Vos préférences n'ont pas été modifiées"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Vos préférences ont été effacées avec succès"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Il y a eu un problème ! Vos préférences n'ont pas été effacées"
 
@@ -165,48 +165,48 @@ msgid "Failed to prepare stream"
 msgstr "Échec de la préparation du flux"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Mise à jour de yt-dlp ! Cela devrait prendre une minute ou deux... "
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Vous n'avez pas le droit de mettre à jour yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Arrêt de pikaraoke maintenant !"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Vous n'avez pas le droit de quitter"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Arrêt du système maintenant !"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Vous n'avez pas le droit d'arrêter"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Redémarrage du système maintenant !"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Vous n'avez pas le droit de redémarrer"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr ""
 "Augmentation de la taille du système de fichiers et redémarrage du système "
@@ -214,7 +214,7 @@ msgstr ""
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
 "Impossible d'augmenter la taille du système de fichiers sur des appareils "
@@ -222,115 +222,75 @@ msgstr ""
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Vous n'avez pas le droit de redimensionner le système de fichiers"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Mode administrateur accordé !"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Mot de passe administrateur incorrect !"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "Vous n'êtes pas autorisé à modifier le mot de passe administrateur"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Mot de passe administrateur défini. Les autres appareils devront se "
+"reconnecter."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr ""
+"Mot de passe administrateur effacé. Tout le monde est à nouveau "
+"administrateur."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Déconnexion du mode administrateur !"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Accepter le nom suggéré"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Renommeur de chanson par lots"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Erreur : Aucun nom de fichier n'a été spécifié !"
-
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Erreur : Impossible d'éditer cette chanson car elle se trouve dans la file "
-"d'attente actuelle : "
+"Erreur : Impossible de modifier cette chanson car elle est en file d'attente"
+" ou en cours de lecture : %s"
 
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 "Erreur de renommage de fichier : '%s' en '%s', le nom de fichier existe déjà"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Chansons"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Vous n'êtes pas autorisé à supprimer des chansons"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Erreur : Impossible de supprimer cette chanson car elle est en file "
-"d'attente ou en cours de lecture"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Chanson supprimée : %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Vous n'êtes pas autorisé à renommer les chansons"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Cette chanson joue. Renommez-le une fois terminé."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Entrez un nom pour cette chanson."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Cette chanson n'est plus dans la bibliothèque. Il a peut-être été renommé ou"
-" supprimé d'un autre appareil."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Une chanson appelée « %s » existe déjà."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -340,16 +300,92 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Erreur de renommage du fichier : %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Chansons"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Vous n'êtes pas autorisé à supprimer des chansons"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Erreur : Impossible de supprimer cette chanson car elle est en file "
+"d'attente ou en cours de lecture"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Chanson supprimée : %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Renommer la chanson"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Vous n'êtes pas autorisé à renommer les chansons"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Cette chanson joue. Renommez-le une fois terminé."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Entrez un nom pour cette chanson."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Cette chanson n'est plus dans la bibliothèque. Il a peut-être été renommé ou"
+" supprimé d'un autre appareil."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Une chanson appelée « %s » existe déjà."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Fichier renommé : %s to %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "En cours de lecture"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Paramètres"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -365,80 +401,86 @@ msgstr "Vous n'avez pas le droit de modifier les préférences"
 msgid "You don't have permission to clear preferences"
 msgstr "Vous n'avez pas le droit d'effacer les préférences"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "File d'attente"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Vous n'êtes pas autorisé à ajouter des chansons aléatoires"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Ajout de %s pistes aléatoires"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Il n'y a plus de chansons !"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Non autorisé"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "La file d'attente a été supprimée !"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Déplacé en haut de la file d'attente"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Déplacé en bas de la file d'attente"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Déplacée vers le haut dans la file d'attente"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Déplacée vers le bas dans la file d'attente"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Supprimé de la file d'attente"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Erreur de passage en haut de la file d'attente"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Erreur de déplacement vers le bas de la file d'attente"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Erreur lors du déplacement vers le haut dans la file d'attente"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Erreur lors du déplacement vers le bas dans la file d'attente"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Erreur lors de la suppression de la file d'attente"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Ajouter un nouveau"
 
@@ -447,6 +489,29 @@ msgstr "Ajouter un nouveau"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Vous n'êtes pas autorisé à afficher cette page"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Séances"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Historique de lecture"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Classements"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -482,8 +547,8 @@ msgstr "Joué à"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Interprète"
 
@@ -491,8 +556,8 @@ msgstr "Interprète"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Chanson"
 
@@ -586,24 +651,15 @@ msgstr ""
 "Êtes-vous sûr de vouloir effacer la file d'attente ENTIÈRE ? Tapez ok pour "
 "continuer"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Êtes-vous sûr de vouloir supprimer {title} de la file d'attente ?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Êtes-vous sûr de vouloir supprimer cette chanson de la bibliothèque ?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} demi-tons"
@@ -611,20 +667,20 @@ msgstr "{value} demi-tons"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transposer cette chanson : {label} ?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Êtes-vous sûr de vouloir redémarrer cette piste ?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -636,7 +692,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -646,13 +702,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Erreur"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -663,50 +719,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Session en cours : {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Accueil"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "File d'attente"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Classements"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Historique de lecture"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Séances"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Paramètres"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -716,7 +741,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -726,13 +751,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Afficher uniquement les chansons à renommer"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -743,13 +768,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Afficher toutes les chansons"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Chargement des chansons..."
 
@@ -767,117 +792,111 @@ msgid "No suggestion!"
 msgstr "Aucune suggestion !"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Renommer la chanson"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Nom de fichier actuel"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Nouveau nom de fichier"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Formatage automatique"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Échanger artiste/titre"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Suggérer depuis iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "Pays de recherche iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Enregistrer"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Annuler"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Supprimer cette musique"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Renommer en masse"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Disponible à la bibliothèque"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Tous les dossiers"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Recherche par titre, artiste..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Effacer"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Toutes les chansons"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Dossiers"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Trier par ordre alphabétique"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Trier par date"
 
@@ -890,14 +909,14 @@ msgstr "Supprimer cette entrée du journal de lecture ?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Rien n'a encore été joué."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Joué"
 
@@ -915,48 +934,48 @@ msgstr "Jouant"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Possibilités"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Afficher tous les artistes"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Masquer ignoré"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Statut"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Ajouter à la file d'attente"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Cette chanson n'est plus dans la bibliothèque"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Supprimer l'entrée"
 
@@ -985,47 +1004,42 @@ msgstr ""
 "Êtes-vous sûr de vouloir ignorer cette chanson ? Si vous ne l'avez pas "
 "ajouté, demandez d'abord la permission !"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "En cours de lecture"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Prochaine chanson"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Contrôles du lecteur"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Recommencer la chanson"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Lecture/Pause"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Arrêter la chanson en cours"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Modifier la tonalité"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Modifier"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Micros"
 
@@ -1063,7 +1077,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1076,7 +1090,7 @@ msgid "Scanning..."
 msgstr "Balayage..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Rafraîchir"
 
@@ -1102,185 +1116,189 @@ msgstr "Historique de lecture effacé"
 msgid "Library sync complete"
 msgstr "Synchronisation de la bibliothèque terminée"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informations"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL de %(site_title)s :"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "URL QR code à partager avec un ami :"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Administrateur"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Saisissez le mot de passe administrateur"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Connexion"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Vous l'avez oublié ? Redémarrez PiKaraoke avec --admin-password pour en "
+"définir un nouveau."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Bibliothèque de chansons"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Bibliothèque"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Chansons en bibliothèque :"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Synchroniser maintenant"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr ""
 "Réconcilie la bibliothèque avec le répertoire de chansons en arrière-plan."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Renommer"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artiste - Titre"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Titre - Artiste"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Ordre des noms de chansons suggérés par iTunes"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Réinitialiser tout l'historique"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Supprime chaque session et chaque lecture enregistrée. Cela ne peut pas être"
 " annulé."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Préférences utilisateur"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Paramètres de l'écran de démarrage"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Désactiver la vidéo d'arrière-plan"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Désactiver la musique de fond"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Désactiver l'écran des scores après chaque chanson"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Masquer les notifications"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Afficher l'horloge de démarrage"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Masquer l'URL et le QR code"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Masquer le logo sur l'écran de démarrage"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Masquer le nom de la session sur l'écran de démarrage"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Masquer toutes les surcouches, y compris la lecture en cours, la lecture "
 "suivante et le QR code"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume par défaut des vidéos (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume de la musique de fond (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1289,17 +1307,17 @@ msgstr ""
 "  Utilisez 0 pour désactiver."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Délai en secondes avant le début de la chanson suivante"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1307,27 +1325,27 @@ msgstr ""
 "les haut-parleurs."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latence"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Annulation de l'écho"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Expérimental"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(réduit le feedback, ajoute de la latence)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1335,92 +1353,92 @@ msgstr ""
 "requis ne sont pas installés."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Sous Linux / Raspberry Pi, installez-le avec :"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "et redémarrez PiKaraoke."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Phrases de partition"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 "Ajoutez une phrase par ligne dans chaque case et cliquez sur Enregistrer."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Phrases à score FAIBLE (score < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Ça pourrait être mieux..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Phrases de score MID (30 > score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "C'était ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Phrases à score ÉLEVÉ (60 < score)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Merveilleux..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Paramètres du serveur"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Langue préférée (nécessite un redémarrage)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Paramètres du serveur"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normaliser le volume"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Télécharger des vidéos de haute qualité"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1431,7 +1449,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1441,7 +1459,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1451,7 +1469,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1461,7 +1479,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1470,7 +1488,7 @@ msgstr ""
 "avance l'audio | positif = retarde l'audio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limite de chansons qu'un utilisateur individuel peut ajouter à la file "
@@ -1478,14 +1496,14 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Activer la file d'attente équitable (le mode round-robin garantit que les "
 "utilisateurs se relaient)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1496,13 +1514,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Chansons par défaut par page."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1512,7 +1530,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1521,98 +1539,98 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Gardez le serveur éveillé : non pris en charge sur cette plateforme."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr ""
 "Gardez le serveur éveillé pendant que PiKaraoke est en cours d'exécution"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Effacer les préférences"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Statistiques système :"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Informations système"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Plateforme :"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Version OS :"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "Version yt-dlp :"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "Version FFmpeg :"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Version pikaraoke :"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Statistiques système :"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "Processeur :"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Chargement..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Utilisation du disque :"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Mémoire:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Mises à jour"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "Mise à jour yt-dlp"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1625,13 +1643,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Mettre à jour yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1640,19 +1658,19 @@ msgstr ""
 "    Vérifiez le journal d'erreurs de pikaraoke."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Autre"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Redimensionner le système de fichiers Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1663,25 +1681,52 @@ msgstr ""
 "    Cette opération redémarrera le système."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Cliquez ici pour vous déconnecter du mode administrateur."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Changez le mot de passe administrateur. Tous les autres appareils devront se"
+" reconnecter."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Tout le monde sur le réseau est un administrateur. Définissez un mot de "
+"passe pour garder les commandes du lecteur, l'édition des chansons et "
+"l'arrêt pour vous."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Enregistrer le mot de passe"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Effacer le mot de passe"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Se déconnecter"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Arrêt"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1691,17 +1736,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Quitter pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Redémarrer le système"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Arrêter le système"
 
@@ -1758,60 +1803,102 @@ msgid "Start a session to queue for singers"
 msgstr "Démarrer une session pour faire la queue pour les chanteurs"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Téléchargements en attente"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Préparation"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Téléchargement de la vidéo"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Téléchargement de fichiers audio"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Fusion"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Terminé"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Réessayer"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Téléchargements en attente"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "En file d'attente"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Erreurs de téléchargement"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Échoué"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Réessayer"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Rejeter"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Faites glisser pour réorganiser"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "La file d'attente est vide"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Jouer"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1821,60 +1908,60 @@ msgstr ""
 "class=\"input mx-2 p-2\" pattern=\"\\d*\" maxlength=\"2\" value=\"3\" "
 "min=\"1\" max=\"99\" style=\"width: 42px\" />"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Tout effacer"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Jouer ensuite"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Déplacer vers le haut"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Monter"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Descendre"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Déplacer vers le bas"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Rebaptiser"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Supprimer de la file d'attente"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Redémarrage"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Sauter"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "File d'attente de téléchargement"
 
@@ -1893,25 +1980,25 @@ msgstr "Rang"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Pièces"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Meilleures chansons"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Les plus performants"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Personne n'a encore chanté."
 
@@ -1924,7 +2011,7 @@ msgstr "Ajout..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "En bibliothèque"
 
@@ -1932,49 +2019,49 @@ msgstr "En bibliothèque"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Ajouter de nouvelles chansons de YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Recherchez YouTube par titre, artiste..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Recherche"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Inclure les résultats non-karaoké"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Avancés"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Collez une URL YouTube :"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Enregistrer pour plus tard"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1985,7 +2072,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1995,7 +2082,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2089,86 +2176,86 @@ msgstr "Montre ces pièces"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Session en cours"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Nommez cette session..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Démarrer la session"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Fin de séance"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Historique des sessions"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Masquer le démarrage automatique"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Session"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Commencé"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Rendre actif"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Exporter au format CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Exporter la liste (texte)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Effacer les jeux"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Supprimer la séance"
 

--- a/pikaraoke/translations/id_ID/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/id_ID/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2026-02-13 11:48+0700\n"
 "Last-Translator: birudanoranye@gmail.com\n"
 "Language-Team: Indonesian <LL@li.org>\n"
@@ -31,39 +31,39 @@ msgstr "Menggeser nada %s setengah nada: %s"
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Antrian download (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Mulai mengunduh: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Sedang mengunduh video: %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Gagal mengunduh lagu: "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Berhasil diunduh dan ditambahkan ke antrian: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Telah diunduh: %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Gagal menambahkan lagu ke antrian: "
 
@@ -103,19 +103,19 @@ msgstr "Lanjutkan: %s"
 msgid "Pause: %s"
 msgstr "Jeda: %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Pengaturan Anda berhasil disimpan"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Terjadi kesalahan! Pengaturan tidak berhasil disimpan"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Pengaturan berhasil dihapus"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Terjadi kesalahan! Pengaturan tidak berhasil dihapus"
 
@@ -161,163 +161,121 @@ msgid "Failed to prepare stream"
 msgstr "Gagal menyiapkan streaming"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Sedang memperbarui yt-dlp! Mohon tunggu 1–2 menit..."
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Anda tidak memiliki izin untuk memperbarui yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Menutup Pikaraoke sekarang!"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Anda tidak memiliki izin untuk keluar"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Mematikan sistem sekarang!"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Anda tidak memiliki izin untuk mematikan sistem"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Merestart sistem sekarang!"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Anda tidak memiliki izin untuk merestart"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Sedang memperluas partisi dan akan restart sistem..."
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "Tidak bisa memperluas partisi di perangkat non-Raspberry Pi!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Anda tidak memiliki izin untuk mengubah ukuran partisi"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Mode admin diaktifkan!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Kata sandi admin salah!"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "Anda tidak memiliki izin untuk mengubah kata sandi admin"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "Kata sandi admin disetel. Perangkat lain harus masuk lagi."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "Kata sandi admin dihapus. Semua orang menjadi admin lagi."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Telah keluar dari mode admin!"
 
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Terima nama yang disarankan"
 
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Pengganti Nama Lagu Massal"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Gagal: tidak ada parameter nama file yang diberikan!"
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr ""
+"Kesalahan: Tidak dapat mengedit lagu ini karena sedang dalam antrean atau "
+"diputar: %s"
 
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "Gagal mengedit: lagu ini sedang ada di antrian: "
-
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "Gagal mengganti nama: '%s' → '%s', nama file sudah ada"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Lagu"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Anda tidak memiliki izin untuk menghapus lagu"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Kesalahan: Tidak dapat menghapus lagu ini karena sedang dalam antrean atau "
-"sedang diputar"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Lagu dihapus: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Anda tidak memiliki izin untuk mengganti nama lagu"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Lagu ini sedang diputar. Ganti namanya jika sudah selesai."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Masukkan nama untuk lagu ini."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Lagu ini sudah tidak ada lagi di perpustakaan. Mungkin telah diganti namanya"
-" atau dihapus dari perangkat lain."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Lagu berjudul '%s' sudah ada."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -327,16 +285,92 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Kesalahan saat mengganti nama file: %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Lagu"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Anda tidak memiliki izin untuk menghapus lagu"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Kesalahan: Tidak dapat menghapus lagu ini karena sedang dalam antrean atau "
+"sedang diputar"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Lagu dihapus: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Ganti Nama Lagu"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Anda tidak memiliki izin untuk mengganti nama lagu"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Lagu ini sedang diputar. Ganti namanya jika sudah selesai."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Masukkan nama untuk lagu ini."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Lagu ini sudah tidak ada lagi di perpustakaan. Mungkin telah diganti namanya"
+" atau dihapus dari perangkat lain."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Lagu berjudul '%s' sudah ada."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Nama file diubah: %s → %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Sedang Diputar"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Pengaturan"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -352,77 +386,83 @@ msgstr "Anda tidak memiliki izin mengubah pengaturan"
 msgid "You don't have permission to clear preferences"
 msgstr "Anda tidak memiliki izin menghapus pengaturan"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Antrian"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Anda tidak memiliki izin untuk menambahkan lagu secara acak"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Menambahkan %s lagu acak"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Lagu sudah habis!"
 
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Tidak diizinkan"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Antrian telah dikosongkan!"
 
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Dipindah ke posisi teratas antrian"
 
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Dipindah ke posisi terbawah antrian"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Naik satu posisi dalam antrian"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Turun satu posisi dalam antrian"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Dihapus dari antrian"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Terjadi kesalahan saat berpindah ke antrean teratas"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Terjadi kesalahan saat berpindah ke antrean terbawah"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Gagal memindahkan ke atas"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Gagal memindahkan ke bawah"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Gagal menghapus dari antrian"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Tambahkan Baru"
 
@@ -431,6 +471,29 @@ msgstr "Tambahkan Baru"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Anda tidak memiliki izin untuk melihat halaman ini"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Sesi"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Mainkan Sejarah"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Peringkat"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -466,8 +529,8 @@ msgstr "Dimainkan Pada"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Pemain"
 
@@ -475,8 +538,8 @@ msgstr "Pemain"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Lagu"
 
@@ -566,24 +629,15 @@ msgstr ""
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Yakin ingin mengosongkan SELURUH antrian? Ketik ok untuk melanjutkan"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Apakah Anda yakin ingin menghapus {title} dari antrean?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Yakin ingin menghapus lagu ini dari pustaka?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} seminada"
@@ -591,20 +645,20 @@ msgstr "{value} seminada"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Ubah urutan lagu ini: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Apakah Anda yakin ingin memulai ulang trek ini?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -616,7 +670,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -626,13 +680,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Kesalahan"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -643,50 +697,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sesi saat ini: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Beranda"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Antrian"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Peringkat"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Mainkan Sejarah"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Sesi"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Pengaturan"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -696,7 +719,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -705,13 +728,13 @@ msgstr ""
 "\tlagu"
 
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Tampilkan hanya lagu yang perlu diganti nama"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -721,12 +744,12 @@ msgstr ""
 
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Tampilkan semua lagu"
 
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Memuat daftar lagu..."
 
@@ -743,117 +766,111 @@ msgid "No suggestion!"
 msgstr "Tidak ada saran!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Ganti Nama Lagu"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Nama file saat ini"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Nama file baru"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Format Otomatis"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Tukar Artis/Judul"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Sarankan dari iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "Negara pencarian iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Simpan"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Membatalkan"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Hapus lagu ini"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Ganti nama secara massal"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Tersedia di perpustakaan"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Semua folder"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Cari berdasarkan judul, artis..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Hapus"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Semua lagu"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Folder"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Urutkan Berdasarkan Abjad"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Urutkan berdasarkan Tanggal"
 
@@ -866,14 +883,14 @@ msgstr "Hapus entri ini dari log pemutaran?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Belum ada yang dimainkan."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Dimainkan"
 
@@ -890,48 +907,48 @@ msgid "Playing"
 msgstr "Bermain"
 
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Opsi"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Tampilkan semua pemain"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Sembunyikan dilewati"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Status"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Tambah ke antrian"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Lagu ini sudah tidak ada lagi di perpustakaan"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Hapus entri"
 
@@ -960,47 +977,42 @@ msgstr ""
 "Yakin ingin melewati lagu ini? Jika bukan Anda yang menambahkannya, mintalah"
 " izin terlebih dahulu!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Sedang Diputar"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Lagu Berikutnya"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Kontrol Pemutar"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Putar ulang dari awal"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Putar/Jeda"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Hentikan lagu saat ini"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Ubah Nada (Key)"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Terapkan"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Mikrofon"
 
@@ -1038,7 +1050,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1051,7 +1063,7 @@ msgid "Scanning..."
 msgstr "Memindai..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Menyegarkan"
 
@@ -1077,180 +1089,184 @@ msgstr "Riwayat pemutaran terhapus"
 msgid "Library sync complete"
 msgstr "Sinkronisasi perpustakaan selesai"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informasi"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "Alamat URL %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Kode QR alamat yang mudah dibagikan ke teman:"
 
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Admin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Masukkan kata sandi administrator"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Masuk"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Lupa? Mulai ulang PiKaraoke dengan --admin-password untuk menyetel yang "
+"baru."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Perpustakaan Lagu"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Perpustakaan"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Lagu di perpustakaan:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Sinkronkan Sekarang"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Rekonsiliasi perpustakaan dengan direktori lagu di latar belakang."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Mengganti nama"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artis - Judul"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Judul - Artis"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Urutan nama lagu yang disarankan iTunes"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Setel ulang semua riwayat"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Menghapus setiap sesi dan setiap pemutaran yang direkam. Hal ini tidak dapat"
 " dibatalkan."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Pengaturan Pengguna"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Pengaturan Layar Pembuka"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Nonaktifkan video latar belakang"
 
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Nonaktifkan musik latar belakang"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Nonaktifkan layar skor setelah setiap lagu"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Sembunyikan notifikasi"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Tampilkan jam splash"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Sembunyikan URL dan kode QR"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Sembunyikan logo di layar splash"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Sembunyikan nama sesi di layar splash"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Sembunyikan semua overlay (sedang diputar, berikutnya, dan QR code)"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume default video (min 0, maks 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume musik latar belakang (min 0, maks 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1259,125 +1275,125 @@ msgstr ""
 "menonaktifkan."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Jeda (detik) sebelum memutar lagu berikutnya"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "Mikrofon terdeteksi di server. Audio disalurkan langsung ke speaker."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latensi"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Pembatalan gema"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Eksperimental"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(mengurangi umpan balik, menambah latensi)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
 "Dukungan mikrofon tidak tersedia. Alat audio yang diperlukan tidak diinstal."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Di Linux/Raspberry Pi, instal dengan:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "dan mulai ulang PiKaraoke."
 
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Frasa Penilaian"
 
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Tambahkan satu frasa per baris di setiap kotak, lalu tekan simpan."
 
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frasa Skor RENDAH (skor < 30)"
 
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Bisa lebih baik lagi..."
 
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frasa Skor SEDANG (30 < skor < 60)"
 
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Lumayan lah..."
 
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frasa Skor TINGGI (skor > 60)"
 
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Luar biasa!"
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Pengaturan Bahasa"
 
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Bahasa pilihan (perlu restart aplikasi)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Pengaturan Server"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normalisasi volume audio"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Unduh video berkualitas tinggi"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1386,7 +1402,7 @@ msgstr ""
 "lebih baik, tapi mulai lebih lambat). Ukuran buffer akan diabaikan.*"
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1396,7 +1412,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1406,7 +1422,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1415,7 +1431,7 @@ msgstr ""
 "ketika perpustakaan memiliki subfolder)"
 
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1424,19 +1440,19 @@ msgstr ""
 "audio | positif = tunda audio"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Batas lagu yang boleh ditambahkan satu pengguna ke antrian (0 = tanpa batas)"
 
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Aktifkan antrian yang adil (mode round-robin memastikan giliran pengguna)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1447,13 +1463,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Lagu default per halaman."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1463,7 +1479,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1472,94 +1488,94 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Jaga agar server tetap aktif: tidak didukung pada platform ini."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Jaga agar server tetap aktif saat PiKaraoke sedang berjalan"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Hapus pengaturan"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Data Sistem"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Informasi Sistem"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Platform:"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Versi OS:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "Versi yt-dlp:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "Versi FFmpeg:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Versi Pikaraoke:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Statistik Sistem"
 
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Memuat..."
 
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Penggunaan Disk:"
 
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Memori:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Pembaruan"
 
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "Perbarui yt-dlp"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1572,14 +1588,14 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Perbarui yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1588,20 +1604,20 @@ msgstr ""
 "\t\t\t\t\t\t\tPeriksa log pikaraoke untuk kesalahan."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Lainnya"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Perluas partisi Raspberry Pi"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1611,24 +1627,50 @@ msgstr ""
 "\t\t\t\t\t\t\tAnda mungkin ingin memperluas sistem file untuk memanfaatkan ruang yang tersisa. Anda hanya perlu melakukan ini sekali saja.\n"
 "\t\t\t\t\t\t\tIni akan me-reboot sistem."
 
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Klik di sini untuk keluar dari mode admin."
+# auto-translated
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Ubah kata sandi administrator. Setiap perangkat lain harus masuk lagi."
 
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+# auto-translated
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Semua orang di jaringan adalah admin. Tetapkan kata sandi untuk menjaga "
+"kontrol pemutar, pengeditan lagu, dan mematikannya sendiri."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Simpan kata sandi"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Hapus kata sandi"
+
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Keluar"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Matikan"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1638,17 +1680,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Keluar dari Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Restart Sistem"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Matikan Sistem"
 
@@ -1704,53 +1746,95 @@ msgstr "Nama penyanyinya"
 msgid "Start a session to queue for singers"
 msgstr "Mulailah sesi untuk mengantri penyanyi"
 
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Download tertunda"
+# auto-translated
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Mempersiapkan"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Mengunduh video"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Mengunduh audio"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Penggabungan"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Selesai"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Mencoba lagi"
 
-#: templates/queue.html:219
+# auto-translated
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Download tertunda"
+
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "Dalam antrian"
 
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Kesalahan Download"
 
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Gagal"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Mencoba kembali"
 
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Tutup"
 
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Seret untuk mengatur ulang urutan"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "Antrian kosong"
 
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Putar"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Jeda"
 
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1760,51 +1844,51 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> lagu acak"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Hapus semua"
 
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Putar Selanjutnya"
 
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Pindah ke atas"
 
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Naik satu"
 
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Turun satu"
 
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Pindah ke bawah"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Ganti nama"
 
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Hapus dari antrian"
 
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Putar ulang"
 
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Lewati"
 
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Antrian download"
 
@@ -1823,25 +1907,25 @@ msgstr "Pangkat"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Dimainkan"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Lagu teratas"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Berkinerja terbaik"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Belum ada yang bernyanyi."
 
@@ -1854,7 +1938,7 @@ msgstr "Menambahkan..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "Di perpustakaan"
 
@@ -1862,50 +1946,50 @@ msgstr "Di perpustakaan"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Tambahkan lagu baru dari YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Cari YouTube berdasarkan judul, artis..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Cari"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Sertakan hasil yang bukan versi karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Lanjutan"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Tempelkan url YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Simpan untuk nanti"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1916,7 +2000,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1926,7 +2010,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2018,86 +2102,86 @@ msgstr "Tunjukkan drama ini"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Sesi Saat Ini"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Beri nama sesi ini..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Mulai sesi"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Akhiri sesi"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Riwayat Sesi"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Sembunyikan mulai otomatis"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sidang"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Dimulai"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Jadikan aktif"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Ekspor CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Ekspor daftar (teks)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Permainan yang jelas"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Hapus sesi"
 

--- a/pikaraoke/translations/it_IT/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/it_IT/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2024-10-30 14:44-0300\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: it_IT <LL@li.org>\n"
@@ -32,39 +32,39 @@ msgstr "Trasposizione di %s semitoni: %s"
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Scaricato ed aggiunto in coda (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Scaricamento video: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Scaricamento video: %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Errore nello scaricamento della canzone: "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Scaricato ed aggiunto in coda: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Scaricato: %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Errore durante l'aggiunta del brano alla coda: "
 
@@ -104,19 +104,19 @@ msgstr "Riprendere: %s"
 msgid "Pause: %s"
 msgstr "Pausa: %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Le tue preferenze sono state modificate con successo"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Qualcosa è andato storto! Le tue preferenze non sono state modificate"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Le tue preferenze sono state cancellate con successo"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Qualcosa è andato storto! Le tue preferenze non sono state cancellate"
 
@@ -163,103 +163,122 @@ msgid "Failed to prepare stream"
 msgstr "Impossibile preparare lo streaming"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Aggiornamento di yt-dlp! Dovrebbe richiedere un minuto o due..."
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Non hai l'autorizzazione per aggiornare yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Chiusura di Pikaraoke!"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Non hai il permesso di chiudere"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Arresto del sistema in corso!"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Non hai il permesso di spegnere"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Riavvio del sistema in corso!"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Non hai il permesso di riavviare"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Espansione del file system e riavvio del sistema in corso!"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
 "Impossibile espandere file system su dispositivi diversi da Raspberry Pi!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Non hai l'autorizzazione per ridimensionare il file system"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Modalità admin concessa!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Password admin errata!"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr ""
+"Non hai l'autorizzazione per modificare la password dell'amministratore"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Password amministratore impostata. Gli altri dispositivi dovranno effettuare"
+" nuovamente l'accesso."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr ""
+"Password amministratore cancellata. Tutti sono di nuovo amministratori."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Sloggato da modalità admin!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Accetta il nome suggerito"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Rinomina brani in batch"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Errore: non sono stati specificati parametri per il nome file!"
-
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Errore: Impossibile modificare questo brano perché è nella coda corrente:"
+"Errore: impossibile modificare questo brano perché è in coda o in "
+"riproduzione: %s"
 
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
@@ -267,65 +286,7 @@ msgstr ""
 "esiste già"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Canzoni"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Non hai l'autorizzazione per eliminare brani"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Errore: impossibile eliminare questo brano perché è in coda o in "
-"riproduzione"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Canzone eliminata: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Non hai l'autorizzazione per rinominare i brani"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Questa canzone sta suonando. Rinominarlo al termine."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Inserisci un nome per questa canzone."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Questa canzone non è più nella libreria. Potrebbe essere stato rinominato o "
-"eliminato da un altro dispositivo."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Esiste già una canzone chiamata '%s'."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -335,16 +296,92 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Errore durante la ridenominazione del file: %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Canzoni"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Non hai l'autorizzazione per eliminare brani"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Errore: impossibile eliminare questo brano perché è in coda o in "
+"riproduzione"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Canzone eliminata: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Rinomina canzone"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Non hai l'autorizzazione per rinominare i brani"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Questa canzone sta suonando. Rinominarlo al termine."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Inserisci un nome per questa canzone."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Questa canzone non è più nella libreria. Potrebbe essere stato rinominato o "
+"eliminato da un altro dispositivo."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Esiste già una canzone chiamata '%s'."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "File rinominato: %s in %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "In riproduzione"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Impostazioni"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -360,80 +397,86 @@ msgstr "Non hai l'autorizzazione per modificare le preferenze"
 msgid "You don't have permission to clear preferences"
 msgstr "Non hai l'autorizzazione per cancellare le preferenze"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Coda"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Non hai l'autorizzazione per aggiungere brani casuali"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Aggiunte %s tracce casuali"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Ho finito le canzoni!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Non autorizzato"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Coda cancellata!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Spostato in cima alla coda"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Spostato in fondo alla coda"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Spostato in alto nella coda"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Spostato in basso nella coda"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Eliminato dalla coda"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Errore durante lo spostamento in cima alla coda"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Errore durante lo spostamento in fondo alla coda"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Errore durante lo spostamento verso l'alto nella coda"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Errore durante lo spostamento verso il basso nella coda"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Errore durante l'eliminazione dalla coda"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Aggiungi nuovo"
 
@@ -442,6 +485,29 @@ msgstr "Aggiungi nuovo"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Non hai il permesso per visualizzare questa pagina"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Sessioni"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Gioca alla storia"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Classifiche"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -477,8 +543,8 @@ msgstr "Giocato a"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Esecutore"
 
@@ -486,8 +552,8 @@ msgstr "Esecutore"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Canzone"
 
@@ -580,24 +646,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Sei sicuro di voler cancellare l'INTERA coda? Digita ok per continuare"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Sei sicuro di voler eliminare {title} dalla coda?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Vuoi davvero eliminare questa canzone dalla libreria?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} semitoni"
@@ -605,20 +662,20 @@ msgstr "{value} semitoni"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Trasponi questa canzone: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Sei sicuro di voler riavviare questa traccia?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -630,7 +687,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -640,13 +697,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Errore"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -657,50 +714,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sessione corrente: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Home"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Coda"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Classifiche"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Gioca alla storia"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Sessioni"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Impostazioni"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -710,7 +736,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -720,13 +746,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Mostra solo i brani da rinominare"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -737,13 +763,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Mostra tutte le canzoni"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Caricamento brani..."
 
@@ -760,117 +786,111 @@ msgid "No suggestion!"
 msgstr "Nessun suggerimento disponibile!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Rinomina canzone"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Nome file corrente"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Nuovo nome file"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Formattazione automatica"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Scambia artista/titolo"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Suggerisci da iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "Paese di ricerca di iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Salva"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Cancellare"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Elimina questa canzone"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Rinominazione in blocco"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Disponibile in biblioteca"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Tutte le cartelle"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Cerca per titolo, artista..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Pulisci"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Tutte le canzoni"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Cartelle"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Ordina in ordine alfabetico"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Ordina per data"
 
@@ -883,14 +903,14 @@ msgstr "Eliminare questa voce dal registro di gioco?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Non è stato ancora giocato nulla."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Giocato"
 
@@ -908,48 +928,48 @@ msgstr "Giocando"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Opzioni"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Mostra tutti gli artisti"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Nascondi ignorato"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Stato"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Aggiungi alla coda"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Questa canzone non è più nella libreria"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Elimina la voce"
 
@@ -978,47 +998,42 @@ msgstr ""
 "Sei sicuro di voler saltare questo brano? Se non hai aggiunto questa "
 "canzone, chiedi prima il permesso!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "In riproduzione"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Prossima canzone"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Controlli riproduzione"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Riavvia canzone"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Riproduci/Pausa"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Interrompi Canzone attuale"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Cambia Tonalità"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Cambia"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Microfoni"
 
@@ -1056,7 +1071,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1069,7 +1084,7 @@ msgid "Scanning..."
 msgstr "Scansione..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Aggiorna"
 
@@ -1095,184 +1110,188 @@ msgstr "Cronologia di riproduzione cancellata"
 msgid "Library sync complete"
 msgstr "Sincronizzazione della libreria completata"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informazioni"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "\"URL di %(site_title)s:\""
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Codice QR URL utile da condividere con un amico:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Ammin"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Inserisci la password di amministrazione"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Login"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"L'hai dimenticato? Riavvia PiKaraoke con --admin-password per impostarne una"
+" nuova."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Libreria di brani"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Biblioteca"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Canzoni in libreria:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Sincronizza ora"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Riconcilia la libreria con la directory dei brani in background."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Rinominare"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artista - Titolo"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Titolo - Artista"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "L'ordine dei nomi dei brani suggeriti da iTunes"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Reimposta tutta la cronologia"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Elimina ogni sessione e ogni riproduzione registrata. Questa operazione non "
 "può essere annullata."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Preferenze Utente"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Impostazioni della schermata iniziale"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Disattiva video in sottofondo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Disattiva la musica di sottofondo"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Disattiva la schermata del punteggio dopo ogni canzone"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Nascondi notifiche"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Mostra l'orologio iniziale"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Nascondi l'URL e il codice QR"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Nascondi il logo nella schermata iniziale"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Nascondi il nome della sessione nella schermata iniziale"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Nascondi tutte le sovrapposizioni, comprese canzoni in riproduzione, "
 "successive e codice QR"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume predefinito dei video (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume della musica di sottofondo (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1281,17 +1300,17 @@ msgstr ""
 "su 0 per disattivarlo."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Il ritardo in secondi prima dell'inizio del brano successivo"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1299,27 +1318,27 @@ msgstr ""
 "altoparlanti."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latenza"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Cancellazione dell'eco"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Sperimentale"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(riduce il feedback, aggiunge latenza)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1327,92 +1346,92 @@ msgstr ""
 "non sono installati."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Su Linux/Raspberry Pi, installalo con:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "e riavvia PiKaraoke."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Punteggio delle frasi"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Aggiungi una frase per riga in ogni casella e premi Salva."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frasi con punteggio BASSO (punteggio < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Potrebbe essere migliore..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frasi con punteggio MID (30 > punteggio < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Era ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frasi con punteggio ALTO (60 < punteggio)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Meraviglioso..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Impostazioni della lingua"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Lingua preferita (richiede il riavvio)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Impostazioni del server"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normalizza audio volume"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Scarica video in alta qualità"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1423,7 +1442,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1433,7 +1452,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1443,7 +1462,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1453,7 +1472,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1462,7 +1481,7 @@ msgstr ""
 "anticipa l'audio | positivo = ritarda l'audio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limite di brani che un singolo utente può aggiungere alla coda (0 = "
@@ -1470,14 +1489,14 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Abilita coda corretta (la modalità round-robin garantisce che gli utenti si "
 "alternino)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1488,13 +1507,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Canzoni predefinite per pagina."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1504,7 +1523,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1513,97 +1532,97 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Mantieni il server attivo: non supportato su questa piattaforma."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Mantieni il server attivo mentre PiKaraoke è in esecuzione"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Cancella preferenze"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Statistiche di sistema"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Informazioni di sistema"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Piattaforma:"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Versione SO:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp versione:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg versione:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versione:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Statistiche di sistema"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "PROCESSORE:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Caricamento..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Utilizzo del disco:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Memoria:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Aggiornamenti"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "Aggiornamento YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1616,13 +1635,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Aggiorna yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1631,19 +1650,19 @@ msgstr ""
 " Controlla i log di pikaraoke per eventuali errori."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Altro"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Espandi il file system del Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1654,25 +1673,52 @@ msgstr ""
 " Questo riavvierà il sistema."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Fare clic qui per uscire dalla modalità amministratore."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Cambia la password dell'amministratore. Tutti gli altri dispositivi dovranno"
+" effettuare nuovamente l'accesso."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Tutti gli utenti della rete sono amministratori. Imposta una password per "
+"tenere per te i controlli del lettore, la modifica dei brani e lo "
+"spegnimento."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Salva password"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Cancella password"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Esci"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Spegnimento"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1682,17 +1728,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Esci da Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Riavvia il sistema"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Spegni il sistema"
 
@@ -1749,60 +1795,102 @@ msgid "Start a session to queue for singers"
 msgstr "Inizia una sessione per mettere in coda i cantanti"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Download in sospeso"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Preparazione"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Download del video"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Download dell'audio"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Fusione"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Completato"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Nuovo tentativo"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Download in sospeso"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "In coda"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Scarica errori"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Fallito"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Riprova"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Congedare"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Trascina per riordinare"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "La coda è vuota"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Giocare"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pausa"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1812,60 +1900,60 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 42px\" /> brani casuali"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Elimina intera coda"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Gioca al prossimo"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Sposta in alto"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Spostati in alto"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Sposta giù"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Sposta in basso"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Rinominare"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Rimuovi dalla coda"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Ricomincia"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Saltare"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Coda di download"
 
@@ -1884,25 +1972,25 @@ msgstr "Rango"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Gioca"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Canzoni migliori"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Migliori interpreti"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Nessuno ha ancora cantato."
 
@@ -1915,7 +2003,7 @@ msgstr "Aggiunta..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "In biblioteca"
 
@@ -1923,49 +2011,49 @@ msgstr "In biblioteca"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Aggiungi nuovi brani da YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Cerca su YouTube per titolo, artista..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Cerca"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Includi risultati non karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Avanzate"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Incolla un URL di YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Risparmia per dopo"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1976,7 +2064,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1986,7 +2074,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2080,86 +2168,86 @@ msgstr "Mostra queste commedie"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Sessione corrente"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Assegna un nome a questa sessione..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Avvia sessione"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Fine sessione"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Cronologia delle sessioni"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Nascondi avvio automatico"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sessione"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Iniziato"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Rendi attivo"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Esporta CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Elenco di esportazione (testo)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Giochi chiari"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Elimina sessione"
 

--- a/pikaraoke/translations/ja_JP/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ja_JP/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-13 22:54-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: ja_JP <LL@li.org>\n"
@@ -35,45 +35,45 @@ msgid "Volume: %s"
 msgstr "ボリューム: %s"
 
 # auto-translated
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "ダウンロードがキューに入れられました (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "ダウンロード開始: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "ビデオをダウンロード中: %s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "曲のダウンロード中にエラーが発生しました:"
 
 # auto-translated
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "ダウンロードされキューに登録されました: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "ダウンロード済み: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "曲のキュー中にエラーが発生しました:"
 
@@ -117,22 +117,22 @@ msgid "Pause: %s"
 msgstr "一時停止: %s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "設定は正常に変更されました"
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "何か問題が発生しました!あなたの設定は変更されませんでした"
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "設定は正常にクリアされました"
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "何か問題が発生しました!あなたの設定はクリアされませんでした"
 
@@ -185,178 +185,135 @@ msgstr "ストリームの準備に失敗しました"
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "yt-dlpを更新中！ 1 ～ 2 分かかるはずです..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "yt-dlp を更新する権限がありません"
 
 # auto-translated
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "ピカカラオケを終了します!"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "終了する許可がありません"
 
 # auto-translated
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "システムをただちにシャットダウンします!"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "シャットダウンする権限がありません"
 
 # auto-translated
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "システムを再起動中です!"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "再起動する権限がありません"
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "ファイルシステムを拡張してシステムを再起動しています!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "Raspberry Pi 以外のデバイスでは fs を拡張できません。"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "ファイルシステムのサイズを変更する権限がありません"
 
 # auto-translated
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "管理者モードが許可されました!"
 
 # auto-translated
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "管理者パスワードが間違っています!"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "管理者パスワードを変更する権限がありません"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "管理者パスワードが設定されました。他のデバイスは再度ログインする必要があります。"
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "管理者パスワードがクリアされました。全員が再び管理者になります。"
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "管理者モードからログアウトしました!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "提案された名前を受け入れる"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "バッチソングリネーム機能"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "エラー: ファイル名パラメーターが指定されていません。"
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr "エラー: この曲はキューに入れられているか、再生中であるため編集できません: %s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "エラー: この曲は現在のキューにあるため編集できません:"
-
-# auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "ファイル名変更エラー: '%s' から '%s'、ファイル名はすでに存在します"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "歌"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "曲を削除する権限がありません"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr "エラー: この曲はキューに入れられているか、再生中のため削除できません"
-
-# auto-translated
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "削除された曲: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "曲の名前を変更する権限がありません"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "この曲が流れています。終了したら名前を変更します。"
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "この曲の名前を入力します。"
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr "この曲はもうライブラリにありません。名前が変更されたか、別のデバイスから削除された可能性があります。"
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "「%s」という曲はすでに存在します。"
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -364,17 +321,91 @@ msgstr "この曲は編集中に再生が始まりました。終了したら名
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "ファイルの名前変更中にエラーが発生しました: %s"
 
 # auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "歌"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "曲を削除する権限がありません"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "エラー: この曲はキューに入れられているか、再生中のため削除できません"
+
+# auto-translated
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "削除された曲: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "曲名の変更"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "曲の名前を変更する権限がありません"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "この曲が流れています。終了したら名前を変更します。"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "この曲の名前を入力します。"
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "この曲はもうライブラリにありません。名前が変更されたか、別のデバイスから削除された可能性があります。"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "「%s」という曲はすでに存在します。"
+
+# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "ファイル名を変更しました: %s から %s"
+
+# auto-translated
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "プレイ中"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "設定"
 
 # auto-translated
 #: routes/info.py:116
@@ -394,88 +425,95 @@ msgid "You don't have permission to clear preferences"
 msgstr "設定をクリアする権限がありません"
 
 # auto-translated
-#: routes/queue.py:80
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "列"
+
+# auto-translated
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "ランダムな曲を追加する権限がありません"
 
 # auto-translated
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "%s ランダム トラックを追加しました"
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "曲がなくなった！"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "無許可"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "行列を一掃しました！"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "キューの先頭に移動しました"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "キューの最後に移動しました"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "キュー内で上に移動しました"
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "キューの下に移動しました"
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "キューから削除されました"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "キューの先頭に移動中にエラーが発生しました"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "キューの最後に移動中にエラーが発生しました"
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "キューを上に移動中にエラーが発生しました"
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "キューを下位に移動中にエラーが発生しました"
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "キューから削除中にエラーが発生しました"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "新規追加"
 
@@ -484,6 +522,29 @@ msgstr "新規追加"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "このページを表示する権限がありません"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "セッション"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "プレイ履歴"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "ランキング"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -519,8 +580,8 @@ msgstr "演奏場所"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "出演者"
 
@@ -528,8 +589,8 @@ msgstr "出演者"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "歌"
 
@@ -635,24 +696,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "キュー全体をクリアしてもよろしいですか?続行するには「ok」と入力してください"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "{title} をキューから削除してもよろしいですか?"
-
-# auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "この曲をライブラリから削除してもよろしいですか?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 半音"
@@ -660,20 +712,20 @@ msgstr "{value} 半音"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "この曲を移調します: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "このトラックを再開してもよろしいですか?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -682,7 +734,7 @@ msgstr "半音はハーフステップとも呼ばれます。これは西洋古
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -690,14 +742,14 @@ msgstr "ファイルシステムを拡張してもよろしいですか?これ�
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "エラー"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -706,52 +758,20 @@ msgstr "お名前を入力してください。これは、このデバイスか
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "現在のセッション: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "家"
 
 # auto-translated
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "列"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "ランキング"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "プレイ履歴"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "セッション"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "設定"
-
-# auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -761,7 +781,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -771,13 +791,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "名前を変更する曲のみを表示"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -788,13 +808,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "すべての曲を表示"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "曲をロード中..."
 
@@ -812,120 +832,114 @@ msgid "No suggestion!"
 msgstr "提案はありません！"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "曲名の変更"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "現在のファイル名"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "新しいファイル名"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "オートフォーマット"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "アーティスト/タイトルを入れ替える"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "iTunesからの提案"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes の検索国"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "保存"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "キャンセル"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "この曲を削除"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "名前の一括変更"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "図書館で利用可能"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "すべてのフォルダー"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "タイトルやアーティストで検索..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "クリア"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "全曲"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "フォルダー"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "アルファベット順に並べ替える"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "日付順に並べ替える"
 
@@ -938,14 +952,14 @@ msgstr "このエントリを再生ログから削除しますか?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "まだ何もプレイされていません。"
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "遊んだ"
 
@@ -963,26 +977,26 @@ msgstr "遊ぶ"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "オプション"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "すべての出演者を表示"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "スキップされた非表示"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "状態"
 
@@ -990,22 +1004,22 @@ msgstr "状態"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "キューに追加"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "この曲はもうライブラリにありません"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "エントリの削除"
 
@@ -1037,54 +1051,48 @@ msgid ""
 msgstr "このトラックをスキップしてもよろしいですか?この曲を追加していない場合は、まず許可を求めてください。"
 
 # auto-translated
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "プレイ中"
-
-# auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "次の曲"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "プレーヤーのコントロール"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "リスタートソング"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "再生/一時停止"
 
 # auto-translated
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "現在の曲を停止"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "キーの変更"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "変化"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "マイク"
 
@@ -1125,7 +1133,7 @@ msgstr "今すぐ yt-dlp を更新してもよろしいですか?現在および
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr "マイクが検出されませんでした。 USB または Bluetooth マイクを接続し、[更新] をクリックします。"
@@ -1136,7 +1144,7 @@ msgid "Scanning..."
 msgstr "走査..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "リフレッシュ"
 
@@ -1161,14 +1169,8 @@ msgid "Library sync complete"
 msgstr "ライブラリの同期が完了しました"
 
 # auto-translated
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "情報"
-
-# auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s の URL:"
@@ -1176,179 +1178,186 @@ msgstr "%(site_title)s の URL:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "友達と共有するのに便利な URL QR コード:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "管理者"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "管理者パスワードを入力してください"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "ログイン"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr "忘れてしまいましたか？ --admin-password を使用して PiKaraoke を再起動し、新しいパスワードを設定します。"
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "ソングライブラリ"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "図書館"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "ライブラリ内の曲:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "今すぐ同期"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "バックグラウンドでライブラリと曲ディレクトリを調整します。"
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "名前の変更"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "アーティスト - タイトル"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "タイトル - アーティスト"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "iTunes で提案された曲名の順序"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "すべての履歴をリセット"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr "記録上のすべてのセッションとすべてのプレイを削除します。これを元に戻すことはできません。"
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "ユーザー設定"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "スプラッシュスクリーンの設定"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "バックグラウンドビデオを無効にする"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "バックグラウンドミュージックを無効にする"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "各曲の後にスコア画面を無効にする"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "通知を非表示にする"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "スプラッシュクロックを表示"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "URLとQRコードを非表示にする"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "スプラッシュ画面のロゴを非表示にする"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "スプラッシュ画面でセッション名を非表示にする"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "現在再生中、次の再生、QR コードを含むすべてのオーバーレイを非表示にします"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "ビデオのデフォルトの音量 (最小 0、最大 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "BGM の音量 (最小 0、最大 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1356,138 +1365,138 @@ msgstr "スクリーン セーバーがアクティブになるまでのアイ�
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "次の曲が始まるまでの遅延秒数"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "オーディオ"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "サーバー上でマイクが検出されました。オーディオはスピーカーに直接ルーティングされます。"
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "レイテンシー"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "エコーキャンセル"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "実験的"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(フィードバックを減らし、レイテンシを追加します)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr "マイクのサポートは利用できません。必要なオーディオ ツールがインストールされていません。"
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Linux / Raspberry Pi では、次のようにインストールします。"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "そしてPiKaraokeを再起動してください。"
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "スコアフレーズ"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "各ボックスに 1 行に 1 つのフレーズを追加し、保存をクリックします。"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "低スコアのフレーズ (スコア < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "もっと良いかもしれない..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID スコア フレーズ (30 > スコア < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "それは大丈夫でした..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "高スコアのフレーズ (60 < スコア)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "素晴らしい..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "言語設定"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "優先言語 (再起動が必要)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "サーバー設定"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "オーディオの音量を正規化する"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "高品質のビデオをダウンロードする"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1495,7 +1504,7 @@ msgstr "再生前にビデオを完全にトランスコードします (ブラ�
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1503,7 +1512,7 @@ msgstr "CDG ピクセル スケーリングを有効にする (CDG ファイル�
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1511,7 +1520,7 @@ msgstr "YouTube タイトルの自動クリーンアップを有効にする (�
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1519,7 +1528,7 @@ msgstr "フォルダーの参照を有効にする (ライブラリにサブフ�
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1527,19 +1536,19 @@ msgstr "音声とビデオの同期を数秒で修正します (負 = 音声を�
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "個々のユーザーがキューに追加できる曲の制限 (0 = 無制限)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "公平なキューを有効にする (ラウンドロビン モードにより、ユーザーが順番に交代できるようになります)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1548,13 +1557,13 @@ msgstr "キロバイト単位のバッファ サイズ。スプラッシュ画�
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "ページごとのデフォルトの曲。"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1562,115 +1571,115 @@ msgstr "サーバーを起動したままにします。コンテナーでは使
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr "サーバーを起動したままにします。systemd-inhibit (Linux) または caffeinate (macOS) が必要です。"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "サーバーを起動したままにします: このプラットフォームではサポートされていません。"
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "PiKaraoke の実行中はサーバーを起動したままにします"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "設定をクリアする"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "システムデータ"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "システム情報"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "プラットフォーム:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "OSバージョン:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp バージョン:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpegのバージョン:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "ピカオケバージョン："
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "システム統計"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU："
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "読み込み中..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "ディスク使用量:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "メモリ："
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "アップデート"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP アップデート"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1684,14 +1693,14 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "yt-dlp を更新する"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1701,21 +1710,21 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "他の"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Raspberry Pi ファイルシステムを拡張する"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1726,27 +1735,49 @@ msgstr ""
 "\t\t\t\t\t\t\tこれによりシステムが再起動されます。"
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "管理者モードからログアウトするには、ここをクリックしてください。"
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr "管理者パスワードを変更します。他のすべてのデバイスは再度ログインする必要があります。"
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr "ネットワーク上の全員が管理者です。パスワードを設定すると、プレーヤーのコントロール、曲の編集、シャットダウンを自分だけのものにできます。"
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "パスワードを保存する"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "パスワードをクリア"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "ログアウト"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "シャットダウン"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1755,19 +1786,19 @@ msgstr "ただプラグを抜くのはやめてください！データの破損
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "ピカカラオケをやめる"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "システムを再起動します"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "シャットダウンシステム"
 
@@ -1824,62 +1855,104 @@ msgid "Start a session to queue for singers"
 msgstr "セッションを開始して歌手の列に並びます"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "保留中のダウンロード"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "準備中"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "ビデオをダウンロードする"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "音声をダウンロードする"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "結合"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "完了"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "再試行中"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "保留中のダウンロード"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "キューに入れられました"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "ダウンロードエラー"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "失敗した"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "リトライ"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "却下する"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "ドラッグして並べ替えます"
 
 # auto-translated
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "キューは空です"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "遊ぶ"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "一時停止"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1890,60 +1963,60 @@ msgstr ""
 "ランダムな曲を追加します"
 
 # auto-translated
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "すべてクリア"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "次にプレイ"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "先頭に移動"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "上に移動"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "下に移動"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "一番下に移動"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "名前の変更"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "キューから削除"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "再起動"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "スキップ"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "ダウンロードキュー"
 
@@ -1962,25 +2035,25 @@ msgstr "ランク"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "演劇"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "トップソング"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "トップパフォーマー"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "まだ誰も歌っていません。"
 
@@ -1993,7 +2066,7 @@ msgstr "追加中..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "図書館内"
 
@@ -2001,19 +2074,19 @@ msgstr "図書館内"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "YouTube から新しい曲を追加する"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "タイトルやアーティストで YouTube を検索..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "検索"
 
@@ -2021,33 +2094,33 @@ msgstr "検索"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "カラオケ以外の試合も含める"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "高度な"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "YouTube の URL を貼り付けます:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "後で使うために保存しておきます"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2058,7 +2131,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2068,7 +2141,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2155,86 +2228,86 @@ msgstr "これらの劇を見せてください"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "現在のセッション"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "このセッションに名前を付けます..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "セッションを開始する"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "セッションを終了する"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "セッション履歴"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "自動起動を非表示にする"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "セッション"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "開始しました"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "アクティブにする"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "CSVのエクスポート"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "エクスポートリスト（テキスト）"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "クリアプレー"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "セッションの削除"
 

--- a/pikaraoke/translations/ko_KR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ko_KR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-13 22:55-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: ko_KR <LL@li.org>\n"
@@ -35,45 +35,45 @@ msgid "Volume: %s"
 msgstr "볼륨: %s"
 
 # auto-translated
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "다운로드 대기 중(#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "다운로드 시작: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "비디오 다운로드 중: %s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "노래 다운로드 중 오류 발생:"
 
 # auto-translated
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "다운로드되어 대기 중: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "다운로드됨: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "노래를 대기열에 추가하는 중에 오류가 발생했습니다."
 
@@ -117,22 +117,22 @@ msgid "Pause: %s"
 msgstr "일시중지: %s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "환경설정이 성공적으로 변경되었습니다."
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "문제가 발생했습니다. 환경설정이 변경되지 않았습니다."
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "환경설정이 삭제되었습니다."
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "문제가 발생했습니다. 환경설정이 삭제되지 않았습니다."
 
@@ -185,178 +185,135 @@ msgstr "스트림을 준비하지 못했습니다."
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "yt-dlp 업데이트 중! 1~2분 정도 걸릴 것 같아요..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "yt-dlp을 업데이트할 권한이 없습니다."
 
 # auto-translated
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "피카라오케를 종료합니다!"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "종료할 권한이 없습니다."
 
 # auto-translated
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "지금 시스템을 종료합니다!"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "종료할 권한이 없습니다."
 
 # auto-translated
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "지금 시스템을 재부팅합니다!"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "재부팅할 권한이 없습니다."
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "지금 파일 시스템을 확장하고 시스템을 재부팅합니다!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "라즈베리 파이가 아닌 장치에서는 fs를 확장할 수 없습니다!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "파일 시스템 크기를 조정할 권한이 없습니다."
 
 # auto-translated
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "관리자 모드가 부여되었습니다!"
 
 # auto-translated
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "잘못된 관리자 비밀번호입니다!"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "관리자 비밀번호를 변경할 권한이 없습니다."
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "관리자 비밀번호가 설정되었습니다. 다른 장치에서는 다시 로그인해야 합니다."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "관리자 비밀번호가 삭제되었습니다. 모두가 다시 관리자가 되었습니다."
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "관리자 모드에서 로그아웃했습니다!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "제안된 이름 수락"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "일괄 노래 이름 바꾸기"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "오류: 파일 이름 매개변수가 지정되지 않았습니다!"
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr "오류: 이 노래가 대기 중이거나 재생 중이므로 편집할 수 없습니다: %s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "오류: 이 노래는 현재 대기열에 있으므로 편집할 수 없습니다."
-
-# auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "파일 이름을 바꾸는 중 오류 발생: '%s'을(를) '%s'(으)로 변경, 파일 이름이 이미 존재합니다."
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "노래"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "노래를 삭제할 권한이 없습니다."
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr "오류: 이 노래는 대기 중이거나 재생 중이므로 삭제할 수 없습니다."
-
-# auto-translated
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "삭제된 노래: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "노래 이름을 바꿀 권한이 없습니다."
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "이 노래가 재생되고 있습니다. 완료되면 이름을 바꾸십시오."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "이 노래의 이름을 입력하세요."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr "이 노래는 더 이상 라이브러리에 없습니다. 다른 장치에서 이름이 변경되었거나 삭제되었을 수 있습니다."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "'%s'이라는 노래가 이미 존재합니다."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -364,17 +321,91 @@ msgstr "편집하는 동안 이 노래가 재생되기 시작했습니다. 완�
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "파일 이름을 바꾸는 중 오류 발생: %s"
 
 # auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "노래"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "노래를 삭제할 권한이 없습니다."
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "오류: 이 노래는 대기 중이거나 재생 중이므로 삭제할 수 없습니다."
+
+# auto-translated
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "삭제된 노래: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "노래 이름 바꾸기"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "노래 이름을 바꿀 권한이 없습니다."
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "이 노래가 재생되고 있습니다. 완료되면 이름을 바꾸십시오."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "이 노래의 이름을 입력하세요."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "이 노래는 더 이상 라이브러리에 없습니다. 다른 장치에서 이름이 변경되었거나 삭제되었을 수 있습니다."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "'%s'이라는 노래가 이미 존재합니다."
+
+# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "파일 이름이 변경되었습니다: %s에서 %s(으)로"
+
+# auto-translated
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "지금 재생 중"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "설정"
 
 # auto-translated
 #: routes/info.py:116
@@ -394,88 +425,95 @@ msgid "You don't have permission to clear preferences"
 msgstr "환경설정을 삭제할 권한이 없습니다."
 
 # auto-translated
-#: routes/queue.py:80
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "대기줄"
+
+# auto-translated
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "임의의 노래를 추가할 권한이 없습니다."
 
 # auto-translated
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "%s개의 무작위 트랙을 추가했습니다."
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "노래가 부족해요!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "승인되지 않은"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "대기열을 삭제했습니다!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "대기열의 맨 위로 이동됨"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "대기열 맨 아래로 이동됨"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "대기열에서 위로 이동됨"
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "대기열에서 아래로 이동됨"
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "대기열에서 삭제됨"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "대기열의 맨 위로 이동하는 중에 오류가 발생했습니다."
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "대기열 맨 아래로 이동하는 중에 오류가 발생했습니다."
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "대기열에서 위로 이동하는 중에 오류가 발생했습니다."
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "대기열에서 아래로 이동하는 중에 오류가 발생했습니다."
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "대기열에서 삭제하는 중에 오류가 발생했습니다."
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "새로 추가"
 
@@ -484,6 +522,29 @@ msgstr "새로 추가"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "이 페이지를 볼 수 있는 권한이 없습니다."
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "세션"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "플레이 기록"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "순위"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -519,8 +580,8 @@ msgstr "플레이 시간"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "수행자"
 
@@ -528,8 +589,8 @@ msgstr "수행자"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "노래"
 
@@ -635,24 +696,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "대기열 전체를 삭제하시겠습니까? 계속하려면 확인을 입력하세요."
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "대기열에서 {title}을(를) 삭제하시겠습니까?"
-
-# auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "정말로 이 노래를 라이브러리에서 삭제하시겠습니까?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 반음"
@@ -660,20 +712,20 @@ msgstr "{value} 반음"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "이 노래를 조옮김하세요: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "이 트랙을 다시 시작하시겠습니까?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -682,7 +734,7 @@ msgstr "반음은 반음이라고도 합니다. 고전 서양 음악에서 사�
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -690,14 +742,14 @@ msgstr "파일 시스템을 확장하시겠습니까? 그러면 라즈베리 파
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "오류"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -706,52 +758,20 @@ msgstr "이름을 입력해주세요. 이 장치에서 대기열에 추가한 �
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "현재 세션: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "집"
 
 # auto-translated
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "대기줄"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "순위"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "플레이 기록"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "세션"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "설정"
-
-# auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -761,7 +781,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -771,13 +791,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "이름을 바꿀 노래만 표시"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -788,13 +808,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "모든 노래 표시"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "노래 로드 중..."
 
@@ -812,120 +832,114 @@ msgid "No suggestion!"
 msgstr "제안이 없습니다!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "노래 이름 바꾸기"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "현재 파일 이름"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "새 파일 이름"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "자동 포맷"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "아티스트/타이틀 교체"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "iTunes에서 제안"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes 검색 국가"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "구하다"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "취소"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "이 노래 삭제"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "일괄 이름 바꾸기"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "도서관에서 이용 가능"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "모든 폴더"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "제목, 아티스트로 검색..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "분명한"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "모든 노래"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "폴더"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "알파벳순으로 정렬"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "날짜순으로 정렬"
 
@@ -938,14 +952,14 @@ msgstr "플레이 로그에서 이 항목을 삭제하시겠습니까?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "아직 재생된 항목이 없습니다."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "플레이함"
 
@@ -963,26 +977,26 @@ msgstr "재생"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "옵션"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "모든 출연자 표시"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "건너뛴 숨기기"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "상태"
 
@@ -990,22 +1004,22 @@ msgstr "상태"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "대기열에 추가"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "이 노래는 더 이상 라이브러리에 없습니다."
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "항목 삭제"
 
@@ -1037,54 +1051,48 @@ msgid ""
 msgstr "이 트랙을 건너뛰시겠습니까? 이 노래를 추가하지 않았다면 먼저 권한을 요청하세요!"
 
 # auto-translated
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "지금 재생 중"
-
-# auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "다음 노래"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "플레이어 제어"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "노래 다시 시작"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "재생/일시 정지"
 
 # auto-translated
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "현재 노래 중지"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "키 변경"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "변화"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "마이크"
 
@@ -1125,7 +1133,7 @@ msgstr "지금 yt-dlp을 업데이트하시겠습니까? 현재 및 보류 중�
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr "마이크가 감지되지 않았습니다. USB 또는 Bluetooth 마이크를 연결하고 새로 고침을 클릭하세요."
@@ -1136,7 +1144,7 @@ msgid "Scanning..."
 msgstr "스캐닝..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "새로 고치다"
 
@@ -1161,14 +1169,8 @@ msgid "Library sync complete"
 msgstr "라이브러리 동기화 완료"
 
 # auto-translated
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "정보"
-
-# auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s의 URL:"
@@ -1176,179 +1178,186 @@ msgstr "%(site_title)s의 URL:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "친구와 공유할 수 있는 편리한 URL QR 코드:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "관리자"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "관리자 비밀번호를 입력하세요"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "로그인"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr "잊어버리셨나요? --admin-password를 사용하여 PiKaraoke를 다시 시작하여 새로운 비밀번호를 설정하세요."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "노래 라이브러리"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "도서관"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "라이브러리에 있는 노래:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "지금 동기화"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "백그라운드에서 노래 디렉토리와 라이브러리를 조정합니다."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "이름 바꾸기"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "아티스트 - 제목"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "제목 - 아티스트"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "iTunes 추천 노래 이름 순서"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "모든 기록 재설정"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr "기록된 모든 세션과 모든 플레이를 삭제합니다. 이 작업은 취소할 수 없습니다."
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "사용자 환경설정"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "스플래시 화면 설정"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "배경 비디오 비활성화"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "배경 음악 비활성화"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "각 노래가 끝난 후 점수 화면을 비활성화합니다."
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "알림 숨기기"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "스플래시 시계 표시"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "URL 및 QR 코드 숨기기"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "시작 화면에서 로고 숨기기"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "시작 화면에서 세션 이름 숨기기"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "지금 재생 중, 다음 동영상, QR 코드를 포함한 모든 오버레이 숨기기"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "동영상 기본 볼륨(최소 0, 최대 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "배경음악 볼륨 (최소 0, 최대 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1356,138 +1365,138 @@ msgstr "화면 보호기가 활성화되기 전의 유휴 시간(초)입니다. 
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "다음 노래를 시작하기까지의 지연 시간(초)"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "오디오"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "서버에서 마이크가 감지되었습니다. 오디오는 스피커로 직접 라우팅됩니다."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "숨어 있음"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "에코 취소"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "실험적"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(피드백 감소, 대기 시간 추가)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr "마이크 지원을 사용할 수 없습니다. 필수 오디오 도구가 설치되지 않았습니다."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Linux/Raspberry Pi에서는 다음을 사용하여 설치합니다."
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "PiKaraoke를 다시 시작하세요."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "점수 문구"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "각 상자에 한 줄에 하나의 문구를 추가하고 저장을 누르세요."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "낮은 점수 문구(점수 < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "더 좋을 수도..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID 점수 구문(30 > 점수 < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "괜찮았어..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "높은 점수 문구 (60 < 점수)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "훌륭해요..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "언어 설정"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "기본 언어(다시 시작해야 함)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "서버 설정"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "오디오 볼륨 표준화"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "고품질 비디오 다운로드"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1495,7 +1504,7 @@ msgstr "재생하기 전에 비디오를 완전히 트랜스코딩합니다(브�
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1503,7 +1512,7 @@ msgstr "CDG 픽셀 스케일링 활성화(CDG 파일의 시각적 효과가 더�
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1511,7 +1520,7 @@ msgstr "자동 YouTube 제목 정리 사용('Karaoke Version HD'와 같은 의�
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1519,7 +1528,7 @@ msgstr "폴더 탐색 활성화(라이브러리에 하위 폴더가 있는 경�
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1527,19 +1536,19 @@ msgstr "몇 초 만에 오디오 및 비디오 동기화 수정(음수 = 오디�
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "개별 사용자가 대기열에 추가할 수 있는 노래 제한(0 = 무제한)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "공정한 대기열 활성화(라운드 로빈 모드로 사용자가 차례대로 진행되도록 보장)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1548,13 +1557,13 @@ msgstr "버퍼 크기(KB)입니다. 스플래시 화면으로 보내기 전에 �
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "페이지당 기본 노래."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1562,115 +1571,115 @@ msgstr "서버를 깨우세요: 컨테이너에서는 사용할 수 없습니다
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr "서버를 깨우세요: systemd-inhibit(Linux) 또는 카페인(macOS)이 필요합니다."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "서버를 깨우세요: 이 플랫폼에서는 지원되지 않습니다."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "PiKaraoke가 실행되는 동안 서버를 깨워두세요"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "환경설정 지우기"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "시스템 데이터"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "시스템 정보"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "플랫폼:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "운영체제 버전:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp(yt-dlp) 버전:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg 버전:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "피카라오케 버전:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "시스템 통계"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "로드 중..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "디스크 사용량:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "메모리:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "업데이트"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP 업데이트"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1684,14 +1693,14 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "yt-dlp 업데이트"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1701,21 +1710,21 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "다른"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Raspberry Pi 파일 시스템 확장"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1726,27 +1735,49 @@ msgstr ""
 "\t\t\t\t\t\t\t그러면 시스템이 재부팅됩니다."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "관리자 모드에서 로그아웃하려면 여기를 클릭하세요."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr "관리자 비밀번호를 변경하세요. 다른 모든 장치에서는 다시 로그인해야 합니다."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr "네트워크의 모든 사람은 관리자입니다. 플레이어 제어, 노래 편집 및 종료를 혼자서 유지하려면 비밀번호를 설정하세요."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "비밀번호 저장"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "비밀번호 지우기"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "로그아웃"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "일시 휴업"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1755,19 +1786,19 @@ msgstr "플러그만 뽑지 마세요! 데이터 손상을 방지하려면 항�
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "피카라오케 종료"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "시스템 재부팅"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "셧다운 시스템"
 
@@ -1824,62 +1855,104 @@ msgid "Start a session to queue for singers"
 msgstr "가수 대기열에 세션을 시작하세요"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "다운로드 대기 중"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "준비 중"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "비디오 다운로드 중"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "오디오 다운로드 중"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "병합"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "완료"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "재시도 중"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "다운로드 대기 중"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "대기 중"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "다운로드 오류"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "실패한"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "다시 해 보다"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "해고하다"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "드래그하여 재정렬하세요."
 
 # auto-translated
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "대기열이 비어 있습니다."
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "놀다"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "정지시키다"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1890,60 +1963,60 @@ msgstr ""
 " 노래 추가"
 
 # auto-translated
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "모두 지우기"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "다음 플레이"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "맨 위로 이동"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "위로 이동"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "아래로 이동"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "맨 아래로 이동"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "이름 바꾸기"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "대기열에서 제거"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "다시 시작"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "건너뛰다"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "대기열 다운로드"
 
@@ -1962,25 +2035,25 @@ msgstr "계급"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "연극"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "인기곡"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "최고 성과자"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "아직 노래를 부른 사람은 없습니다."
 
@@ -1993,7 +2066,7 @@ msgstr "첨가..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "도서관에서"
 
@@ -2001,19 +2074,19 @@ msgstr "도서관에서"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "YouTube에서 새 노래 추가"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "YouTube에서 제목, 아티스트 등으로 검색하세요."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "찾다"
 
@@ -2021,33 +2094,33 @@ msgstr "찾다"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "노래방이 아닌 경기 포함"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "고급의"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "YouTube URL 붙여넣기:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "나중을 위해 저장"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2058,7 +2131,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2068,7 +2141,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2155,86 +2228,86 @@ msgstr "이 연극을 보여주세요"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "현재 세션"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "이 세션의 이름을 지정하세요..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "세션 시작"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "세션 종료"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "세션 기록"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "자동 시작 숨기기"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "세션"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "시작됨"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "활성화"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "CSV 내보내기"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "목록 내보내기(텍스트)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "명확한 플레이"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "세션 삭제"
 

--- a/pikaraoke/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/nb_NO/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-14 10:27-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: nb_NO <LL@li.org>\n"
@@ -35,45 +35,45 @@ msgid "Volume: %s"
 msgstr "Volum: %s"
 
 # auto-translated
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Nedlastingskø (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Nedlasting starter: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Laster ned video: %s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Feil ved nedlasting av sang:"
 
 # auto-translated
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Lastet ned og satt i kø: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Lastet ned: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Feil ved å sette sang i kø:"
 
@@ -117,22 +117,22 @@ msgid "Pause: %s"
 msgstr "Pause: %s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Preferansene dine ble endret"
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Noe gikk galt! Preferansene dine ble ikke endret"
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Preferansene dine ble slettet"
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Noe gikk galt! Preferansene dine ble ikke slettet"
 
@@ -185,117 +185,130 @@ msgstr "Kunne ikke forberede strømmen"
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Oppdaterer yt-dlp! Burde ta et minutt eller to..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Du har ikke tillatelse til å oppdatere yt-dlp"
 
 # auto-translated
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Avslutter pikaraoke nå!"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Du har ikke tillatelse til å slutte"
 
 # auto-translated
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Slår av systemet nå!"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Du har ikke tillatelse til å stenge"
 
 # auto-translated
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Starter systemet på nytt nå!"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Du har ikke tillatelse til å starte på nytt"
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Utvider filsystemet og starter systemet på nytt nå!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "Kan ikke utvide fs på ikke-raspberry pi-enheter!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Du har ikke tillatelse til å endre størrelse på filsystemet"
 
 # auto-translated
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Administrasjonsmodus gitt!"
 
 # auto-translated
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Feil administratorpassord!"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "Du har ikke tillatelse til å endre administratorpassordet"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "Administratorpassord satt. Andre enheter må logge på igjen."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "Administratorpassord slettet. Alle er administratorer igjen."
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Logget ut av admin-modus!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Godta foreslåtte navn"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Batch Song Renamer"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Feil: Ingen filnavnparametere ble spesifisert!"
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr ""
+"Feil: Kan ikke redigere denne sangen fordi den er i kø eller spilles av: %s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "Feil: Kan ikke redigere denne sangen fordi den er i gjeldende kø:"
-
-# auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
@@ -303,64 +316,7 @@ msgstr ""
 "allerede"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Sanger"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Du har ikke tillatelse til å slette sanger"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr "Feil: Kan ikke slette denne sangen fordi den er i kø eller spilles av"
-
-# auto-translated
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Sang slettet: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Du har ikke tillatelse til å gi nytt navn til sanger"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Denne sangen spilles. Gi det nytt navn når det er ferdig."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Skriv inn et navn for denne sangen."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Denne sangen er ikke lenger på biblioteket. Det kan ha blitt omdøpt eller "
-"slettet fra en annen enhet."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "En sang kalt «%s» finnes allerede."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -370,17 +326,93 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Feil ved å gi nytt navn til fil: %s"
 
 # auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Sanger"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Du har ikke tillatelse til å slette sanger"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "Feil: Kan ikke slette denne sangen fordi den er i kø eller spilles av"
+
+# auto-translated
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Sang slettet: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Gi nytt navn til sangen"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Du har ikke tillatelse til å gi nytt navn til sanger"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Denne sangen spilles. Gi det nytt navn når det er ferdig."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Skriv inn et navn for denne sangen."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Denne sangen er ikke lenger på biblioteket. Det kan ha blitt omdøpt eller "
+"slettet fra en annen enhet."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "En sang kalt «%s» finnes allerede."
+
+# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Omdøpt fil: %s til %s"
+
+# auto-translated
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Spiller nå"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Innstillinger"
 
 # auto-translated
 #: routes/info.py:116
@@ -400,88 +432,95 @@ msgid "You don't have permission to clear preferences"
 msgstr "Du har ikke tillatelse til å slette preferanser"
 
 # auto-translated
-#: routes/queue.py:80
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Kø"
+
+# auto-translated
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Du har ikke tillatelse til å legge til tilfeldige sanger"
 
 # auto-translated
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Lagt til %s tilfeldige spor"
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Gikk tom for sanger!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Uautorisert"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Tømte køen!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Flyttet til toppen av køen"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Flyttet til bunnen av køen"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Flyttet opp i køen"
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Flyttet ned i køen"
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Slettet fra køen"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Feil ved flytting til toppen av køen"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Feil ved flytting til bunnen av køen"
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Feil ved å flytte opp i køen"
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Feil ved flytting ned i køen"
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Feil ved sletting fra køen"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Legg til ny"
 
@@ -490,6 +529,29 @@ msgstr "Legg til ny"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Du har ikke tillatelse til å se denne siden"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Økter"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Spillhistorikk"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Rangeringer"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -525,8 +587,8 @@ msgstr "Spilt kl"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Utøver"
 
@@ -534,8 +596,8 @@ msgstr "Utøver"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Sang"
 
@@ -643,24 +705,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "Er du sikker på at du vil tømme HELE køen? Skriv ok for å fortsette"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Er du sikker på at du vil slette {title} fra køen?"
-
-# auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Er du sikker på at du vil slette denne sangen fra biblioteket?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} halvtoner"
@@ -668,20 +721,20 @@ msgstr "{value} halvtoner"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponere denne sangen: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Er du sikker på at du vil starte dette sporet på nytt?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -693,7 +746,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -703,14 +756,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Feil"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -721,52 +774,20 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Gjeldende økt: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Hjem"
 
 # auto-translated
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Kø"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Rangeringer"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Spillhistorikk"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Økter"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Innstillinger"
-
-# auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -776,7 +797,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -786,13 +807,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Vis bare sanger som skal gis nytt navn"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -803,13 +824,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Vis alle sangene"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Laster inn sanger ..."
 
@@ -827,120 +848,114 @@ msgid "No suggestion!"
 msgstr "Ingen forslag!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Gi nytt navn til sangen"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Gjeldende filnavn"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Nytt filnavn"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Automatisk formatering"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Bytt artist/tittel"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Foreslå fra iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes-søkeland"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Spare"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Kansellere"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Slett denne sangen"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Gi nytt navn"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Tilgjengelig på biblioteket"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Alle mapper"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Søk etter tittel, artist..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Klar"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Alle sanger"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Mapper"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Sorter alfabetisk"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Sorter etter dato"
 
@@ -953,14 +968,14 @@ msgstr "Vil du slette denne oppføringen fra spilleloggen?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Ingenting er spilt ennå."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Spilt"
 
@@ -978,26 +993,26 @@ msgstr "Spiller"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Alternativer"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Vis alle utøvere"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Skjul hoppet over"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Status"
 
@@ -1005,22 +1020,22 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Legg til i kø"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Denne sangen er ikke lenger på biblioteket"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Slett oppføring"
 
@@ -1054,54 +1069,48 @@ msgstr ""
 " denne sangen, spør om tillatelse først!"
 
 # auto-translated
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Spiller nå"
-
-# auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Neste sang"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Spillerkontroll"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Start sangen på nytt"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Spill av/pause"
 
 # auto-translated
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Stopp gjeldende sang"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Endre nøkkel"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Endre"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Mikrofoner"
 
@@ -1144,7 +1153,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1157,7 +1166,7 @@ msgid "Scanning..."
 msgstr "Skanner..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Forfriske"
 
@@ -1184,14 +1193,8 @@ msgid "Library sync complete"
 msgstr "Biblioteksynkronisering fullført"
 
 # auto-translated
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informasjon"
-
-# auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL til %(site_title)s:"
@@ -1199,179 +1202,187 @@ msgstr "URL til %(site_title)s:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Praktisk URL QR-kode for å dele med en venn:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Admin"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Skriv inn administratorpassordet"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Logg inn"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Glemt det? Start PiKaraoke på nytt med --admin-passord for å sette et nytt."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Sangbibliotek"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Bibliotek"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Sanger i biblioteket:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Synkroniser nå"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Avstemmer biblioteket med sangkatalogen i bakgrunnen."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Gi nytt navn"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artist - Tittel"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Tittel - Artist"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Rekkefølge av iTunes foreslåtte sangnavn"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Tilbakestill all historikk"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr "Sletter hver økt og hver avspilling på plate. Dette kan ikke angres."
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Brukerinnstillinger"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Splash-skjerminnstillinger"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Deaktiver bakgrunnsvideo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Deaktiver bakgrunnsmusikk"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Deaktiver partiturskjermen etter hver sang"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Skjul varsler"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Vis sprutklokke"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Skjul URL-en og QR-koden"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Skjul logoen på velkomstskjermen"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Skjul øktnavnet på velkomstskjermen"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Skjul alle overlegg, inkludert nå som spilles, opp neste og QR-kode"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Standardvolum for videoene (min 0, maks 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volum på bakgrunnsmusikken (min 0, maks 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1381,43 +1392,43 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Forsinkelsen i sekunder før du starter neste sang"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Lyd"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "Mikrofoner oppdaget på serveren. Lyden rutes direkte til høyttalere."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latens"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Ekko kansellering"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Eksperimentell"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(reduserer tilbakemelding, legger til ventetid)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1425,96 +1436,96 @@ msgstr ""
 "installert."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "På Linux / Raspberry Pi, installer den med:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "og start PiKaraoke på nytt."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Score setninger"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Legg til én setning per linje i hver boks og trykk på lagre."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "setninger med lav poengsum (score < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Kunne vært bedre..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID-poengsetninger (30 > score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Det var ok..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "HIGH Score-setninger (60 < poengsum)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Fantastisk..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Språkinnstillinger"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Foretrukket språk (krever omstart)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Serverinnstillinger"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normaliser lydvolumet"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Last ned videoer av høy kvalitet"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1524,7 +1535,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1534,7 +1545,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1544,7 +1555,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1554,7 +1565,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1564,7 +1575,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Begrensning av sanger en individuell bruker kan legge til i køen (0 = "
@@ -1572,13 +1583,13 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "Aktiver rettferdig kø (round-robin-modus sikrer at brukerne bytter)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1589,13 +1600,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Standard sanger per side."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1604,7 +1615,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1612,108 +1623,108 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Hold serveren våken: støttes ikke på denne plattformen."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Hold serveren våken mens PiKaraoke kjører"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Tydelige preferanser"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Systemdata"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Systeminfo"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Plattform:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "OS-versjon:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp versjon:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg versjon:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Pikaraoke versjon:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Systemstatistikk"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Laster inn..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Diskbruk:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Hukommelse:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Oppdateringer"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP-oppdatering"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1727,14 +1738,14 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Oppdater yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1744,21 +1755,21 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Annen"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Utvid Raspberry Pi-filsystemet"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1769,27 +1780,51 @@ msgstr ""
 "\t\t\t\t\t\t\tDette vil starte systemet på nytt."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Klikk her for å logge ut fra admin-modus."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr "Endre administratorpassordet. Alle andre enheter må logge på igjen."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Alle på nettverket er administratorer. Angi et passord for å holde "
+"spillerkontrollene, sangredigering og avslutning for deg selv."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Lagre passord"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Tøm passord"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Logg ut"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Avslutning"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1800,19 +1835,19 @@ msgstr ""
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Avslutt Pikaraoke"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Start systemet på nytt"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Slå av systemet"
 
@@ -1869,62 +1904,104 @@ msgid "Start a session to queue for singers"
 msgstr "Start en økt for å stå i kø for sangere"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Venter på nedlastinger"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Forbereder"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Laster ned video"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Laster ned lyd"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Slår sammen"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Fullført"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Prøver på nytt"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Venter på nedlastinger"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "I kø"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Last ned feil"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Mislyktes"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Prøv på nytt"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Avskjedige"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Dra for å omorganisere"
 
 # auto-translated
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "Køen er tom"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Spille"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pause"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1935,60 +2012,60 @@ msgstr ""
 "style=\"width: 42px\" /> tilfeldige sanger"
 
 # auto-translated
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Fjern alle"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Spill Neste"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Flytt til toppen"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Flytt opp"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Flytt ned"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Flytt til bunnen"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Gi nytt navn"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Fjern fra køen"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Start på nytt"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Hopp over"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Last ned kø"
 
@@ -2007,25 +2084,25 @@ msgstr "Rang"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Spiller"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Topp sanger"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Topp utøvere"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Ingen har sunget ennå."
 
@@ -2038,7 +2115,7 @@ msgstr "Legger til ..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "På biblioteket"
 
@@ -2046,19 +2123,19 @@ msgstr "På biblioteket"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Legg til nye sanger fra YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Søk på YouTube etter tittel, artist..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Søk"
 
@@ -2066,33 +2143,33 @@ msgstr "Søk"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Inkluder ikke-karaoke-kamper"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Avansert"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Lim inn en YouTube-nettadresse:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Lagre til senere"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2103,7 +2180,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2113,7 +2190,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2206,86 +2283,86 @@ msgstr "Vis disse skuespillene"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Nåværende økt"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Gi denne økten et navn..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Start økten"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Avslutt økten"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Sesjonshistorie"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Skjul autostartet"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sesjon"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Startet"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Gjør aktiv"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Eksporter CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Eksporter liste (tekst)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Tydelige skuespill"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Slett økten"
 

--- a/pikaraoke/translations/nl_NL/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/nl_NL/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-13 22:56-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: nl_NL <LL@li.org>\n"
@@ -35,45 +35,45 @@ msgid "Volume: %s"
 msgstr "Volume: %s"
 
 # auto-translated
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Downloaden in wachtrij (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Downloaden begint: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Video downloaden: %s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Fout bij downloaden van nummer:"
 
 # auto-translated
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Gedownload en in de wachtrij geplaatst: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Gedownload: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Fout bij het in de wachtrij plaatsen van nummer:"
 
@@ -117,22 +117,22 @@ msgid "Pause: %s"
 msgstr "Pauze: %s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Uw voorkeuren zijn succesvol gewijzigd"
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Er is iets misgegaan! Uw voorkeuren zijn niet gewijzigd"
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Uw voorkeuren zijn succesvol gewist"
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Er is iets misgegaan! Uw voorkeuren zijn niet gewist"
 
@@ -186,185 +186,140 @@ msgstr "Kan stream niet voorbereiden"
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Yt-dlp bijwerken! Het zou een minuut of twee moeten duren..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Je hebt geen toestemming om yt-dlp bij te werken"
 
 # auto-translated
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Nu pikaraoke verlaten!"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "U heeft geen toestemming om te stoppen"
 
 # auto-translated
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Systeem wordt nu afgesloten!"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "U heeft geen toestemming om af te sluiten"
 
 # auto-translated
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Systeem nu opnieuw opstarten!"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "U heeft geen toestemming om opnieuw op te starten"
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Bestandssysteem uitbreiden en systeem nu opnieuw opstarten!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "Kan fs niet uitbreiden op niet-Raspberry Pi-apparaten!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr ""
 "U heeft geen toestemming om de grootte van het bestandssysteem te wijzigen"
 
 # auto-translated
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Beheerdersmodus toegestaan!"
 
 # auto-translated
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Onjuist beheerderswachtwoord!"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "U heeft geen toestemming om het beheerderswachtwoord te wijzigen"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Beheerderswachtwoord ingesteld. Andere apparaten moeten opnieuw inloggen."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "Beheerderswachtwoord gewist. Iedereen is weer beheerder."
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Uitgelogd uit de beheerdersmodus!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Accepteer de voorgestelde naam"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Hernoemer van batchnummers"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Fout: Er zijn geen bestandsnaamparameters opgegeven!"
-
-# auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Fout: Kan dit nummer niet bewerken omdat het in de huidige wachtrij staat:"
+"Fout: Kan dit nummer niet bewerken omdat het in de wachtrij staat of wordt "
+"afgespeeld: %s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr ""
 "Fout bij hernoemen van bestand: '%s' naar '%s', bestandsnaam bestaat al"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Liedjes"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Je hebt geen toestemming om nummers te verwijderen"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Fout: Kan dit nummer niet verwijderen omdat het in de wachtrij staat of "
-"wordt afgespeeld"
-
-# auto-translated
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Nummer verwijderd: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Je hebt geen toestemming om de naam van nummers te wijzigen"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Dit nummer wordt afgespeeld. Hernoem het wanneer het klaar is."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Voer een naam in voor dit nummer."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Dit nummer staat niet meer in de bibliotheek. Het is mogelijk hernoemd of "
-"verwijderd van een ander apparaat."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Er bestaat al een nummer met de naam '%s'."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -374,17 +329,95 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Fout bij hernoemen van bestand: %s"
 
 # auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Liedjes"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Je hebt geen toestemming om nummers te verwijderen"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Fout: Kan dit nummer niet verwijderen omdat het in de wachtrij staat of "
+"wordt afgespeeld"
+
+# auto-translated
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Nummer verwijderd: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Hernoem het nummer"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Je hebt geen toestemming om de naam van nummers te wijzigen"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Dit nummer wordt afgespeeld. Hernoem het wanneer het klaar is."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Voer een naam in voor dit nummer."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Dit nummer staat niet meer in de bibliotheek. Het is mogelijk hernoemd of "
+"verwijderd van een ander apparaat."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Er bestaat al een nummer met de naam '%s'."
+
+# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Hernoemd bestand: %s naar %s"
+
+# auto-translated
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Nu aan het spelen"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Instellingen"
 
 # auto-translated
 #: routes/info.py:116
@@ -404,88 +437,95 @@ msgid "You don't have permission to clear preferences"
 msgstr "U heeft geen toestemming om voorkeuren te wissen"
 
 # auto-translated
-#: routes/queue.py:80
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Wachtrij"
+
+# auto-translated
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Je hebt geen toestemming om willekeurige nummers toe te voegen"
 
 # auto-translated
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "%s willekeurige nummers toegevoegd"
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Er waren geen liedjes meer!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Ongeautoriseerd"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "De wachtrij gewist!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Verplaatst naar de top van de wachtrij"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Verplaatst naar de onderkant van de wachtrij"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Verplaatst in de wachtrij"
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Verplaatst naar beneden in de wachtrij"
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Verwijderd uit wachtrij"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Fout bij het verplaatsen naar de bovenkant van de wachtrij"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Fout bij het verplaatsen naar de onderkant van de wachtrij"
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Fout bij het omhooggaan in de wachtrij"
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Fout bij het naar beneden verplaatsen in de wachtrij"
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Fout bij verwijderen uit wachtrij"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Nieuw toevoegen"
 
@@ -494,6 +534,29 @@ msgstr "Nieuw toevoegen"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "U heeft geen toestemming om deze pagina te bekijken"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Sessies"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Speelgeschiedenis"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Ranglijsten"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -529,8 +592,8 @@ msgstr "Gespeeld bij"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Uitvoerder"
 
@@ -538,8 +601,8 @@ msgstr "Uitvoerder"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Liedje"
 
@@ -648,24 +711,15 @@ msgstr ""
 "Weet u zeker dat u de HELE wachtrij wilt wissen? Typ ok om door te gaan"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Weet u zeker dat u {title} uit de wachtrij wilt verwijderen?"
-
-# auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Weet je zeker dat je dit nummer uit de bibliotheek wilt verwijderen?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} halve tonen"
@@ -673,20 +727,20 @@ msgstr "{value} halve tonen"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponeer dit nummer: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Weet je zeker dat je dit nummer opnieuw wilt starten?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -698,7 +752,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -708,14 +762,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Fout"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -726,52 +780,20 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Huidige sessie: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Thuis"
 
 # auto-translated
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Wachtrij"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Ranglijsten"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Speelgeschiedenis"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Sessies"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Instellingen"
-
-# auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -781,7 +803,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -791,13 +813,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Toon alleen nummers waarvan u de naam wilt wijzigen"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -808,13 +830,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Toon alle nummers"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Nummers laden..."
 
@@ -833,120 +855,114 @@ msgid "No suggestion!"
 msgstr "Geen suggestie!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Hernoem het nummer"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Huidige bestandsnaam"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Nieuwe bestandsnaam"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Automatisch formatteren"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Wissel artiest/titel om"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Suggestie van iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes-zoekland"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Redden"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Annuleren"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Verwijder dit nummer"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Bulk hernoemen"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Verkrijgbaar in de bibliotheek"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Alle mappen"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Zoek op titel, artiest..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Duidelijk"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Alle liedjes"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Mappen"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Alfabetisch sorteren"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Sorteer op datum"
 
@@ -959,14 +975,14 @@ msgstr "Deze vermelding uit het afspeellogboek verwijderen?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Er is nog niets gespeeld."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Gespeeld"
 
@@ -984,26 +1000,26 @@ msgstr "Spelen"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Opties"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Toon alle artiesten"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Verbergen overgeslagen"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Status"
 
@@ -1011,22 +1027,22 @@ msgstr "Status"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Toevoegen aan wachtrij"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Dit nummer staat niet meer in de bibliotheek"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Invoer verwijderen"
 
@@ -1060,54 +1076,48 @@ msgstr ""
 "toegevoegd, vraag dan eerst toestemming!"
 
 # auto-translated
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Nu aan het spelen"
-
-# auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Volgend nummer"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Spelercontrole"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Start het nummer opnieuw"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Afspelen/pauzeren"
 
 # auto-translated
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Stop het huidige nummer"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Sleutel wijzigen"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Wijziging"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Microfoons"
 
@@ -1150,7 +1160,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1163,7 +1173,7 @@ msgid "Scanning..."
 msgstr "Scannen..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Vernieuwen"
 
@@ -1190,14 +1200,8 @@ msgid "Library sync complete"
 msgstr "Synchronisatie van bibliotheek voltooid"
 
 # auto-translated
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informatie"
-
-# auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL van %(site_title)s:"
@@ -1205,91 +1209,100 @@ msgstr "URL van %(site_title)s:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Handige URL QR-code om te delen met een vriend:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Beheerder"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Voer het beheerderswachtwoord in"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Login"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Vergeten? Start PiKaraoke opnieuw met --admin-password om een ​​nieuw "
+"wachtwoord in te stellen."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Liedbibliotheek"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Bibliotheek"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Nummers in bibliotheek:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Synchroniseer nu"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Verzoent de bibliotheek met de songmap op de achtergrond."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Hernoemen"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artiest - Titel"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Titel - Artiest"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Volgorde van door iTunes voorgestelde namen van nummers"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Reset de hele geschiedenis"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Verwijdert elke sessie en elk opgenomen spel. Dit kan niet ongedaan worden "
@@ -1297,89 +1310,89 @@ msgstr ""
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Gebruikersvoorkeuren"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Instellingen opstartscherm"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Schakel achtergrondvideo uit"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Schakel achtergrondmuziek uit"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Schakel het scorescherm na elk nummer uit"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Meldingen verbergen"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Laat de splashklok zien"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Verberg de URL en QR-code"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Verberg het logo op het startscherm"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Verberg de sessienaam op het startscherm"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Verberg alle overlays, inclusief nu spelen, volgende en QR-code"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Standaardvolume van de video's (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume van de achtergrondmuziek (min 0, max 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1389,17 +1402,17 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "De vertraging in seconden voordat het volgende nummer begint"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Audio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1407,27 +1420,27 @@ msgstr ""
 "luidsprekers geleid."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latentie"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Echo-annulering"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Experimenteel"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(vermindert feedback, voegt latentie toe)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1435,96 +1448,96 @@ msgstr ""
 "geïnstalleerd."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "Op Linux / Raspberry Pi installeer je het met:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "en start PiKaraoke opnieuw."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Score-zinnen"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Voeg één zin per regel toe in elk vak en klik op Opslaan."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "LAGE scorezinnen (score < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Kan beter..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID-scorezinnen (30 > score < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Dat was oké..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Zinnen met een HOGE Score (60 < score)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Geweldig..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Taalinstellingen"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Voorkeurstaal (herstart vereist)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Serverinstellingen"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normaliseer het audiovolume"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Download video's van hoge kwaliteit"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1535,7 +1548,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1545,7 +1558,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1555,7 +1568,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1565,7 +1578,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1575,7 +1588,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Limiet van nummers die een individuele gebruiker aan de wachtrij kan "
@@ -1583,7 +1596,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Schakel eerlijke wachtrij in (round-robin-modus zorgt ervoor dat gebruikers "
@@ -1591,7 +1604,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1602,13 +1615,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Standaardnummers per pagina."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1618,7 +1631,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1627,108 +1640,108 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Houd de server wakker: wordt niet ondersteund op dit platform."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Houd de server wakker terwijl PiKaraoke actief is"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Duidelijke voorkeuren"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Systeemgegevens"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Systeeminfo"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Platform:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "OS-versie:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp-versie:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg-versie:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Picaraoke-versie:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Systeemstatistieken"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Laden..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Schijfgebruik:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Geheugen:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Updates"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP-update"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1742,14 +1755,14 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Update yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1759,21 +1772,21 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Ander"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Vouw het Raspberry Pi-bestandssysteem uit"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1784,27 +1797,53 @@ msgstr ""
 "\t\t\t\t\t\t\tHierdoor wordt het systeem opnieuw opgestart."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Klik hier om uit te loggen uit de beheerdersmodus."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Wijzig het beheerderswachtwoord. Elk ander apparaat moet opnieuw inloggen."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Iedereen op het netwerk is een beheerder. Stel een wachtwoord in om de "
+"bediening van de speler, het bewerken van nummers en het afsluiten voor "
+"uzelf te houden."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Wachtwoord opslaan"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Wachtwoord wissen"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Uitloggen"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Afsluiten"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1815,19 +1854,19 @@ msgstr ""
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Stop met Picaraoke"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Start het systeem opnieuw op"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Systeem afsluiten"
 
@@ -1884,62 +1923,104 @@ msgid "Start a session to queue for singers"
 msgstr "Start een sessie om in de rij te staan ​​voor zangers"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Downloads in behandeling"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Voorbereiden"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Video downloaden"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Audio downloaden"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Samenvoegen"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Voltooid"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Opnieuw proberen"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Downloads in behandeling"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "In de wachtrij"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Downloadfouten"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Mislukt"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Opnieuw proberen"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Afwijzen"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Sleep om de volgorde te wijzigen"
 
 # auto-translated
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "De wachtrij is leeg"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Toneelstuk"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pauze"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1950,60 +2031,60 @@ msgstr ""
 "style=\"width: 42px\" /> willekeurige nummers toe"
 
 # auto-translated
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Alles wissen"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Speel Volgende"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Verplaats naar boven"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Ga omhoog"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Ga naar beneden"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Verplaats naar beneden"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Hernoemen"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Verwijderen uit wachtrij"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Opnieuw opstarten"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Overslaan"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Wachtrij downloaden"
 
@@ -2022,25 +2103,25 @@ msgstr "Rang"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Speelt"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Topnummers"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Toppresteerders"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Er heeft nog niemand gezongen."
 
@@ -2053,7 +2134,7 @@ msgstr "Toevoegen..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "In bibliotheek"
 
@@ -2061,19 +2142,19 @@ msgstr "In bibliotheek"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Voeg nieuwe nummers van YouTube toe"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Zoek op YouTube op titel, artiest..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Zoekopdracht"
 
@@ -2081,33 +2162,33 @@ msgstr "Zoekopdracht"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Inclusief niet-karaokewedstrijden"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Geavanceerd"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Plak een YouTube-URL:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Bewaar voor later"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2118,7 +2199,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2128,7 +2209,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2223,86 +2304,86 @@ msgstr "Laat deze toneelstukken zien"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Huidige sessie"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Noem deze sessie..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Sessie starten"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Sessie beëindigen"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Sessiegeschiedenis"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Automatisch gestart verbergen"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sessie"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Gestart"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Actief maken"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "CSV exporteren"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Lijst exporteren (tekst)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Duidelijke toneelstukken"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Sessie verwijderen"
 

--- a/pikaraoke/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/pt_BR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: mawkee@gmail.com\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2022-06-28 18:57-0300\n"
 "Last-Translator: FULL NAME <mawkee@gmail.com>\n"
 "Language-Team: pt_BR <LL@li.org>\n"
@@ -32,39 +32,39 @@ msgstr "Transpondo em %s semitons: %s"
 msgid "Volume: %s"
 msgstr "Volume: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Música adicionada à fila (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Baixando vídeo: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Baixando vídeo: %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Erro ao baixar a música: "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Música adicionada à fila: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Baixada: %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Erro ao adicionar a música à fila: "
 
@@ -104,19 +104,19 @@ msgstr "Retomando: %s"
 msgid "Pause: %s"
 msgstr "Pausa: %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Suas preferências foram alteradas com sucesso"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Algo deu errado! Suas preferências não foram alteradas"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Suas preferências foram limpas com sucesso"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Algo deu errado! Suas preferências não foram limpas"
 
@@ -163,54 +163,54 @@ msgid "Failed to prepare stream"
 msgstr "Falha ao preparar stream"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Atualizando o yt-dlp! Isso deve levar um ou dois minutos... "
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "Você não tem permissão para atualizar o yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Fechando o Pikaraoke!"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "Você não tem permissão para sair"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Desligando o sistema!"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "Você não tem permissão para sair"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Reiniciando o sistema!"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "Você não tem permissão para reiniciar o sistema"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "Expandindo o sistema e reiniciando!"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr ""
 "Não é possivel expandir o sistema de arquivos em dispositivos não-raspberry "
@@ -218,109 +218,70 @@ msgstr ""
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "Você não tem permissão para redimensionar o sistema de arquivos"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Modo administrador concedido!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Senha de administração incorreta!"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "Você não tem permissão para alterar a senha do administrador"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Senha de administrador definida. Outros dispositivos precisarão fazer login "
+"novamente."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "Senha de administrador apagada. Todo mundo é administrador novamente."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Você saiu do modo administrador!"
 
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Aceitar nome sugerido"
 
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Renomear músicas em lote"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Erro: Nenhum nome de arquivo foi especificado!"
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr ""
+"Erro: não é possível editar esta música porque ela está na fila ou tocando: "
+"%s"
 
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "Erro: Nao é possivel editar essa musica porque ela está na fila: "
-
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "Erro ao renomear o arquivo: '%s' para '%s', Nome do arquivo já existe"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Músicas"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "Você não tem permissão para excluir músicas"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Erro: não é possível excluir esta música porque ela está na fila ou tocando"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Música removida: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "Você não tem permissão para renomear músicas"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Esta música está tocando. Renomeie-o quando terminar."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Digite um nome para esta música."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Esta música não está mais na biblioteca. Pode ter sido renomeado ou excluído"
-" de outro dispositivo."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Uma música chamada '%s' já existe."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -330,16 +291,91 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Erro ao renomear arquivo: %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Músicas"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "Você não tem permissão para excluir músicas"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Erro: não é possível excluir esta música porque ela está na fila ou tocando"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Música removida: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Renomear música"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "Você não tem permissão para renomear músicas"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Esta música está tocando. Renomeie-o quando terminar."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Digite um nome para esta música."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Esta música não está mais na biblioteca. Pode ter sido renomeado ou excluído"
+" de outro dispositivo."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Uma música chamada '%s' já existe."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Música renomeada: %s para %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Tocando agora"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Configurações"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -355,80 +391,86 @@ msgstr "Você não tem permissão para alterar as preferências"
 msgid "You don't have permission to clear preferences"
 msgstr "Você não tem permissão para limpar as preferências"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Fila"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "Você não tem permissão para adicionar músicas aleatórias"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Adicionadas %s músicas aleatórias"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Acabaram as músicas!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Não autorizado"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Fila limpa!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Movido para o topo da fila"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Movido para o final da fila"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Movida para cima na fila"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Movida para baixo na fila"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Removida da fila"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Erro ao mover para o topo da fila"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Erro ao mover para o final da fila"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Erro ao mover para cima na fila"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Erro ao mover para baixo na fila"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Erro ao remover da fila"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Adicionar novo"
 
@@ -437,6 +479,29 @@ msgstr "Adicionar novo"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "Você não tem permissão para visualizar esta página"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Sessões"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "Histórico de jogos"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Classificações"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -472,8 +537,8 @@ msgstr "Jogado em"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Intérprete"
 
@@ -481,8 +546,8 @@ msgstr "Intérprete"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Canção"
 
@@ -576,24 +641,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Tem certeza de que deseja limpar TODA a fila? Digite ok para continuar"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Tem certeza de que deseja excluir {title} da fila?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Tem certeza que quer excluir esta música da biblioteca?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} semitons"
@@ -601,20 +657,20 @@ msgstr "{value} semitons"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Transponha esta música: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Tem certeza de que deseja reiniciar esta faixa?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -625,7 +681,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -635,13 +691,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Erro"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -652,49 +708,18 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Sessão atual: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Home"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Fila"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Classificações"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "Histórico de jogos"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Sessões"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Configurações"
-
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -703,7 +728,7 @@ msgstr ""
 "\tde acordo com a sua conexão com a internet."
 
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -712,12 +737,12 @@ msgstr ""
 "\tmúsicas"
 
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Mostrar somente músicas para renomear"
 
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -727,13 +752,13 @@ msgstr ""
 
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Mostrar todas as músicas"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Carregando músicas..."
 
@@ -750,117 +775,111 @@ msgid "No suggestion!"
 msgstr "Sem sugestões!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Renomear música"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Nome do arquivo atual"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Novo nome de arquivo"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Formatação automática"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Trocar Artista/Título"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Sugerir do iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "País de pesquisa do iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Salvar"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Apagar esta música"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Renomear em massa"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Disponível na biblioteca"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Todas as pastas"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Pesquise por título, artista..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Limpar"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Todas as músicas"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Pastas"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Classificar em ordem alfabética"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Classificar por data"
 
@@ -873,14 +892,14 @@ msgstr "Excluir esta entrada do registro de reprodução?"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Nada foi jogado ainda."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Jogado"
 
@@ -898,48 +917,48 @@ msgstr "Jogando"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Opções"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Mostrar todos os artistas"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Ocultar ignorado"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Status"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Adicionar à fila"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Esta música não está mais na biblioteca"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Excluir entrada"
 
@@ -968,47 +987,42 @@ msgstr ""
 "Tem certeza que quer pular esta música? Se não foi você que adicionou, peça "
 "permissão primeiro!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Tocando agora"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Próxima música"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Controles do Player"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Reiniciar Música"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Tocar/Pausar"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Parar música atual"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Mudar tom"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Alterar"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Microfones"
 
@@ -1046,7 +1060,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1059,7 +1073,7 @@ msgid "Scanning..."
 msgstr "Digitalizando..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -1085,183 +1099,186 @@ msgstr "Histórico de jogo apagado"
 msgid "Library sync complete"
 msgstr "Sincronização da biblioteca concluída"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Informação"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL do %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "QR code da URL para compartilhar com um amigo:"
 
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Administração"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Digite a senha de administrador"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Login"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Esqueceu? Reinicie o PiKaraoke com --admin-password para definir uma nova."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Biblioteca de músicas"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Biblioteca"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Músicas na biblioteca:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Sincronizar agora"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Reconcilia a biblioteca com o diretório de músicas em segundo plano."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Renomeando"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Artista - Título"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Título - Artista"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Ordem dos nomes das músicas sugeridas pelo iTunes"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Redefinir todo o histórico"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Exclui todas as sessões e todas as jogadas registradas. Isto não pode ser "
 "desfeito."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Preferências de usuário"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Configurações da tela de apresentação"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Desativar vídeo de fundo"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Desativar música de fundo"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Desativar tela de pontuaçãoa após cada música"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Ocultar notificações"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Mostrar relógio inicial"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Ocultar URL e QR code"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Ocultar o logotipo na tela inicial"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Oculte o nome da sessão na tela inicial"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr ""
 "Ocultar todas as sobreposições, incluindo 'tocando agora', 'a seguir' e QR "
 "code"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Volume padrão dos videos (min 0, max 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Volume da música de fundo (min 0, max 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1270,17 +1287,17 @@ msgstr ""
 "0 para desabilitar."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Tempo de espera em segundos antes de iniciar a próxima música"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Áudio"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1288,27 +1305,27 @@ msgstr ""
 "alto-falantes."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Latência"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Cancelamento de eco"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Experimental"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(reduz feedback, adiciona latência)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
@@ -1316,82 +1333,82 @@ msgstr ""
 "necessárias não estão instaladas."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "No Linux/Raspberry Pi, instale-o com:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "e reinicie o PiKaraoke."
 
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Frases das pontuações"
 
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "Adicione uma frase por linha em cada caixa e clique em salvar."
 
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Frases para notas BAIXAS (nota < 30)"
 
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Poderia ser melhor..."
 
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Frases para notas MÉDIAS (30 > nota < 30)"
 
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Foi legalzinho..."
 
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Frases para notas ALTAS (60 < score)"
 
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Maravilhoso..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Configurações de idioma"
 
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Idioma preferido (requer reinicialização)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Configurações do servidor"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Normalizar volume de audio"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Baixar videos em alta qualidade"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1401,7 +1418,7 @@ msgstr ""
 "será ignorado.*"
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1411,7 +1428,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1421,7 +1438,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1430,7 +1447,7 @@ msgstr ""
 "Músicas quando a biblioteca tiver subpastas)"
 
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1439,19 +1456,19 @@ msgstr ""
 "áudio | positivo = atrasa o áudio)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "Limite de músicas para cada usuário na fila (0 = ilimitado)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Habilitar fila justa (o modo round-robin garante que os usuários se revezem)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1462,13 +1479,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Músicas padrão por página."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1478,7 +1495,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1487,96 +1504,96 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Mantenha o servidor ativo: não é compatível com esta plataforma."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Mantenha o servidor ativo enquanto o PiKaraoke estiver em execução"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Limpar preferências"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Status do Sistema"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Informação do Sistema"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Plataforma:"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Versão do sistem:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "Versão do yt-dlp:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "Versão do FFmpeg"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Versão do Pikaraoke:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Status do Sistema"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "CPU:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Carregando..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Uso de disco:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Memória:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Atualizações"
 
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "Atualização do YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1591,13 +1608,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Atualizar yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1606,19 +1623,19 @@ msgstr ""
 "\t\t\t\t\t\t\tVerifique se há erros no log do pikaraoke."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Outros"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Expandir sistema de arquivos do Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1628,24 +1645,51 @@ msgstr ""
 "\t\t\t\t\t\t\tvocê pode querer expandir o sistema de arquivos para utilizar o espaço restante. Você só precisa fazer isso uma vez.\n"
 "\t\t\t\t\t\t\tIsto reiniciará o sistema."
 
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Clique aqui para sair do modo de administração."
+# auto-translated
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Altere a senha do administrador. Todos os outros dispositivos precisarão "
+"fazer login novamente."
 
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+# auto-translated
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Todos na rede são administradores. Defina uma senha para manter os controles"
+" do player, a edição de músicas e o desligamento para você."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Salvar senha"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Limpar senha"
+
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Log out"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Desligar"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1655,17 +1699,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Sair do Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Reiniciar sistema"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Desligar sistema"
 
@@ -1722,59 +1766,101 @@ msgid "Start a session to queue for singers"
 msgstr "Inicie uma sessão para fazer fila para cantores"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Downloads pendentes"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Preparando"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Baixando vídeo"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Baixando áudio"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Mesclando"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Concluído"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Tentando novamente"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Downloads pendentes"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "Na fila"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Erros de download"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Fracassado"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Tentar novamente"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Liberar"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "A fila está vazia"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Jogar"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Pausando"
 
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1784,60 +1870,60 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 40px\" /> músicas aleatórias"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Limpar todos"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Jogue a seguir"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Mover para o topo"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Subir"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Mover para baixo"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Mover para baixo"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Renomear"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Remover da fila"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Reiniciar"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Pular"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Fila de download"
 
@@ -1856,25 +1942,25 @@ msgstr "Classificação"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Peças"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Melhores músicas"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Melhores desempenhos"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Ninguém cantou ainda."
 
@@ -1887,7 +1973,7 @@ msgstr "Adicionando..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "Na biblioteca"
 
@@ -1895,49 +1981,49 @@ msgstr "Na biblioteca"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Adicione novas músicas do YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Pesquise no YouTube por título, artista..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Busca"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Adicionar resultados não-karaoke"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Avançado"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Cole um URL do YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Salvar para mais tarde"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1946,7 +2032,7 @@ msgstr "Procurando no YouTube por <small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1956,7 +2042,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2048,86 +2134,86 @@ msgstr "Mostre essas peças"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Sessão Atual"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Dê um nome a esta sessão..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Iniciar sessão"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Encerrar sessão"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "Histórico da sessão"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Ocultar inicialização automática"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Sessão"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Iniciado"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Tornar ativo"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Exportar CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Lista de exportação (texto)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Jogadas claras"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Excluir sessão"
 

--- a/pikaraoke/translations/ru_RU/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/ru_RU/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-11-09 03:26+0300\n"
 "Last-Translator: \n"
 "Language-Team: ru_RU <LL@li.org>\n"
@@ -32,39 +32,39 @@ msgstr "Транспозиция на  %s полутонов: %s"
 msgid "Volume: %s"
 msgstr "Громкость: %s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "Скачано и помещено в очередь (#%d): %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "Начинается загрузка: %s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "Загрузка видео: %s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "Ошибка при скачивании песни: "
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "Скачано и помещено в очередь: %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "Скачано: %s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "Ошибка помещения песни в очередь: "
 
@@ -104,19 +104,19 @@ msgstr "Возобновить: %s"
 msgid "Pause: %s"
 msgstr "Пауза: %s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "Ваши настройки были успешно изменены"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "Что-то пошло не так! Ваши настройки остались без изменений"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "Ваши настройки были успешно сброшены"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "Что-то пошло не так! Ваши настройки не были сброшены"
 
@@ -163,167 +163,125 @@ msgid "Failed to prepare stream"
 msgstr "Не удалось подготовить поток"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "Обновление yt-dlp! Это займет пару минут... "
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "У вас нет прав для обновления yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "Выйти из pikaraoke прямо сейчас!"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "У вас не хватает прапв для выхода"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "Останавливаем систему прямо сейчас!"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "У вас не хватает прав на выключение"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "Сейчас перезагрузим систему!"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "У вас не хватает прав на перезагрузку"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "А сейчас расширяем файловую систему и перезагружаем систему!"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "Невозможно расширить ФС на устройствах, отличных от raspberry pi!"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "У вас не хватает прав, чтобы изменить размер файловой системы"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "Права администратора получены!"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "Неверный пароль администратора!"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "У вас нет разрешения на изменение пароля администратора."
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr ""
+"Пароль администратора установлен. На других устройствах потребуется снова "
+"войти в систему."
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "Пароль администратора удален. Все снова администраторы."
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "Выход из режима администратора!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "Принять предложенное имя"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "Пакетное переименование песен"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "Ошибка: Не указан параметр имя файла!"
-
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
 msgstr ""
-"Ошибка: Нельзя отредактировать песню,  поскольку она стоит в текущей "
-"очереди: "
+"Ошибка: невозможно редактировать эту песню, поскольку она находится в "
+"очереди или воспроизводится: %s"
 
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "Ошибка переименования файла из '%s' в '%s', Такое имя файла уже есть"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "Песни"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "У вас недостаточно прав для удаления песен"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr ""
-"Ошибка: невозможно удалить эту песню, поскольку она находится в очереди или "
-"воспроизводится."
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "Песня удалена: %s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "У вас недостаточно прав для переименования песен."
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "Эта песня играет. Переименуйте его, когда он закончится."
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "Введите название этой песни."
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr ""
-"Этой песни больше нет в библиотеке. Возможно, он был переименован или удален"
-" с другого устройства."
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "Песня под названием «%s» уже существует."
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -333,16 +291,92 @@ msgstr ""
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "Ошибка переименования файла: %s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "Песни"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "У вас недостаточно прав для удаления песен"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr ""
+"Ошибка: невозможно удалить эту песню, поскольку она находится в очереди или "
+"воспроизводится."
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "Песня удалена: %s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "Переименовать песню"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "У вас недостаточно прав для переименования песен."
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "Эта песня играет. Переименуйте его, когда он закончится."
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "Введите название этой песни."
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr ""
+"Этой песни больше нет в библиотеке. Возможно, он был переименован или удален"
+" с другого устройства."
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "Песня под названием «%s» уже существует."
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "Файл переименован из  %s в %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "Сейчас играет"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "Настройки"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -358,80 +392,86 @@ msgstr "У вас не хватает прав, чтобы менять наст
 msgid "You don't have permission to clear preferences"
 msgstr "У вас нет прав на сброс настроек"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "Очередь"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "У вас недостаточно прав для добавления случайных песен."
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "Добавлено %s случайных треков"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "Вышли за пределы списка песен!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "Несанкционированный"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "Очередь очищена!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "Перемещено в начало очереди"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "Перемещено в конец очереди"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "Перемещено в начало очереди"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "Перемещено в конец очереди"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "Удалено из очереди"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "Ошибка перемещения в начало очереди."
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "Ошибка перемещения в конец очереди"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "Ошибка перемещения в начало очереди"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "Ошибка перемещения в конец очереди"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "Ошибка удаления из очереди"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "Добавить новый"
 
@@ -440,6 +480,29 @@ msgstr "Добавить новый"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "У вас нет разрешения на просмотр этой страницы"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "Сессии"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "История игр"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "Рейтинги"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -475,8 +538,8 @@ msgstr "Играл в"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "Исполнитель"
 
@@ -484,8 +547,8 @@ msgstr "Исполнитель"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "Песня"
 
@@ -579,24 +642,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr ""
 "Вы уверены, что хотите очистить ВСЮ очередь? Введите ОК, чтобы продолжить"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "Вы уверены, что хотите удалить {title} из очереди?"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "Вы уверены, что хотите удалить эту песню из библиотеки?"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} полутонов"
@@ -604,20 +658,20 @@ msgstr "{value} полутонов"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "Транспонировать эту песню: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "Вы уверены, что хотите перезапустить этот трек?"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -628,7 +682,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -638,13 +692,13 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "Ошибка"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -655,50 +709,19 @@ msgstr ""
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "Текущая сессия: {name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "Домой"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "Очередь"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "Рейтинги"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "История игр"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "Сессии"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "Настройки"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -708,7 +731,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -718,13 +741,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "Показать только песни для переименования"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -735,12 +758,12 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "Показать все песни"
 
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "Загрузка песен..."
 
@@ -758,117 +781,111 @@ msgid "No suggestion!"
 msgstr "Нет подходящих!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "Переименовать песню"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "Текущее имя файла"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "Новое имя файла"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "Автоматическое форматирование"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "Поменять исполнителя/название"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "Предложить из iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "Страна поиска iTunes"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "Сохранить"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "Отмена"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "Удалить эту песню"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "Массовое переименование"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "Доступно в библиотеке"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "Все папки"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "Поиск по названию, исполнителю..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "Очистить"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "Все песни"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "Папки"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "Сортировать по алфавиту"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "Сортировать по дате"
 
@@ -881,14 +898,14 @@ msgstr "Удалить эту запись из журнала воспроиз�
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "Еще ничего не сыграно."
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "Играл"
 
@@ -906,48 +923,48 @@ msgstr "Играя"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "Параметры"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "Показать всех исполнителей"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "Скрыть пропущенные"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "Статус"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "Добавить в очередь"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "Этой песни больше нет в библиотеке"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "Удалить запись"
 
@@ -976,47 +993,42 @@ msgstr ""
 "Вы точно хотите пропустить этот трек? Если это не вы добавили песню, "
 "предварительно будет запрошено разрешение на это!"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "Сейчас играет"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "Следующая песня"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "Управление плейером"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "Рестарт песни"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "Играть/пауза"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "Останов текущей песни"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "Поменять высоту"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "Поменять"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "Микрофоны"
 
@@ -1054,7 +1066,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr ""
@@ -1067,7 +1079,7 @@ msgid "Scanning..."
 msgstr "Сканирование..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -1093,182 +1105,185 @@ msgstr "История игр удалена"
 msgid "Library sync complete"
 msgstr "Синхронизация библиотеки завершена"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "Информация"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "УРЛ  %(site_title)s:"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "Простой УРЛ QR код чтобы поделиться с другими:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "Админ"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "Введите пароль администратора"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "Логин"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr ""
+"Забыли? Перезапустите PiKaraoke с --admin-password, чтобы установить новый."
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "Библиотека песен"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "Библиотека"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "Песни в библиотеке:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "Синхронизировать сейчас"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "Согласовывает библиотеку с каталогом песен в фоновом режиме."
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "Переименование"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "Художник - Название"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "Название - Художник"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "Порядок предложенных iTunes названий песен"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "Сбросить всю историю"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr ""
 "Удаляет каждую сессию и каждое воспроизведение в записи. Это невозможно "
 "отменить."
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "Пользовательские настройки"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "Установки заставки"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "Отключить фоновое видео"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "Отключить фоновую музыку"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "Отключить экран набранных балов после каждой песни"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "Скрыть уведомления"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "Показать часы-заставку"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "Скрыть УРЛ и QR код"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "Скрыть логотип на заставке"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "Скрыть имя сеанса на заставке"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "Скрыть все оверлеи, включая сейчас играет, следующая и QR код"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "Громкость видео по уморчанию (мин 0, макс 100)"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "Громкость фоновой музыки (мин 0, макс 100)"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1277,17 +1292,17 @@ msgstr ""
 "Поставьте 0, чтобы отключить его."
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "Задержка в секундах перед стартом следующей песни"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "Аудио"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr ""
@@ -1295,118 +1310,118 @@ msgstr ""
 "динамики."
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "Задержка"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "Эхоподавление"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "Экспериментальный"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(уменьшает обратную связь, увеличивает задержку)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
 "Поддержка микрофона недоступна. Необходимые аудиоинструменты не установлены."
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "В Linux/Raspberry Pi установите его с помощью:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "и перезапустите ПиКараоке."
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "Оценка фраз"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr ""
 "Добавьте по одной фразе в каждой строке в каждое поле и нажмите «Сохранить»."
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "Фразы с НИЗКИМ баллом (балл < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "Могло бы быть лучше..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "Фразы со средней оценкой (30 > оценка < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "Это было ок..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "Фразы с высоким баллом (60 <балл)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "Замечательно..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "Языковые настройки"
 
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "Выбор языка (требуется рестарт)"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "Настройки сервера"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "Нормализовать громкость звука"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "Скачивать видео высокого качества"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1416,7 +1431,7 @@ msgstr ""
 "проигнорирован.*"
 
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1426,7 +1441,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1436,7 +1451,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1445,7 +1460,7 @@ msgstr ""
 "«Песни», если в библиотеке есть подпапки)"
 
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1454,7 +1469,7 @@ msgstr ""
 "звук, положительное = вперед видео)"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr ""
 "Предел количества песен от одного пользователя, которые  можно добавить в "
@@ -1462,14 +1477,14 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "Включить честную очередь (циклический режим гарантирует, что пользователи "
 "работают по очереди)"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1480,13 +1495,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "Песни по умолчанию на странице."
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1495,7 +1510,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1504,97 +1519,97 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "Не позволяйте серверу спать: не поддерживается на этой платформе."
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "Не позволяйте серверу спать во время работы PiKaraoke"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "Сбросить настройки"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "Статистика системы"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "Информация о системе"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "Платформа:"
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "Версия ОС:"
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "Версия yt-dlp:"
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "Версия FFmpeg:"
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "Версия Pikaraoke:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "Статистика системы"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "ПРОЦЕССОР:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "Загрузка..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "Использование диска:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "Память:"
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "Обновление"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "Обновление YT-DLP"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1607,13 +1622,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "Обновить yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1622,19 +1637,19 @@ msgstr ""
 "    Смотрите ошибки в логах pikaraoke."
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "Иное"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "Раскрыть файловую систему Raspberry Pi"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1645,25 +1660,51 @@ msgstr ""
 "    Система будет перезагружена."
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "Нажмите здесь, чтобы выйти из режима администратора."
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"Измените пароль администратора. На всех остальных устройствах потребуется "
+"войти в систему снова."
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"Каждый в сети является администратором. Установите пароль, чтобы сохранить "
+"для себя управление плеером, редактирование песен и выключение."
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "Сохранить пароль"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "Очистить пароль"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "Выйти"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "Выключить"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1673,17 +1714,17 @@ msgstr ""
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "Выход из Pikaraoke"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "Перезагрузить систему"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "Выключить систему"
 
@@ -1740,59 +1781,101 @@ msgid "Start a session to queue for singers"
 msgstr "Начать сеанс, чтобы встать в очередь для певцов"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "Ожидающие загрузки"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "Подготовка"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "Загрузка видео"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "Загрузка аудио"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "Слияние"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "Завершено"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "Повторная попытка"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "Ожидающие загрузки"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "В очереди"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "Ошибки загрузки"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "Неуспешный"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "Повторить попытку"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "Увольнять"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "Очередь пуста"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "Играть"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "Пауза"
 
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1802,60 +1885,60 @@ msgstr ""
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
 "style=\"width: 40px\" /> случайных песни"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "Очистить все"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "Играть дальше"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "Перейти наверх"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "Двигаться вверх"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "Вниз"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "Переместиться вниз"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "Переименовать"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "Удалить из очереди"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "Перезапуск"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "Пропускать"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "Очередь загрузки"
 
@@ -1874,25 +1957,25 @@ msgstr "Классифицировать"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "Пьесы"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "Лучшие песни"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "Лучшие исполнители"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "Никто еще не пел."
 
@@ -1905,7 +1988,7 @@ msgstr "Добавление..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "В библиотеке"
 
@@ -1913,49 +1996,49 @@ msgstr "В библиотеке"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "Добавляйте новые песни с YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "Поиск на YouTube по названию, исполнителю..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "Поиск"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "Включить совпадения  не караоке"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "Продвинутое"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "Вставьте URL-адрес YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "Сохранить на потом"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1966,7 +2049,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1976,7 +2059,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2068,86 +2151,86 @@ msgstr "Показать эти пьесы"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "Текущая сессия"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "Назовите эту сессию..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "Начать сеанс"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "Завершить сеанс"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "История сеансов"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "Скрыть автозапуск"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "Сессия"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "Началось"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "Сделать активным"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "Экспортировать CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "Экспортировать список (текст)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "Четкие пьесы"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "Удалить сеанс"
 

--- a/pikaraoke/translations/th_TH/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/th_TH/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2025-01-14 10:20-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: th_TH <LL@li.org>\n"
@@ -35,45 +35,45 @@ msgid "Volume: %s"
 msgstr "ระดับเสียง: %s"
 
 # auto-translated
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "ดาวน์โหลดอยู่ในคิว (#%d): %s"
 
 # auto-translated
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "เริ่มดาวน์โหลด: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "กำลังดาวน์โหลดวิดีโอ: %s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "เกิดข้อผิดพลาดในการดาวน์โหลดเพลง:"
 
 # auto-translated
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "ดาวน์โหลดและเข้าคิวแล้ว: %s"
 
 # auto-translated
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "ดาวน์โหลดแล้ว: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "เกิดข้อผิดพลาดในการเข้าคิวเพลง:"
 
@@ -117,22 +117,22 @@ msgid "Pause: %s"
 msgstr "หยุดชั่วคราว: %s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "การเปลี่ยนแปลงการตั้งค่าของคุณสำเร็จแล้ว"
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "มีบางอย่างผิดพลาด! การตั้งค่าของคุณไม่เปลี่ยนแปลง"
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "การตั้งค่าของคุณถูกล้างเรียบร้อยแล้ว"
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "มีบางอย่างผิดพลาด! การตั้งค่าของคุณไม่ได้รับการล้าง"
 
@@ -185,164 +185,197 @@ msgstr "ไม่สามารถเตรียมสตรีมได้"
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "กำลังอัปเดต yt-dlp! ควรใช้เวลาหนึ่งหรือสองนาที..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "คุณไม่ได้รับอนุญาตให้อัปเดต yt-dlp"
 
 # auto-translated
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "ออกจากพิคาราโอเกะแล้ว!"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "คุณไม่ได้รับอนุญาตให้ออก"
 
 # auto-translated
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "ขณะนี้กำลังปิดระบบ!"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "คุณไม่ได้รับอนุญาตให้ปิดระบบ"
 
 # auto-translated
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "กำลังรีบูตระบบทันที!"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "คุณไม่ได้รับอนุญาตให้รีบูต"
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "กำลังขยายระบบไฟล์และระบบรีบูตทันที!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "ไม่สามารถขยาย fs บนอุปกรณ์ที่ไม่ใช่ Raspberry pi ได้!"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "คุณไม่ได้รับอนุญาตให้ปรับขนาดระบบไฟล์"
 
 # auto-translated
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "อนุญาตโหมดผู้ดูแลระบบแล้ว!"
 
 # auto-translated
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "รหัสผ่านผู้ดูแลระบบไม่ถูกต้อง!"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "คุณไม่ได้รับอนุญาตให้เปลี่ยนรหัสผ่านของผู้ดูแลระบบ"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "ตั้งรหัสผ่านผู้ดูแลระบบ อุปกรณ์อื่นๆ จะต้องเข้าสู่ระบบอีกครั้ง"
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "ล้างรหัสผ่านผู้ดูแลระบบแล้ว ทุกคนเป็นผู้ดูแลระบบอีกครั้ง"
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "ออกจากระบบโหมดผู้ดูแลระบบ!"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "ยอมรับชื่อที่แนะนำ"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "การเปลี่ยนชื่อเพลงเป็นชุด"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "ข้อผิดพลาด: ไม่ได้ระบุพารามิเตอร์ชื่อไฟล์!"
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr ""
+"ข้อผิดพลาด: ไม่สามารถแก้ไขเพลงนี้ได้เนื่องจากอยู่ในคิวหรือเล่นอยู่: %s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "ข้อผิดพลาด: ไม่สามารถแก้ไขเพลงนี้ได้เนื่องจากอยู่ในคิวปัจจุบัน:"
-
-# auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "เกิดข้อผิดพลาดในการเปลี่ยนชื่อไฟล์: '%s' เป็น '%s' มีชื่อไฟล์อยู่แล้ว"
 
 # auto-translated
+#: routes/batch_song_renamer.py:260 routes/files.py:316
+msgid ""
+"This song started playing while you were editing it. Rename it when it "
+"finishes."
+msgstr "เพลงนี้เริ่มเล่นในขณะที่คุณกำลังตัดต่อ เปลี่ยนชื่อเมื่อเสร็จสิ้น"
+
+# auto-translated
+#. Message shown after a rename failed. Followed by the system error.
+#: routes/batch_song_renamer.py:265 routes/files.py:322
+#, python-format
+msgid "Error renaming file: %s"
+msgstr "เกิดข้อผิดพลาดในการเปลี่ยนชื่อไฟล์: %s"
+
+# auto-translated
 #. Title of the page listing the songs already on this machine.
 #. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
 msgid "Songs"
 msgstr "เพลง"
 
 # auto-translated
-#: routes/files.py:216
+#: routes/files.py:217
 msgid "You don't have permission to delete songs"
 msgstr "คุณไม่ได้รับอนุญาตให้ลบเพลง"
 
 # auto-translated
 #. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
+#: routes/files.py:222
 msgid "Error: Can't delete this song because it is queued or playing"
 msgstr "ข้อผิดพลาด: ไม่สามารถลบเพลงนี้ได้เนื่องจากอยู่ในคิวหรือเล่นอยู่"
 
 # auto-translated
-#: routes/files.py:228
+#: routes/files.py:229
 #, python-format
 msgid "Song deleted: %s"
 msgstr "เพลงที่ถูกลบ: %s"
 
 # auto-translated
-#: routes/files.py:260 routes/files.py:283
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "เปลี่ยนชื่อเพลง"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
 msgid "You don't have permission to rename songs"
 msgstr "คุณไม่ได้รับอนุญาตให้เปลี่ยนชื่อเพลง"
 
 # auto-translated
 #. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
+#: routes/files.py:266
 msgid "This song is playing. Rename it when it finishes."
 msgstr "เพลงนี้กำลังเล่นอยู่ เปลี่ยนชื่อเมื่อเสร็จสิ้น"
 
 # auto-translated
 #. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
+#: routes/files.py:290
 msgid "Enter a name for this song."
 msgstr "ป้อนชื่อเพลงนี้"
 
 # auto-translated
-#: routes/files.py:294
+#: routes/files.py:296
 msgid ""
 "This song is no longer in the library. It may have been renamed or deleted "
 "from another device."
@@ -351,31 +384,30 @@ msgstr ""
 
 # auto-translated
 #. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
+#: routes/files.py:308
 #, python-format
 msgid "A song called '%s' already exists."
 msgstr "มีเพลงชื่อ '%s' อยู่แล้ว"
 
 # auto-translated
-#: routes/files.py:314
-msgid ""
-"This song started playing while you were editing it. Rename it when it "
-"finishes."
-msgstr "เพลงนี้เริ่มเล่นในขณะที่คุณกำลังตัดต่อ เปลี่ยนชื่อเมื่อเสร็จสิ้น"
-
-# auto-translated
-#. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
-#, python-format
-msgid "Error renaming file: %s"
-msgstr "เกิดข้อผิดพลาดในการเปลี่ยนชื่อไฟล์: %s"
-
-# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "เปลี่ยนชื่อไฟล์: %s เป็น %s"
+
+# auto-translated
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "กำลังเล่นอยู่"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "การตั้งค่า"
 
 # auto-translated
 #: routes/info.py:116
@@ -395,88 +427,95 @@ msgid "You don't have permission to clear preferences"
 msgstr "คุณไม่ได้รับอนุญาตให้ล้างค่ากำหนด"
 
 # auto-translated
-#: routes/queue.py:80
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "คิว"
+
+# auto-translated
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "คุณไม่ได้รับอนุญาตให้เพิ่มเพลงแบบสุ่ม"
 
 # auto-translated
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "เพิ่ม %s แทร็กแบบสุ่ม"
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "เพลงหมด!"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "ไม่ได้รับอนุญาต"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "เคลียร์คิว!"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "ย้ายไปอยู่ด้านบนของคิว"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "ย้ายไปอยู่ด้านล่างสุดของคิว"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "ขยับขึ้นไปตามคิว."
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "เลื่อนลงมาตามคิว."
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "ลบออกจากคิวแล้ว"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "เกิดข้อผิดพลาดในการย้ายไปอยู่ด้านบนสุดของคิว"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "เกิดข้อผิดพลาดในการย้ายไปที่ด้านล่างของคิว"
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "เกิดข้อผิดพลาดในการเลื่อนขึ้นในคิว"
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "เกิดข้อผิดพลาดในการย้ายลงในคิว"
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "เกิดข้อผิดพลาดในการลบออกจากคิว"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "เพิ่มใหม่"
 
@@ -485,6 +524,29 @@ msgstr "เพิ่มใหม่"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "คุณไม่ได้รับอนุญาตให้ดูหน้านี้"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "เซสชัน"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "ประวัติการเล่น"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "อันดับ"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -520,8 +582,8 @@ msgstr "เล่นที่"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "นักแสดง"
 
@@ -529,8 +591,8 @@ msgstr "นักแสดง"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "เพลง"
 
@@ -638,24 +700,15 @@ msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการล้างคิวทั้งหมด พิมพ์ตกลงเพื่อดำเนินการต่อ"
 
 # auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบ {title} ออกจากคิว"
-
-# auto-translated
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบเพลงนี้ออกจากห้องสมุด"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} ครึ่งเสียง"
@@ -663,20 +716,20 @@ msgstr "{value} ครึ่งเสียง"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "ย้ายเพลงนี้: {label}?"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการรีสตาร์ทแทร็กนี้"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -688,7 +741,7 @@ msgstr ""
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -697,14 +750,14 @@ msgstr ""
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "ข้อผิดพลาด"
 
 # auto-translated
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -713,52 +766,20 @@ msgstr "กรุณากรอกชื่อของคุณ ซึ่ง�
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "เซสชันปัจจุบัน: {name}"
 
 # auto-translated
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "บ้าน"
 
 # auto-translated
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "คิว"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "อันดับ"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "ประวัติการเล่น"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "เซสชัน"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "การตั้งค่า"
-
-# auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -768,7 +789,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -778,13 +799,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "แสดงเฉพาะเพลงที่จะเปลี่ยนชื่อ"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -795,13 +816,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "แสดงเพลงทั้งหมด"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "กำลังโหลดเพลง..."
 
@@ -819,120 +840,114 @@ msgid "No suggestion!"
 msgstr "ไม่มีข้อเสนอแนะ!"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "เปลี่ยนชื่อเพลง"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "ชื่อไฟล์ปัจจุบัน"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "ชื่อไฟล์ใหม่"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "จัดรูปแบบอัตโนมัติ"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "สลับศิลปิน/ชื่อเรื่อง"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "แนะนำจาก iTunes"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "ประเทศค้นหา iTunes"
 
 # auto-translated
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "บันทึก"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "ยกเลิก"
 
 # auto-translated
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "ลบเพลงนี้"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "เปลี่ยนชื่อเป็นกลุ่ม"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "มีจำหน่ายแล้วในห้องสมุด"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "โฟลเดอร์ทั้งหมด"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "ค้นหาตามชื่อศิลปิน..."
 
 # auto-translated
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "ชัดเจน"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "ทุกเพลง"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "โฟลเดอร์"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "จัดเรียงตามตัวอักษร"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "เรียงตามวันที่"
 
@@ -945,14 +960,14 @@ msgstr "ลบรายการนี้ออกจากบันทึกก
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "ยังไม่ได้เล่นอะไรเลย"
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "เล่นแล้ว"
 
@@ -970,26 +985,26 @@ msgstr "กำลังเล่น"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "ตัวเลือก"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "แสดงนักแสดงทั้งหมด"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "ซ่อนข้ามไป"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "สถานะ"
 
@@ -997,22 +1012,22 @@ msgstr "สถานะ"
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "เพิ่มเข้าคิว"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "เพลงนี้ไม่ได้อยู่ในห้องสมุดอีกต่อไป"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "ลบรายการ"
 
@@ -1045,54 +1060,48 @@ msgstr ""
 "คุณแน่ใจหรือไม่ว่าต้องการข้ามแทร็กนี้ ใครไม่ได้แอดเพลงนี้ต้องขออนุญาตก่อน!"
 
 # auto-translated
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "กำลังเล่นอยู่"
-
-# auto-translated
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "เพลงถัดไป"
 
 # auto-translated
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "การควบคุมผู้เล่น"
 
 # auto-translated
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "รีสตาร์ทเพลง"
 
 # auto-translated
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "เล่น/หยุดชั่วคราว"
 
 # auto-translated
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "หยุดเพลงปัจจุบัน"
 
 # auto-translated
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "เปลี่ยนคีย์"
 
 # auto-translated
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "เปลี่ยน"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "ไมโครโฟน"
 
@@ -1135,7 +1144,7 @@ msgstr ""
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr "ไม่พบไมโครโฟน เชื่อมต่อไมโครโฟน USB หรือบลูทูธ แล้วคลิกรีเฟรช"
@@ -1146,7 +1155,7 @@ msgid "Scanning..."
 msgstr "กำลังสแกน..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "รีเฟรช"
 
@@ -1173,14 +1182,8 @@ msgid "Library sync complete"
 msgstr "การซิงค์ไลบรารีเสร็จสมบูรณ์"
 
 # auto-translated
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "ข้อมูล"
-
-# auto-translated
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "URL ของ %(site_title)s:"
@@ -1188,179 +1191,186 @@ msgstr "URL ของ %(site_title)s:"
 # auto-translated
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "รหัส QR URL ที่มีประโยชน์เพื่อแบ่งปันกับเพื่อน:"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "ผู้ดูแลระบบ"
 
 # auto-translated
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "ป้อนรหัสผ่านผู้ดูแลระบบ"
 
 # auto-translated
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "เข้าสู่ระบบ"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr "ลืมมันเหรอ? รีสตาร์ท PiKaraoke ด้วย --admin-password เพื่อตั้งค่าใหม่"
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "ห้องสมุดเพลง"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "ห้องสมุด"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "เพลงในห้องสมุด:"
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "ซิงค์ทันที"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "กระทบยอดไลบรารีกับไดเร็กทอรีเพลงในเบื้องหลัง"
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "กำลังเปลี่ยนชื่อ"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "ศิลปิน - ชื่อเรื่อง"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "หัวเรื่อง - ศิลปิน"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "ลำดับของ iTunes แนะนำชื่อเพลง"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "รีเซ็ตประวัติทั้งหมด"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr "ลบทุกเซสชันและทุกการเล่นที่บันทึกไว้ สิ่งนี้ไม่สามารถยกเลิกได้"
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "การตั้งค่าผู้ใช้"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "การตั้งค่าหน้าจอสแปลช"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "ปิดการใช้งานวิดีโอพื้นหลัง"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "ปิดการใช้งานเพลงพื้นหลัง"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "ปิดการใช้งานหน้าจอคะแนนหลังจากแต่ละเพลง"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "ซ่อนการแจ้งเตือน"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "แสดงนาฬิกาสาด"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "ซ่อน URL และโค้ด QR"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "ซ่อนโลโก้บนหน้าจอสแปลช"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "ซ่อนชื่อเซสชันบนหน้าจอเริ่มต้น"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "ซ่อนโอเวอร์เลย์ทั้งหมด รวมถึงกำลังเล่น ถัดไป และโค้ด QR"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "ระดับเสียงเริ่มต้นของวิดีโอ (ขั้นต่ำ 0, สูงสุด 100)"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "ระดับเสียงเพลงประกอบ (ต่ำสุด 0, สูงสุด 100)"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1370,139 +1380,139 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "ดีเลย์เป็นวินาทีก่อนเริ่มเพลงถัดไป"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "เสียง"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "ตรวจพบไมโครโฟนบนเซิร์ฟเวอร์ เสียงจะถูกส่งไปยังลำโพงโดยตรง"
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "เวลาแฝง"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "การยกเลิกเสียงสะท้อน"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "การทดลอง"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "(ลดการตอบสนอง เพิ่มเวลาแฝง)"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr ""
 "การสนับสนุนไมโครโฟนไม่พร้อมใช้งาน ไม่ได้ติดตั้งเครื่องมือเสียงที่จำเป็น"
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "บน Linux / Raspberry Pi ให้ติดตั้งด้วย:"
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "และรีสตาร์ท PiKaraoke"
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "คะแนนวลี"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "เพิ่มหนึ่งวลีต่อบรรทัดในแต่ละช่องแล้วกดบันทึก"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "วลีคะแนนต่ำ (คะแนน < 30)"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "อาจจะดีกว่านี้..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "วลีคะแนน MID (30 > คะแนน < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "นั่นก็โอเค..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "วลีคะแนนสูง (60 < คะแนน)"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "มหัศจรรย์..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "การตั้งค่าภาษา"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "ภาษาที่ต้องการ (ต้องรีสตาร์ท)"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "การตั้งค่าเซิร์ฟเวอร์"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "ปรับระดับเสียงให้เป็นปกติ"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "ดาวน์โหลดวิดีโอคุณภาพสูง"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1512,7 +1522,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1522,7 +1532,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1532,7 +1542,7 @@ msgstr ""
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1542,7 +1552,7 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1552,20 +1562,20 @@ msgstr ""
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "ขีดจำกัดของเพลงที่ผู้ใช้แต่ละรายสามารถเพิ่มลงในคิวได้ (0 = ไม่จำกัด)"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr ""
 "เปิดใช้งานคิวที่ยุติธรรม (โหมด Round-Robin ช่วยให้มั่นใจว่าผู้ใช้ผลัดกัน)"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1576,13 +1586,13 @@ msgstr ""
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "เพลงเริ่มต้นต่อหน้า"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1592,7 +1602,7 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr ""
@@ -1600,108 +1610,108 @@ msgstr ""
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "ทำให้เซิร์ฟเวอร์ตื่นอยู่เสมอ: ไม่รองรับบนแพลตฟอร์มนี้"
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "ให้เซิร์ฟเวอร์ตื่นตัวในขณะที่ PiKaraoke กำลังทำงานอยู่"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "ล้างค่ากำหนด"
 
 # auto-translated
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "ข้อมูลระบบ"
 
 # auto-translated
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "ข้อมูลระบบ"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "แพลตฟอร์ม:"
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "เวอร์ชันระบบปฏิบัติการ:"
 
 # auto-translated
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "เวอร์ชัน yt-dlp:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "เวอร์ชัน FFmpeg:"
 
 # auto-translated
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "เวอร์ชั่นปิคาราโอเกะ:"
 
 # auto-translated
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "สถิติของระบบ"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "ซีพียู:"
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "กำลังโหลด..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "การใช้ดิสก์:"
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "หน่วยความจำ:"
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "อัพเดท"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "อัปเดต YT-DLP"
 
 # auto-translated
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1715,14 +1725,14 @@ msgstr ""
 # auto-translated
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "อัพเดต yt-dlp"
 
 # auto-translated
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1732,21 +1742,21 @@ msgstr ""
 
 # auto-translated
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "อื่น"
 
 # auto-translated
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "ขยายระบบไฟล์ Raspberry Pi"
 
 # auto-translated
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1757,27 +1767,52 @@ msgstr ""
 "\t\t\t\t\t\t\tนี่จะเป็นการรีบูตระบบ"
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "คลิกที่นี่เพื่อออกจากระบบโหมดผู้ดูแลระบบ"
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr ""
+"เปลี่ยนรหัสผ่านผู้ดูแลระบบ อุปกรณ์อื่นๆ ทุกเครื่องจะต้องเข้าสู่ระบบอีกครั้ง"
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr ""
+"ทุกคนในเครือข่ายเป็นผู้ดูแลระบบ ตั้งรหัสผ่านเพื่อควบคุมโปรแกรมเล่น แก้ไขเพลง"
+" และปิดระบบให้กับตัวคุณเอง"
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "บันทึกรหัสผ่าน"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "ล้างรหัสผ่าน"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "ออกจากระบบ"
 
 # auto-translated
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "ปิดเครื่อง"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1788,19 +1823,19 @@ msgstr ""
 # auto-translated
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "เลิกปิ๊กคาราโอเกะ"
 
 # auto-translated
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "รีบูตระบบ"
 
 # auto-translated
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "ระบบปิดเครื่อง"
 
@@ -1857,62 +1892,104 @@ msgid "Start a session to queue for singers"
 msgstr "เริ่มเซสชั่นเพื่อเข้าคิวนักร้อง"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "รอการดาวน์โหลด"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "กำลังเตรียมตัว"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "กำลังดาวน์โหลดวิดีโอ"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "กำลังดาวน์โหลดเสียง"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "การผสาน"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "เสร็จสิ้น"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "กำลังลองอีกครั้ง"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "รอการดาวน์โหลด"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "เข้าคิว"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "ดาวน์โหลดข้อผิดพลาด"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "ล้มเหลว"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "ลองอีกครั้ง"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "อนุญาตให้ออกไป"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "ลากเพื่อเรียงลำดับใหม่"
 
 # auto-translated
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "คิวว่างแล้ว"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "เล่น"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "หยุดชั่วคราว"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1923,60 +2000,60 @@ msgstr ""
 "style=\"width: 42px\" /> เพลงสุ่ม"
 
 # auto-translated
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "เคลียร์ทั้งหมด"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "เล่นถัดไป"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "ย้ายไปด้านบน"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "เลื่อนขึ้น"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "เลื่อนลง"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "ย้ายไปด้านล่าง"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "เปลี่ยนชื่อ"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "ลบออกจากคิว"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "รีสตาร์ท"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "ข้าม"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "คิวดาวน์โหลด"
 
@@ -1995,25 +2072,25 @@ msgstr "อันดับ"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "เล่น"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "เพลงยอดนิยม"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "นักแสดงชั้นนำ"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "ยังไม่มีใครร้องเลย"
 
@@ -2026,7 +2103,7 @@ msgstr "กำลังเพิ่ม..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "ในห้องสมุด"
 
@@ -2034,19 +2111,19 @@ msgstr "ในห้องสมุด"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "เพิ่มเพลงใหม่จาก YouTube"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "ค้นหา YouTube ตามชื่อศิลปิน..."
 
 # auto-translated
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "ค้นหา"
 
@@ -2054,33 +2131,33 @@ msgstr "ค้นหา"
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "รวมการแข่งขันที่ไม่ใช่คาราโอเกะ"
 
 # auto-translated
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "ขั้นสูง"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "วาง URL ของ YouTube:"
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "เก็บไว้ดูทีหลัง"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -2091,7 +2168,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2101,7 +2178,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2192,86 +2269,86 @@ msgstr "แสดงละครเหล่านี้"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "เซสชันปัจจุบัน"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "ตั้งชื่อเซสชันนี้..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "เริ่มเซสชัน"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "สิ้นสุดเซสชัน"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "ประวัติเซสชัน"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "ซ่อนการเริ่มต้นอัตโนมัติ"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "การประชุม"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "เริ่ม"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "ทำให้มีความกระตือรือร้น"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "ส่งออก CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "รายการส่งออก (ข้อความ)"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "ละครชัดๆ"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "ลบเซสชัน"
 

--- a/pikaraoke/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2022-04-28 10:09-0400\n"
 "Last-Translator: \n"
 "Language-Team: zh_Hans_CN <LL@li.org>\n"
@@ -34,42 +34,42 @@ msgstr "移调 %s 个半音：%s"
 msgid "Volume: %s"
 msgstr "音量：%s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "成功添加歌曲 (#%d)： %s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "下载: %s"
 
 # auto-translated
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "正在下载视频：%s"
 
 # auto-translated
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "下载歌曲时出错："
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "成功添加歌曲： %s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "下载: %s"
 
 # auto-translated
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "歌曲排队错误："
 
@@ -113,22 +113,22 @@ msgid "Pause: %s"
 msgstr "暂停：%s"
 
 # auto-translated
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "您的偏好设置已成功更改"
 
 # auto-translated
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "出了问题！您的偏好没有改变"
 
 # auto-translated
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "您的偏好设置已成功清除"
 
 # auto-translated
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "出了问题！您的偏好未清除"
 
@@ -178,173 +178,130 @@ msgstr "准备流失败"
 
 # auto-translated
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "正在更新 yt-dlp！应该需要一两分钟..."
 
 # auto-translated
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "您无权更新 yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "退出卡拉OK派"
 
 # auto-translated
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "您无权退出"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "关机"
 
 # auto-translated
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "您无权关闭"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "重启系统"
 
 # auto-translated
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "您没有重新启动的权限"
 
 # auto-translated
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "立即扩展文件系统并重新启动系统！"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "无法在非树莓派设备上扩展文件系统！"
 
 # auto-translated
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "您无权调整文件系统大小"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "管理员模式开启"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "管理员密码错误"
 
 # auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "您无权更改管理员密码"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "管理员密码设置。其他设备需要重新登录。"
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "管理员密码已清除。每个人又都是管理员了。"
+
+# auto-translated
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "已退出管理模式！"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "接受建议的名称"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "批量歌曲重命名器"
 
 # auto-translated
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "错误：未指定文件名参数！"
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr "错误：无法编辑这首歌曲，因为它正在排队或正在播放：%s"
 
 # auto-translated
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "错误：无法编辑这首歌曲，因为它位于当前队列中："
-
-# auto-translated
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "将文件 '%s' 重命名为 '%s' 时出错，文件名已存在"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "歌曲"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "您无权删除歌曲"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr "错误：无法删除这首歌曲，因为它正在排队或正在播放"
-
-# auto-translated
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "已删除歌曲：%s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "您无权重命名歌曲"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "正在播放这首歌。完成后重命名。"
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "输入这首歌的名称。"
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr "这首歌已经不在图书馆里了。它可能已被重命名或从其他设备中删除。"
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "一首名为“%s”的歌曲已经存在。"
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -352,17 +309,90 @@ msgstr "这首歌在您编辑时开始播放。完成后重命名。"
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "重命名文件时出错：%s"
 
 # auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "歌曲"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "您无权删除歌曲"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "错误：无法删除这首歌曲，因为它正在排队或正在播放"
+
+# auto-translated
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "已删除歌曲：%s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "重命名歌曲"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "您无权重命名歌曲"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "正在播放这首歌。完成后重命名。"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "输入这首歌的名称。"
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "这首歌已经不在图书馆里了。它可能已被重命名或从其他设备中删除。"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "一首名为“%s”的歌曲已经存在。"
+
+# auto-translated
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "已重命名文件：%s 为 %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "正在播放曲目"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "设置"
 
 # auto-translated
 #: routes/info.py:116
@@ -381,88 +411,94 @@ msgstr "您无权更改偏好设置"
 msgid "You don't have permission to clear preferences"
 msgstr "您无权清除偏好设置"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "列表"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "您无权添加随机歌曲"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "添加随机%s首歌"
 
 # auto-translated
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "歌曲没了！"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "未经授权"
 
 # auto-translated
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "清空队列！"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "移至队列顶部"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "移至队列底部"
 
 # auto-translated
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "在队列中移动"
 
 # auto-translated
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "在队列中向下移动"
 
 # auto-translated
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "已从队列中删除"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "移至队列顶部时出错"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "移至队列底部时出错"
 
 # auto-translated
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "在队列中向上移动时出错"
 
 # auto-translated
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "在队列中向下移动时出错"
 
 # auto-translated
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "从队列中删除时出错"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "添加新内容"
 
@@ -471,6 +507,29 @@ msgstr "添加新内容"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "您没有权限查看此页面"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "会议"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "播放历史"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "排行榜"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -506,8 +565,8 @@ msgstr "玩过"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "演员"
 
@@ -515,8 +574,8 @@ msgstr "演员"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "歌曲"
 
@@ -621,24 +680,15 @@ msgstr "您想更改使用此设备的人的姓名吗？这将显示在排队的
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "您确定要清除整个队列吗？输入“确定”继续"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "您确定要从队列中删除 {title} 吗？"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "确认即将把此歌曲从音乐库里删除？"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 半音"
@@ -646,20 +696,20 @@ msgstr "{value} 半音"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "转置这首歌：{label}？"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "您确定要重新开始该曲目吗？"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -668,7 +718,7 @@ msgstr "半音也称为半音。它是西方古典音乐中使用的最小音程
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -676,13 +726,13 @@ msgstr "您确定要扩展文件系统吗？这将重新启动您的树莓派。
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "错误"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -691,50 +741,19 @@ msgstr "演唱者（我）的名字是："
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "当前会话：{name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "主页"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "列表"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "排行榜"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "播放历史"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "会议"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "设置"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -744,7 +763,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -754,13 +773,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "仅显示要重命名的歌曲"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -771,13 +790,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "显示所有歌曲"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "正在加载歌曲..."
 
@@ -794,117 +813,111 @@ msgid "No suggestion!"
 msgstr "没有搜索建议！"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "重命名歌曲"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "当前文件名"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "新文件名"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "自动格式化"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "交换艺术家/标题"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "来自 iTunes 的建议"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes 搜索国家/地区"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "保存"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "取消"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "删除此曲"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "批量重命名"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "在图书馆可以找到"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "所有文件夹"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "按标题、艺术家搜索..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "清除所有"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "所有歌曲"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "文件夹"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "按字母顺序排序"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "按日期排序"
 
@@ -917,14 +930,14 @@ msgstr "从播放日志中删除此条目吗？"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "还没有播放任何内容。"
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "玩过"
 
@@ -942,48 +955,48 @@ msgstr "演奏"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "选项"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "显示所有表演者"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "隐藏跳过的"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "地位"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "添加至播放列表"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "这首歌已经不在库里了"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "删除条目"
 
@@ -1010,47 +1023,42 @@ msgid ""
 "permission first!"
 msgstr "你确定要跳过这首歌？"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "正在播放曲目"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "下一首歌"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "播放器"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "重新开始"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "播放/暂停"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "停止并跳到下一首歌"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "升降调"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "确认更改声调"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "麦克风"
 
@@ -1087,7 +1095,7 @@ msgstr "确定升级yt-dlp？会终止正在下载的音乐"
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr "未检测到麦克风。连接 USB 或蓝牙麦克风，然后单击“刷新”。"
@@ -1098,7 +1106,7 @@ msgid "Scanning..."
 msgstr "扫描..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "刷新"
 
@@ -1122,190 +1130,192 @@ msgstr "播放历史记录已删除"
 msgid "Library sync complete"
 msgstr "库同步完成"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "信息"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s 的网址"
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "快捷QR码（用于分享给朋友）"
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "行政"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "输入管理员密码"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "登录"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr "忘记了？使用 --admin-password 重新启动 PiKaraoke 以设置新密码。"
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "歌库"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "图书馆"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "库里的歌曲："
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "立即同步"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "在后台协调库与歌曲目录。"
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "重命名"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "艺术家 - 头衔"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "头衔 - 艺术家"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "iTunes 建议歌曲名称的顺序"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "重置所有历史记录"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr "删除记录中的每个会话和每个播放。此操作无法撤消。"
 
 # auto-translated
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "用户偏好"
 
 # auto-translated
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "启动画面设置"
 
 # auto-translated
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "禁用背景视频"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "禁用背景音乐"
 
 # auto-translated
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "每首歌曲后禁用乐谱屏幕"
 
 # auto-translated
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "隐藏通知"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "显示启动时钟"
 
 # auto-translated
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "隐藏网址和二维码"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "隐藏启动屏幕上的徽标"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "在启动屏幕上隐藏会话名称"
 
 # auto-translated
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "隐藏所有叠加层，包括正在播放、下一个和二维码"
 
 # auto-translated
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "视频的默认音量（最小 0，最大 100）"
 
 # auto-translated
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "背景音乐音量（最小 0，最大 100）"
 
 # auto-translated
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
@@ -1313,138 +1323,138 @@ msgstr "屏幕保护程序激活之前的空闲时间（以秒为单位）。设
 
 # auto-translated
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "开始下一首歌曲之前的延迟（以秒为单位）"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "声音的"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "在服务器上检测到麦克风。音频直接传送至扬声器。"
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "延迟"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "回声消除"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "实验性的"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "（减少反馈，增加延迟）"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr "麦克风支持不可用。未安装所需的音频工具。"
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "在 Linux / Raspberry Pi 上，安装它："
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "并重新启动 PiKaraoke。"
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "给短语评分"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "在每个框中每行添加一个短语，然后点击“保存”。"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "低分短语（分数 < 30）"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "可能会更好..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID 得分短语 (30 > 得分 < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "那就可以了..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "高分短语（60 < 分数）"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "精彩..."
 
 # auto-translated
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "语言设置"
 
 # auto-translated
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "首选语言（需要重新启动）"
 
 # auto-translated
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "服务器设置"
 
 # auto-translated
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "标准化音量"
 
 # auto-translated
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "下载高质量视频"
 
 # auto-translated
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1452,7 +1462,7 @@ msgstr "在播放前对视频进行完全转码（浏览器兼容性更好，启
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1460,7 +1470,7 @@ msgstr "启用 CDG 像素缩放（CDG 文件的视觉效果更清晰，可能会
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1468,7 +1478,7 @@ msgstr "启用自动 YouTube 标题清​​理（删除“卡拉 OK 版本高�
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1476,7 +1486,7 @@ msgstr "启用文件夹浏览（当库有子文件夹时，将文件夹视图添
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
@@ -1484,19 +1494,19 @@ msgstr "在几秒钟内修复音频和视频同步（负=提前音频|正=延迟
 
 # auto-translated
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "单个用户可以添加到队列中的歌曲数量限制（0 = 无限制）"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "启用公平队列（循环模式确保用户轮流）"
 
 # auto-translated
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1505,13 +1515,13 @@ msgstr "缓冲区大小（以千字节为单位）。在将视频发送到启动
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "每页默认歌曲。"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1519,108 +1529,108 @@ msgstr "保持服务器唤醒：在容器中不可用。禁用主机上的睡眠
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr "保持服务器唤醒：需要 systemd-inhibit (Linux) 或 caffeinate (macOS)。"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "保持服务器唤醒：此平台不支持。"
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "PiKaraoke 运行时保持服务器处于唤醒状态"
 
 # auto-translated
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "明确的偏好"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "系统信息"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "系统信息"
 
 # auto-translated
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "平台："
 
 # auto-translated
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "操作系统版本："
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp 版本:"
 
 # auto-translated
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg 版本："
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "卡拉OK派 版本:"
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "系统信息"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "中央处理器："
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "加载中..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "磁盘使用情况："
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "记忆："
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "更新"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP 更新"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1633,13 +1643,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "更新 yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1648,19 +1658,19 @@ msgstr ""
 "    查看卡拉OK派的错误日志以检查错误"
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "其他"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "拓展Raspberry Pi文件系统"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1671,26 +1681,48 @@ msgstr ""
 "    这会让你的电脑系统重启"
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "单击此处从管理模式注销。"
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr "更改管理员密码。所有其他设备都需要重新登录。"
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr "网络上的每个人都是管理员。设置密码，让您自己控制播放器、编辑歌曲和关机。"
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "保存密码"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "清除密码"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "退出"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "关闭"
 
 # auto-translated
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1698,17 +1730,17 @@ msgstr "不要只是拔掉插头！始终正确关闭服务器以避免数据损
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "退出卡拉OK派"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "重启系统"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "关机"
 
@@ -1765,61 +1797,103 @@ msgid "Start a session to queue for singers"
 msgstr "开始一个会话来排队等待歌手"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "待下载"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "准备中"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "下载视频"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "下载音频"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "合并"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "已完成"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "重试"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "待下载"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "排队"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "下载错误"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "失败的"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "重试"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "解雇"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "拖动以重新排序"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "播放列表是空的"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "玩"
 
 # auto-translated
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "暂停"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1829,60 +1903,60 @@ msgstr ""
 " maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" /> "
 "随机歌曲"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "清除所有"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "播放下一个"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "移至顶部"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "向上移动"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "下移"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "移至底部"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "重命名"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "从队列中删除"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "重新启动"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "跳过"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "下载队列"
 
@@ -1901,25 +1975,25 @@ msgstr "秩"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "戏剧"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "热门歌曲"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "表现最佳者"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "还没有人唱歌。"
 
@@ -1932,7 +2006,7 @@ msgstr "添加..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "在图书馆"
 
@@ -1940,49 +2014,49 @@ msgstr "在图书馆"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "添加来自 YouTube 的新歌曲"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "按标题、艺术家搜索 YouTube..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "搜索"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "搜索包含原唱版本（非伴奏）"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "高级设置"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "粘贴 YouTube 网址："
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "保存以供稍后使用"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1991,7 +2065,7 @@ msgstr "在YouTube上搜索<small><i>'%(search_term)s'</i></small>"
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -2001,7 +2075,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2088,86 +2162,86 @@ msgstr "展示这些剧目"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "当前会话"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "将此会话命名..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "开始会话"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "结束会话"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "会话历史记录"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "隐藏自动启动"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "会议"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "开始"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "激活"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "导出 CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "导出列表（文本）"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "清晰的戏剧"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "删除会话"
 

--- a/pikaraoke/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/pikaraoke/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.1.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-20 10:03+1000\n"
+"POT-Creation-Date: 2026-08-28 08:48+1000\n"
 "PO-Revision-Date: 2024-08-28 10:09-0400\n"
 "Last-Translator: \n"
 "Language-Team: zh_hant_TW <LL@li.org>\n"
@@ -31,39 +31,39 @@ msgstr "調整音調 %s 個半音：%s"
 msgid "Volume: %s"
 msgstr "音量：%s"
 
-#: lib/download_manager.py:184
+#: lib/download_manager.py:264
 #, python-format
 msgid "Download queued (#%d): %s"
 msgstr "成功添加歌曲 (#%d)：%s"
 
 #. Message shown when download is added and will start immediately
-#: lib/download_manager.py:188
+#: lib/download_manager.py:268
 #, python-format
 msgid "Download starting: %s"
 msgstr "開始下載：%s"
 
 #. Message shown when download actually starts (after waiting in queue)
-#: lib/download_manager.py:344
+#: lib/download_manager.py:457
 #, python-format
 msgid "Downloading video: %s"
 msgstr "正在下載影片：%s"
 
-#: lib/download_manager.py:370
+#: lib/download_manager.py:483
 msgid "Error downloading song: "
 msgstr "下載歌曲時出錯："
 
-#: lib/download_manager.py:390
+#: lib/download_manager.py:503
 #, python-format
 msgid "Downloaded and queued: %s"
 msgstr "成功添加歌曲：%s"
 
 #. Message shown after the download is completed but not queued
-#: lib/download_manager.py:394
+#: lib/download_manager.py:507
 #, python-format
 msgid "Downloaded: %s"
 msgstr "下載：%s"
 
-#: lib/download_manager.py:418
+#: lib/download_manager.py:531
 msgid "Error queueing song: "
 msgstr "添加歌曲到播放列表時出錯："
 
@@ -103,19 +103,19 @@ msgstr "繼續播放：%s"
 msgid "Pause: %s"
 msgstr "暫停：%s"
 
-#: lib/preference_manager.py:142
+#: lib/preference_manager.py:144
 msgid "Your preferences were changed successfully"
 msgstr "您的偏好設定已成功更改"
 
-#: lib/preference_manager.py:145 templates/info.html:19
+#: lib/preference_manager.py:147 templates/info.html:19
 msgid "Something went wrong! Your preferences were not changed"
 msgstr "發生錯誤！您的偏好設定未被更改"
 
-#: lib/preference_manager.py:162
+#: lib/preference_manager.py:164
 msgid "Your preferences were cleared successfully"
 msgstr "您的偏好設定已成功清除"
 
-#: lib/preference_manager.py:165
+#: lib/preference_manager.py:167
 msgid "Something went wrong! Your preferences were not cleared"
 msgstr "發生錯誤！您的偏好設定未被清除"
 
@@ -162,161 +162,121 @@ msgid "Failed to prepare stream"
 msgstr "準備流失敗"
 
 #. Message shown after starting the yt-dlp update.
-#: routes/admin.py:59
+#: routes/admin.py:64
 msgid "Updating yt-dlp! Should take a minute or two... "
 msgstr "正在更新 yt-dlp！可能需要一兩分鐘..."
 
 #. Message shown after trying to update yt-dlp without admin permissions.
-#: routes/admin.py:66
+#: routes/admin.py:71
 msgid "You don't have permission to update yt-dlp"
 msgstr "您沒有權限更新 yt-dlp"
 
 #. Message shown after quitting pikaraoke.
-#: routes/admin.py:97
+#: routes/admin.py:102
 msgid "Exiting pikaraoke now!"
 msgstr "正在退出卡拉OK派！"
 
 #. Message shown after trying to quit pikaraoke without admin permissions.
-#: routes/admin.py:104
+#: routes/admin.py:109
 msgid "You don't have permission to quit"
 msgstr "您沒有權限退出"
 
 #. Message shown after shutting down the system.
-#: routes/admin.py:114
+#: routes/admin.py:119
 msgid "Shutting down system now!"
 msgstr "正在關閉系統！"
 
 #. Message shown after trying to shut down the system without admin
 #. permissions.
-#: routes/admin.py:121
+#: routes/admin.py:126
 msgid "You don't have permission to shut down"
 msgstr "您沒有權限關閉系統"
 
 #. Message shown after rebooting the system.
-#: routes/admin.py:131
+#: routes/admin.py:136
 msgid "Rebooting system now!"
 msgstr "正在重新啟動系統！"
 
 #. Message shown after trying to reboot the system without admin permissions.
-#: routes/admin.py:138
+#: routes/admin.py:143
 msgid "You don't have permission to Reboot"
 msgstr "您沒有權限重新啟動系統"
 
 #. Message shown after expanding the filesystem.
-#: routes/admin.py:148
+#: routes/admin.py:153
 msgid "Expanding filesystem and rebooting system now!"
 msgstr "正在擴展檔案系統並重新啟動系統！"
 
 #. Message shown after trying to expand the filesystem on a non-raspberry pi
 #. device.
-#: routes/admin.py:153
+#: routes/admin.py:158
 msgid "Cannot expand fs on non-raspberry pi devices!"
 msgstr "無法在非樹莓派設備上擴展檔案系統！"
 
 #. Message shown after trying to expand the filesystem without admin
 #. permissions
-#: routes/admin.py:156
+#: routes/admin.py:161
 msgid "You don't have permission to resize the filesystem"
 msgstr "您沒有權限調整檔案系統大小"
 
 #. Message shown after logging in as admin successfully
-#: routes/admin.py:178
+#: routes/admin.py:180
 msgid "Admin mode granted!"
 msgstr "管理員模式已啟用！"
 
 #. Message shown after failing to login as admin
-#: routes/admin.py:182
+#: routes/admin.py:183
 msgid "Incorrect admin password!"
 msgstr "管理員密碼不正確！"
 
+# auto-translated
+#. Message shown after trying to change the admin password without permission.
+#: routes/admin.py:193
+msgid "You don't have permission to change the admin password"
+msgstr "您無權更改管理員密碼"
+
+# auto-translated
+#. Message shown after setting a new admin password.
+#: routes/admin.py:205
+msgid "Admin password set. Other devices will need to log in again."
+msgstr "管理員密碼設定。其他裝置需要重新登入。"
+
+# auto-translated
+#. Message shown after clearing the admin password, making everyone an admin.
+#: routes/admin.py:208
+msgid "Admin password cleared. Everyone is an admin again."
+msgstr "管理員密碼已清除。每個人又都是管理員了。"
+
 #. Message shown after logging out as admin successfully
-#: routes/admin.py:192
+#: routes/admin.py:217
 msgid "Logged out of admin mode!"
 msgstr "已登出管理員模式！"
 
 # auto-translated
 #. Title of the button to accept the suggested name
-#: routes/batch_song_renamer.py:144
+#: routes/batch_song_renamer.py:147
 msgid "Accept suggested name"
 msgstr "接受建議的名稱"
 
 # auto-translated
 #. Title of the files page.
-#. Page title for the page where the user can batch rename songs.
-#: routes/batch_song_renamer.py:152 templates/batch-song-renamer.html:133
+#: routes/batch_song_renamer.py:155
 msgid "Batch Song Renamer"
 msgstr "大量歌曲重命名器"
 
-#. Message shown after trying to edit a song without specifying the filename.
-#: routes/batch_song_renamer.py:236
-msgid "Error: No filename parameters were specified!"
-msgstr "錯誤：未指定檔案名參數！"
+# auto-translated
+#: routes/batch_song_renamer.py:244
+#, python-format
+msgid "Error: Can't edit this song because it is queued or playing: %s"
+msgstr "錯誤：無法編輯這首歌曲，因為它正在排隊或正在播放：%s"
 
-#: routes/batch_song_renamer.py:245
-msgid "Error: Can't edit this song because it is in the current queue: "
-msgstr "錯誤：無法編輯此歌曲，因為它在當前播放列表中："
-
-#: routes/batch_song_renamer.py:259
+#: routes/batch_song_renamer.py:251
 #, python-format
 msgid "Error renaming file: '%s' to '%s', Filename already exists"
 msgstr "重命名檔案時出錯：'%s' 到 '%s'，檔案名已存在"
 
 # auto-translated
-#. Title of the page listing the songs already on this machine.
-#. Navigation link for the page listing songs already on this machine.
-#: routes/files.py:187 templates/base.html:456 templates/base.html:459
-msgid "Songs"
-msgstr "歌曲"
-
-# auto-translated
-#: routes/files.py:216
-msgid "You don't have permission to delete songs"
-msgstr "您無權刪除歌曲"
-
-# auto-translated
-#. Message shown after trying to delete a song that is queued or playing.
-#: routes/files.py:221
-msgid "Error: Can't delete this song because it is queued or playing"
-msgstr "錯誤：無法刪除這首歌曲，因為它正在排隊或正在播放"
-
-#: routes/files.py:228
-#, python-format
-msgid "Song deleted: %s"
-msgstr "歌曲已刪除：%s"
-
-# auto-translated
-#: routes/files.py:260 routes/files.py:283
-msgid "You don't have permission to rename songs"
-msgstr "您無權重命名歌曲"
-
-# auto-translated
-#. Message shown after trying to rename the song that is playing.
-#: routes/files.py:264
-msgid "This song is playing. Rename it when it finishes."
-msgstr "正在播放這首歌。完成後重命名。"
-
-# auto-translated
-#. Message shown after saving the rename page with an empty name.
-#: routes/files.py:288
-msgid "Enter a name for this song."
-msgstr "輸入這首歌的名稱。"
-
-# auto-translated
-#: routes/files.py:294
-msgid ""
-"This song is no longer in the library. It may have been renamed or deleted "
-"from another device."
-msgstr "這首歌已經不在圖書館了。它可能已被重新命名或從其他裝置中刪除。"
-
-# auto-translated
-#. Message shown after trying to rename a song to a name already in use.
-#: routes/files.py:306
-#, python-format
-msgid "A song called '%s' already exists."
-msgstr "一首名為「%s」的歌曲已經存在。"
-
-# auto-translated
-#: routes/files.py:314
+#: routes/batch_song_renamer.py:260 routes/files.py:316
 msgid ""
 "This song started playing while you were editing it. Rename it when it "
 "finishes."
@@ -324,16 +284,88 @@ msgstr "這首歌在您編輯時開始播放。完成後重命名。"
 
 # auto-translated
 #. Message shown after a rename failed. Followed by the system error.
-#: routes/files.py:320
+#: routes/batch_song_renamer.py:265 routes/files.py:322
 #, python-format
 msgid "Error renaming file: %s"
 msgstr "重新命名檔案時發生錯誤：%s"
 
+# auto-translated
+#. Title of the page listing the songs already on this machine.
+#. Navigation link for the page listing songs already on this machine.
+#: routes/files.py:188 templates/base.html:454 templates/base.html:457
+msgid "Songs"
+msgstr "歌曲"
+
+# auto-translated
+#: routes/files.py:217
+msgid "You don't have permission to delete songs"
+msgstr "您無權刪除歌曲"
+
+# auto-translated
+#. Message shown after trying to delete a song that is queued or playing.
+#: routes/files.py:222
+msgid "Error: Can't delete this song because it is queued or playing"
+msgstr "錯誤：無法刪除這首歌曲，因為它正在排隊或正在播放"
+
+#: routes/files.py:229
+#, python-format
+msgid "Song deleted: %s"
+msgstr "歌曲已刪除：%s"
+
+# auto-translated
+#. Title of the page where a song can be renamed.
+#: routes/files.py:241
+msgid "Rename Song"
+msgstr "重命名歌曲"
+
+# auto-translated
+#: routes/files.py:262 routes/files.py:285
+msgid "You don't have permission to rename songs"
+msgstr "您無權重命名歌曲"
+
+# auto-translated
+#. Message shown after trying to rename the song that is playing.
+#: routes/files.py:266
+msgid "This song is playing. Rename it when it finishes."
+msgstr "正在播放這首歌。完成後重命名。"
+
+# auto-translated
+#. Message shown after saving the rename page with an empty name.
+#: routes/files.py:290
+msgid "Enter a name for this song."
+msgstr "輸入這首歌的名稱。"
+
+# auto-translated
+#: routes/files.py:296
+msgid ""
+"This song is no longer in the library. It may have been renamed or deleted "
+"from another device."
+msgstr "這首歌已經不在圖書館了。它可能已被重新命名或從其他裝置中刪除。"
+
+# auto-translated
+#. Message shown after trying to rename a song to a name already in use.
+#: routes/files.py:308
+#, python-format
+msgid "A song called '%s' already exists."
+msgstr "一首名為「%s」的歌曲已經存在。"
+
 #. Message shown after renaming a file.
-#: routes/files.py:325
+#: routes/files.py:327
 #, python-format
 msgid "Renamed file: %s to %s"
 msgstr "已重命名檔案：%s 到 %s"
+
+#. Title of the home page, which shows the song playing now.
+#: routes/home.py:24
+msgid "Now Playing"
+msgstr "正在播放"
+
+# auto-translated
+#. Title of the settings and system information page.
+#. Dropdown link to the settings and system information page.
+#: routes/info.py:43 templates/base.html:509
+msgid "Settings"
+msgstr "設定"
 
 #: routes/info.py:116
 msgid "CPU usage query unsupported"
@@ -349,80 +381,86 @@ msgstr "您沒有權限更改偏好設定"
 msgid "You don't have permission to clear preferences"
 msgstr "您沒有權限清除偏好設定"
 
+#. Title of the queue page.
+#. Navigation link for the queue page.
+#: routes/queue.py:58 templates/base.html:447
+msgid "Queue"
+msgstr "播放列表"
+
 # auto-translated
-#: routes/queue.py:80
+#: routes/queue.py:74
 msgid "You don't have permission to add random songs"
 msgstr "您無權添加隨機歌曲"
 
 #. Message shown after adding random tracks
-#: routes/queue.py:86
+#: routes/queue.py:80
 #, python-format
 msgid "Added %s random tracks"
 msgstr "已添加 %s 首隨機歌曲"
 
 #. Message shown after running out songs to add during random track addition
-#: routes/queue.py:89
+#: routes/queue.py:83
 msgid "Ran out of songs!"
 msgstr "歌曲已用完！"
 
 # auto-translated
 #. Message shown when non-admin tries to edit queue
-#: routes/queue.py:121
+#: routes/queue.py:115
 msgid "Unauthorized"
 msgstr "未經授權"
 
-#: routes/queue.py:131
+#: routes/queue.py:125
 msgid "Cleared the queue!"
 msgstr "已清空播放列表！"
 
 # auto-translated
-#: routes/queue.py:143
+#: routes/queue.py:137
 msgid "Moved to top of queue"
 msgstr "移至隊列頂部"
 
 # auto-translated
-#: routes/queue.py:144
+#: routes/queue.py:138
 msgid "Moved to bottom of queue"
 msgstr "移至隊列底部"
 
-#: routes/queue.py:145
+#: routes/queue.py:139
 msgid "Moved up in queue"
 msgstr "在播放列表中上移"
 
-#: routes/queue.py:146
+#: routes/queue.py:140
 msgid "Moved down in queue"
 msgstr "在播放列表中下移"
 
-#: routes/queue.py:147
+#: routes/queue.py:141
 msgid "Deleted from queue"
 msgstr "已從播放列表中刪除"
 
 # auto-translated
-#: routes/queue.py:150
+#: routes/queue.py:144
 msgid "Error moving to top of queue"
 msgstr "移至佇列頂部時出錯"
 
 # auto-translated
-#: routes/queue.py:151
+#: routes/queue.py:145
 msgid "Error moving to bottom of queue"
 msgstr "移至佇列底部時出錯"
 
-#: routes/queue.py:152
+#: routes/queue.py:146
 msgid "Error moving up in queue"
 msgstr "在播放列表中上移時出錯"
 
-#: routes/queue.py:153
+#: routes/queue.py:147
 msgid "Error moving down in queue"
 msgstr "在播放列表中下移時出錯"
 
-#: routes/queue.py:154
+#: routes/queue.py:148
 msgid "Error deleting from queue"
 msgstr "從播放列表中刪除時出錯"
 
 # auto-translated
 #. Title of the page used to get new songs into the library.
 #. Navigation link for the page used to get new songs into the library.
-#: routes/search.py:61 templates/base.html:462 templates/base.html:465
+#: routes/search.py:61 templates/base.html:460 templates/base.html:463
 msgid "Add New"
 msgstr "新增內容"
 
@@ -431,6 +469,29 @@ msgstr "新增內容"
 #: routes/sessions.py:63
 msgid "You don't have permission to view this page"
 msgstr "您沒有權限查看此頁面"
+
+# auto-translated
+#. Title of the session management page.
+#. Dropdown link to the karaoke session management page, only shown to the
+#. host.
+#: routes/sessions.py:79 templates/base.html:503
+msgid "Sessions"
+msgstr "會議"
+
+# auto-translated
+#. Title of the page logging everything that has been sung.
+#. Dropdown link to the log of everything that has been sung.
+#. Header of the play history management section of the settings page.
+#: routes/sessions.py:95 templates/base.html:496 templates/info.html:425
+msgid "Play History"
+msgstr "播放歷史"
+
+# auto-translated
+#. Title of the most-played songs and most active singers page.
+#. Dropdown link to the most-played songs and most active singers.
+#: routes/sessions.py:117 templates/base.html:491
+msgid "Rankings"
+msgstr "排行榜"
 
 # auto-translated
 #. Error when starting a session without supplying a name
@@ -466,8 +527,8 @@ msgstr "玩過"
 #. Label before the name of the singer the play log is filtered to.
 #. Play log column header for who sang the song.
 #. Ranking table column header for the person who sang.
-#: routes/sessions_api.py:312 templates/history.html:412
-#: templates/history.html:469 templates/rankings.html:176
+#: routes/sessions_api.py:312 templates/history.html:411
+#: templates/history.html:468 templates/rankings.html:175
 msgid "Performer"
 msgstr "演員"
 
@@ -475,8 +536,8 @@ msgstr "演員"
 #. Label before the name of the song the play log is filtered to.
 #. Play log column header for the song that was sung.
 #. Ranking table column header for the song that was sung.
-#: routes/sessions_api.py:312 templates/history.html:432
-#: templates/history.html:473 templates/rankings.html:128
+#: routes/sessions_api.py:312 templates/history.html:431
+#: templates/history.html:472 templates/rankings.html:127
 msgid "Song"
 msgstr "歌曲"
 
@@ -566,24 +627,15 @@ msgstr "您要更改使用此設備的人的姓名嗎？這將顯示在排隊的
 msgid "Are you sure you want to clear the ENTIRE queue? Type ok to continue"
 msgstr "您確定要清除整個佇列嗎？輸入“確定”繼續"
 
-# auto-translated
-#. Confirmation dialog when removing a song from the queue. {title} is
-#. replaced
-#. with the title
-#: templates/base.html:41
-#, python-brace-format
-msgid "Are you sure you want to delete {title} from the queue?"
-msgstr "您確定要從佇列中刪除 {title} 嗎？"
-
 #. Confirmation dialog when permanently deleting a song file from the library
-#: templates/base.html:43
+#: templates/base.html:41
 msgid "Are you sure you want to delete this song from the library?"
 msgstr "您確定要從音樂庫中刪除此歌曲嗎？"
 
 # auto-translated
 #. Label showing the number of semitones for pitch shift. {value} is replaced
 #. with a number like +3 or -2.
-#: templates/base.html:45
+#: templates/base.html:43
 #, python-brace-format
 msgid "{value} semitones"
 msgstr "{value} 半音"
@@ -591,20 +643,20 @@ msgstr "{value} 半音"
 # auto-translated
 #. Confirmation dialog when changing the key/pitch of a song. {label} is
 #. replaced with a label like "+3 semitones".
-#: templates/base.html:47
+#: templates/base.html:45
 #, python-brace-format
 msgid "Transpose this song: {label}?"
 msgstr "轉置這首歌：{label}？"
 
 # auto-translated
 #. Confirmation dialog when restarting the currently playing track.
-#: templates/base.html:49
+#: templates/base.html:47
 msgid "Are you sure you want to restart this track?"
 msgstr "您確定要重新開始該曲目嗎？"
 
 # auto-translated
 #. Informational tooltip explaining what a semitone is.
-#: templates/base.html:51
+#: templates/base.html:49
 msgid ""
 "A semitone is also known as a half-step. It is the smallest interval used in"
 " classical Western music, equal to a twelfth of an octave or half a tone."
@@ -613,7 +665,7 @@ msgstr "半音也稱為半音。它是西方古典音樂中使用的最小音程
 # auto-translated
 #. Confirmation dialog when expanding the filesystem on Raspberry Pi, which
 #. triggers a reboot.
-#: templates/base.html:53
+#: templates/base.html:51
 msgid ""
 "Are you sure you want to expand the filesystem? This will reboot your "
 "raspberry pi."
@@ -621,13 +673,13 @@ msgstr "您確定要擴充檔案系統嗎？這將重新啟動您的樹莓派。
 
 # auto-translated
 #. Generic error prefix shown before an error message.
-#: templates/base.html:55
+#: templates/base.html:53
 msgid "Error"
 msgstr "錯誤"
 
 #. Prompt which asks the user their name when they first try to add to the
 #. queue.
-#: templates/base.html:120
+#: templates/base.html:118
 msgid ""
 "Please enter your name. This will show up next to the songs you queue up "
 "from this device."
@@ -636,50 +688,19 @@ msgstr "請輸入您的名字。這將顯示在您從此設備添加的歌曲旁
 # auto-translated
 #. Accessible label for the banner naming the karaoke session in progress.
 #. {name} is replaced with the session's name.
-#: templates/base.html:212 templates/base.html:526
+#: templates/base.html:210 templates/base.html:524
 #, python-brace-format
 msgid "Current session: {name}"
 msgstr "目前會話：{name}"
 
 #. Navigation link for the home page.
-#: templates/base.html:443
+#: templates/base.html:441
 msgid "Home"
 msgstr "首頁"
 
-#. Navigation link for the queue page.
-#: templates/base.html:449 templates/queue.html:509
-msgid "Queue"
-msgstr "播放列表"
-
-# auto-translated
-#. Dropdown link to the most-played songs and most active singers.
-#: templates/base.html:493
-msgid "Rankings"
-msgstr "排行榜"
-
-# auto-translated
-#. Dropdown link to the log of everything that has been sung.
-#. Header of the play history management section of the settings page.
-#: templates/base.html:498 templates/info.html:432
-msgid "Play History"
-msgstr "播放歷史"
-
-# auto-translated
-#. Dropdown link to the karaoke session management page, only shown to the
-#. host.
-#: templates/base.html:505
-msgid "Sessions"
-msgstr "會議"
-
-# auto-translated
-#. Dropdown link to the settings and system information page.
-#: templates/base.html:511
-msgid "Settings"
-msgstr "設定"
-
 # auto-translated
 #. Message about the wait for loading the songs
-#: templates/batch-song-renamer.html:136
+#: templates/batch-song-renamer.html:134
 msgid ""
 "The loading process may take a few seconds, as the song titles are compared online. Loading time may vary\n"
 "\tbased on your internet connection."
@@ -689,7 +710,7 @@ msgstr ""
 
 # auto-translated
 #. Label which displays that all songs are being shown
-#: templates/batch-song-renamer.html:141
+#: templates/batch-song-renamer.html:139
 msgid ""
 "Showing all\n"
 "\tsongs"
@@ -699,13 +720,13 @@ msgstr ""
 
 # auto-translated
 #. Button which changes to show only the songs to rename
-#: templates/batch-song-renamer.html:144
+#: templates/batch-song-renamer.html:142
 msgid "Show only songs to rename"
 msgstr "僅顯示要重新命名的歌曲"
 
 # auto-translated
 #. Label which displays that only songs to rename are being shown.
-#: templates/batch-song-renamer.html:147
+#: templates/batch-song-renamer.html:145
 msgid ""
 "Showing only songs\n"
 "\tto rename"
@@ -716,13 +737,13 @@ msgstr ""
 # auto-translated
 #. Button which changes to show all songs
 #. Button which stops filtering the play log to one song.
-#: templates/batch-song-renamer.html:150 templates/history.html:438
+#: templates/batch-song-renamer.html:148 templates/history.html:437
 msgid "Show all songs"
 msgstr "顯示所有歌曲"
 
 # auto-translated
 #. Message displaying that the songs are currently being loaded
-#: templates/batch-song-renamer.html:158
+#: templates/batch-song-renamer.html:156
 msgid "Loading songs..."
 msgstr "正在加載歌曲..."
 
@@ -739,117 +760,111 @@ msgid "No suggestion!"
 msgstr "沒有建議！"
 
 # auto-translated
-#. Page title for the page where a song can be renamed.
-#: templates/edit.html:99
-msgid "Rename Song"
-msgstr "重命名歌曲"
-
-# auto-translated
 #. Label showing the original filename on disk before editing.
-#: templates/edit.html:108
+#: templates/edit.html:103
 msgid "Current filename"
 msgstr "目前檔案名稱"
 
 # auto-translated
 #. Label for the input where the user types the new filename.
-#: templates/edit.html:127
+#: templates/edit.html:122
 msgid "New filename"
 msgstr "新檔案名稱"
 
 # auto-translated
 #. Label on button which applies automatic formatting to tidy the filename.
-#: templates/edit.html:138
+#: templates/edit.html:133
 msgid "Auto Format"
 msgstr "自動格式化"
 
 # auto-translated
 #. Label on button which swaps the artist and title around the dash separator.
-#: templates/edit.html:143
+#: templates/edit.html:138
 msgid "Swap Artist/Title"
 msgstr "交換藝術家/標題"
 
 # auto-translated
 #. Label on button which searches for track name suggestions from iTunes.
-#: templates/edit.html:150
+#: templates/edit.html:145
 msgid "Suggest from iTunes"
 msgstr "來自 iTunes 的建議"
 
 # auto-translated
 #. Label for iTunes search country dropdown
-#: templates/edit.html:155 templates/info.html:416
+#: templates/edit.html:150 templates/info.html:409
 msgid "iTunes search country"
 msgstr "iTunes 搜尋國家/地區"
 
 #. Label on button which saves the changes.
-#: templates/edit.html:169
+#: templates/edit.html:164
 msgid "Save"
 msgstr "儲存"
 
 # auto-translated
-#: templates/edit.html:174
+#: templates/edit.html:169
 msgid "Cancel"
 msgstr "取消"
 
 #. Label on button which deletes the current song.
-#: templates/edit.html:183
+#: templates/edit.html:178
 msgid "Delete this song"
 msgstr "刪除此歌曲"
 
 # auto-translated
 #. Button to open the batch song renamer page.
-#: templates/files.html:220
+#: templates/files.html:216
 msgid "Bulk rename"
 msgstr "批次重命名"
 
 # auto-translated
 #. Subtitle under the Songs heading, explaining that this page lists songs
 #. already downloaded.
-#: templates/files.html:226
+#: templates/files.html:224
 msgid "Available in the library"
 msgstr "在圖書館可以找到"
 
 # auto-translated
 #. Breadcrumb link back to the top level of the folder view.
-#: templates/files.html:356
+#: templates/files.html:343
 msgid "All folders"
 msgstr "所有資料夾"
 
 # auto-translated
 #. Placeholder in the box that filters the songs already on this machine.
-#: templates/files.html:382
+#: templates/files.html:369
 msgid "Search by title, artist..."
 msgstr "按標題、藝術家搜尋..."
 
 #. Button which empties the filter box and shows every song again.
 #. Link which clears the text from the search box.
-#: templates/files.html:388 templates/search.html:554
+#: templates/files.html:375 templates/search.html:551
 msgid "Clear"
 msgstr "清除"
 
 # auto-translated
 #. Button which lists every song at once, ignoring the folders they are stored
 #. in.
-#: templates/files.html:446
+#: templates/files.html:433
 msgid "All songs"
 msgstr "所有歌曲"
 
 # auto-translated
 #. Button which groups the songs by the folder they are stored in.
-#: templates/files.html:451
+#: templates/files.html:438
 msgid "Folders"
 msgstr "資料夾"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. name.
-#: templates/files.html:462
+#: templates/files.html:449
 msgid "Sort Alphabetically"
 msgstr "按字母順序排序"
 
 # auto-translated
 #. Button which changes how the songs are sorted so they become sorted by
 #. date.
-#: templates/files.html:467
+#: templates/files.html:454
 msgid "Sort by Date"
 msgstr "按日期排序"
 
@@ -862,14 +877,14 @@ msgstr "從播放日誌中刪除此條目嗎？"
 # auto-translated
 #. Shown when the play log has no entries yet.
 #. Shown on the rankings page when no songs have been played yet.
-#: templates/history.html:42 templates/rankings.html:163
+#: templates/history.html:42 templates/rankings.html:162
 msgid "Nothing has been played yet."
 msgstr "還沒有播放任何內容。"
 
 # auto-translated
 #. Status of a song that was sung all the way through.
 #. Play log column header for when the song was played.
-#: templates/history.html:44 templates/history.html:465
+#: templates/history.html:44 templates/history.html:464
 msgid "Played"
 msgstr "玩過"
 
@@ -887,48 +902,48 @@ msgstr "演奏"
 
 # auto-translated
 #: templates/history.html:182 templates/queue.html:164
-#: templates/queue.html:326 templates/sessions.html:153
+#: templates/queue.html:386 templates/sessions.html:153
 msgid "Options"
 msgstr "選項"
 
 # auto-translated
 #. Button which stops filtering the play log to one singer.
-#: templates/history.html:421
+#: templates/history.html:420
 msgid "Show all performers"
 msgstr "顯示所有表演者"
 
 # auto-translated
 #. Checkbox which hides songs that were skipped before they finished.
-#: templates/history.html:447
+#: templates/history.html:446
 msgid "Hide skipped"
 msgstr "隱藏跳過的"
 
 # auto-translated
 #. Play log column header for whether the song was played through, skipped, or
 #. is still playing.
-#: templates/history.html:476
+#: templates/history.html:475
 msgid "Status"
 msgstr "地位"
 
 #. Menu item which adds the song from this play log entry to the queue.
 #. Button which adds an already-downloaded song to the queue.
 #. Button which downloads a song and puts it straight in the queue.
-#: templates/history.html:496 templates/rankings.html:141
-#: templates/search.html:370 templates/search.html:579
-#: templates/search.html:647 templates/search.html:657
+#: templates/history.html:495 templates/rankings.html:140
+#: templates/search.html:370 templates/search.html:576
+#: templates/search.html:644 templates/search.html:654
 msgid "Add to queue"
 msgstr "添加到播放列表"
 
 # auto-translated
 #. Shown in place of "add to queue" when the song has since been removed from
 #. the library.
-#: templates/history.html:501
+#: templates/history.html:500
 msgid "This song is no longer in the library"
 msgstr "這首歌已經不在柯瑞了"
 
 # auto-translated
 #. Menu item which removes this entry from the play log.
-#: templates/history.html:506
+#: templates/history.html:505
 msgid "Delete entry"
 msgstr "刪除條目"
 
@@ -955,47 +970,42 @@ msgid ""
 "permission first!"
 msgstr "您確定要跳過這首歌嗎？如果您不是添加這首歌的人，請先徵求許可！"
 
-#. Header showing the currently playing song.
-#: templates/home.html:235
-msgid "Now Playing"
-msgstr "正在播放"
-
 #. Title for the section displaying the next song to be played.
-#: templates/home.html:248
+#: templates/home.html:246
 msgid "Next Song"
 msgstr "下一首歌"
 
 #. Title of the box with controls such as pause and skip.
-#: templates/home.html:255
+#: templates/home.html:253
 msgid "Player Control"
 msgstr "播放器控制"
 
 #. Title attribute on the button to play or pause the current song.
-#: templates/home.html:259
+#: templates/home.html:257
 msgid "Restart Song"
 msgstr "重新開始歌曲"
 
 #. Title attribute on the button to skip to the next song.
-#: templates/home.html:261
+#: templates/home.html:259
 msgid "Play/Pause"
 msgstr "播放/暫停"
 
-#: templates/home.html:263
+#: templates/home.html:261
 msgid "Stop Current Song"
 msgstr "停止當前歌曲"
 
 #. Title of a control to change the key/pitch of the playing song.
-#: templates/home.html:285
+#: templates/home.html:283
 msgid "Change Key"
 msgstr "更改音調"
 
 #. Label on the button to confirm the change in key/pitch of the playing song.
-#: templates/home.html:305
+#: templates/home.html:303
 msgid "Change"
 msgstr "更改"
 
 # auto-translated
-#: templates/home.html:315 templates/info.html:553
+#: templates/home.html:313 templates/info.html:546
 msgid "Microphones"
 msgstr "麥克風"
 
@@ -1031,7 +1041,7 @@ msgstr "您確定要立即更新 yt-dlp 嗎？當前和待處理的下載可能�
 # auto-translated
 #. Confirmation text when the user wants to expand the filesystem to take the
 #. entire SD card.
-#: templates/info.html:166 templates/info.html:558
+#: templates/info.html:166 templates/info.html:551
 msgid ""
 "No microphones detected. Connect a USB or Bluetooth mic and click Refresh."
 msgstr "未偵測到麥克風。連接 USB 或藍牙麥克風，然後按一下「刷新」。"
@@ -1042,7 +1052,7 @@ msgid "Scanning..."
 msgstr "掃描..."
 
 # auto-translated
-#: templates/info.html:234 templates/info.html:579
+#: templates/info.html:234 templates/info.html:572
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -1066,312 +1076,314 @@ msgstr "播放記錄已刪除"
 msgid "Library sync complete"
 msgstr "庫同步完成"
 
-#. Title of the information page.
-#: templates/info.html:310
-msgid "Information"
-msgstr "資訊"
-
 #. Label which appears before a url which links to the current page.
-#: templates/info.html:322
+#: templates/info.html:313
 #, python-format
 msgid "URL of %(site_title)s:"
 msgstr "%(site_title)s 的網址："
 
 #. Label before a QR code which brings a frind (pal) to the main page if
 #. scanned, so they can also add songs. QR code follows this text.
-#: templates/info.html:328
+#: templates/info.html:319
 msgid "Handy URL QR code to share with a pal:"
 msgstr "方便分享給朋友的網址 QR 碼："
 
 # auto-translated
 #. Title of the admin section.
-#: templates/info.html:336 templates/info.html:860
+#: templates/info.html:327 templates/info.html:852
 msgid "Admin"
 msgstr "行政"
 
 #. Title fo the form to enter the administrator password.
-#: templates/info.html:342
+#: templates/info.html:333
 msgid "Enter the administrator password"
 msgstr "輸入管理員密碼"
 
 #. Text on submit button for the admin login form.
-#: templates/info.html:351
+#: templates/info.html:342
 msgid "Login"
 msgstr "登入"
 
 # auto-translated
+#. Tells a locked-out host how to reset a forgotten admin password.
+#: templates/info.html:347
+msgid ""
+"Forgotten it? Restart PiKaraoke with --admin-password to set a new one."
+msgstr "忘記了？使用 --admin-password 重新啟動 PiKaraoke 以設定新密碼。"
+
+# auto-translated
 #. Title of the song library section.
-#: templates/info.html:363
+#: templates/info.html:356
 msgid "Song Library"
 msgstr "歌庫"
 
 # auto-translated
 #. Header of the song library management section.
-#: templates/info.html:368
+#: templates/info.html:361
 msgid "Library"
 msgstr "圖書館"
 
 # auto-translated
 #. Song count display in the library card.
-#: templates/info.html:374
+#: templates/info.html:367
 msgid "Songs in library:"
 msgstr "庫裡的歌曲："
 
 # auto-translated
 #. Button to trigger a background library scan.
-#: templates/info.html:378
+#: templates/info.html:371
 msgid "Sync Now"
 msgstr "立即同步"
 
 # auto-translated
 #. Help text explaining what Sync Now does.
-#: templates/info.html:382
+#: templates/info.html:375
 msgid "Reconciles the library with the song directory in the background."
 msgstr "在後台協調庫與歌曲目錄。"
 
 # auto-translated
 #. Header of the song renaming settings section.
-#: templates/info.html:391
+#: templates/info.html:384
 msgid "Renaming"
 msgstr "重新命名"
 
 # auto-translated
 #. Option for naming songs artist first, e.g. "Abba - Waterloo".
-#: templates/info.html:399
+#: templates/info.html:392
 msgid "Artist - Title"
 msgstr "藝術家 - 頭銜"
 
 # auto-translated
 #. Option for naming songs title first, e.g. "Waterloo - Abba".
-#: templates/info.html:401
+#: templates/info.html:394
 msgid "Title - Artist"
 msgstr "頭銜 - 藝術家"
 
 # auto-translated
 #. Label for the suggestion name order dropdown
-#: templates/info.html:404
+#: templates/info.html:397
 msgid "Order of iTunes suggested song names"
 msgstr "iTunes 建議歌曲名稱的順序"
 
 # auto-translated
 #. Button which deletes the entire play history, every session and every play.
-#: templates/info.html:438
+#: templates/info.html:431
 msgid "Reset all history"
 msgstr "重置所有歷史記錄"
 
 # auto-translated
 #. Help text explaining what Reset all history does.
-#: templates/info.html:442
+#: templates/info.html:435
 msgid "Deletes every session and every play on record. This cannot be undone."
 msgstr "刪除記錄中的每個會話和每個播放。此操作無法撤銷。"
 
 #. Title of the user preferences section.
-#: templates/info.html:449
+#: templates/info.html:442
 msgid "User Preferences"
 msgstr "使用者偏好設定"
 
 #. Title text for the splash screen settings section of preferences
-#: templates/info.html:455
+#: templates/info.html:448
 msgid "Splash screen settings"
 msgstr "啟動畫面設定"
 
 #. Checkbox label which enable/disables background video on the Splash Screen
-#: templates/info.html:463
+#: templates/info.html:456
 msgid "Disable background video"
 msgstr "停用背景影片"
 
 # auto-translated
 #. Checkbox label which enable/disables background music on the Splash Screen
-#: templates/info.html:469
+#: templates/info.html:462
 msgid "Disable background music"
 msgstr "停用背景音樂"
 
 #. Checkbox label which enable/disables the Score Screen
-#: templates/info.html:475
+#: templates/info.html:468
 msgid "Disable the score screen after each song"
 msgstr "停用每首歌曲後的分數畫面"
 
 #. Checkbox label which enable/disables notifications on the splash screen
-#: templates/info.html:481
+#: templates/info.html:474
 msgid "Hide notifications"
 msgstr "隱藏通知"
 
 # auto-translated
 #. Checkbox label which enable/disables the digital clock on the splash screen
-#: templates/info.html:487
+#: templates/info.html:480
 msgid "Show splash clock"
 msgstr "顯示啟動時鐘"
 
 #. Checkbox label which enable/disables the URL display
-#: templates/info.html:492
+#: templates/info.html:485
 msgid "Hide the URL and QR code"
 msgstr "隱藏網址和 QR 碼"
 
 # auto-translated
 #. Checkbox label which enables/disables the logo in the middle of the splash
 #. screen
-#: templates/info.html:498
+#: templates/info.html:491
 msgid "Hide the logo on the splash screen"
 msgstr "隱藏啟動畫面上的標誌"
 
 # auto-translated
 #. Checkbox label which enables/disables the karaoke session name shown under
 #. the logo on the splash screen
-#: templates/info.html:504
+#: templates/info.html:497
 msgid "Hide the session name on the splash screen"
 msgstr "在啟動畫面上隱藏會話名稱"
 
 #. Checkbox label which enable/disables showing overlay data on the splash
 #. screen
-#: templates/info.html:510
+#: templates/info.html:503
 msgid "Hide all overlays, including now playing, up next, and QR code"
 msgstr "隱藏所有覆蓋層，包括正在播放、即將播放和 QR 碼"
 
 #. Numberbox label for setting the default video volume
-#: templates/info.html:516
+#: templates/info.html:509
 msgid "Default volume of the videos (min 0, max 100)"
 msgstr "影片的預設音量（最小 0，最大 100）"
 
 #. Numberbox label for setting the background music volume
-#: templates/info.html:522
+#: templates/info.html:515
 msgid "Volume of the background music (min 0, max 100)"
 msgstr "背景音樂的音量（最小 0，最大 100）"
 
 #. Numberbox label for setting the inactive delay before showing the
 #. screensaver
-#: templates/info.html:529
+#: templates/info.html:522
 msgid ""
 "The amount of idle time in seconds before the screen saver activates. Set to"
 " 0 to disable it."
 msgstr "螢幕保護程式啟動前的閒置時間（秒）。設為 0 可停用。"
 
 #. Numberbox label for setting the delay before playing the next song
-#: templates/info.html:536
+#: templates/info.html:529
 msgid "The delay in seconds before starting the next song"
 msgstr "開始下一首歌曲前的延遲時間（秒）"
 
 # auto-translated
-#: templates/info.html:547
+#: templates/info.html:540
 msgid "Audio"
 msgstr "聲音的"
 
 # auto-translated
-#: templates/info.html:555
+#: templates/info.html:548
 msgid ""
 "Microphones detected on the server. Audio is routed directly to speakers."
 msgstr "在伺服器上偵測到麥克風。音訊直接傳送至揚聲器。"
 
 # auto-translated
-#: templates/info.html:563
+#: templates/info.html:556
 msgid "Latency"
 msgstr "延遲"
 
 # auto-translated
-#: templates/info.html:571
+#: templates/info.html:564
 msgid "Echo cancellation"
 msgstr "迴聲消除"
 
 # auto-translated
-#: templates/info.html:573
+#: templates/info.html:566
 msgid "Experimental"
 msgstr "實驗性的"
 
 # auto-translated
-#: templates/info.html:574
+#: templates/info.html:567
 msgid "(reduces feedback, adds latency)"
 msgstr "（減少回饋，增加延遲）"
 
 # auto-translated
-#: templates/info.html:582
+#: templates/info.html:575
 msgid ""
 "Microphone support is unavailable. Required audio tools are not installed."
 msgstr "麥克風支援不可用。未安裝所需的音訊工具。"
 
 # auto-translated
-#: templates/info.html:585
+#: templates/info.html:578
 msgid "On Linux / Raspberry Pi, install it with:"
 msgstr "在 Linux / Raspberry Pi 上，安裝它："
 
 # auto-translated
-#: templates/info.html:587
+#: templates/info.html:580
 msgid "and restart PiKaraoke."
 msgstr "並重新啟動 PiKaraoke。"
 
 # auto-translated
 #. Title text for the Score Phrases section of preferences
-#: templates/info.html:599
+#: templates/info.html:592
 msgid "Score phrases"
 msgstr "給短語評分"
 
 # auto-translated
 #. Help text explaining how to add phrases
-#: templates/info.html:606
+#: templates/info.html:599
 msgid "Add one phrase per line in each box and hit save."
 msgstr "在每個框中每行新增一個短語，然後點擊「儲存」。"
 
 # auto-translated
 #. Title for LOW Score Phrases
-#: templates/info.html:608
+#: templates/info.html:601
 msgid "LOW Score Phrases (score < 30)"
 msgstr "低分短語（分數 < 30）"
 
 # auto-translated
 #. Placeholder for the low score phrases textarea
-#: templates/info.html:610
+#: templates/info.html:603
 msgid "Could be better..."
 msgstr "可能會更好..."
 
 # auto-translated
 #. Title for MID Score Phrases
-#: templates/info.html:613
+#: templates/info.html:606
 msgid "MID Score Phrases (30 > score < 60)"
 msgstr "MID 得分短語 (30 > 分數 < 60)"
 
 # auto-translated
 #. Placeholder for the MID score phrases textarea
-#: templates/info.html:615
+#: templates/info.html:608
 msgid "That was ok..."
 msgstr "那就可以了..."
 
 # auto-translated
 #. Title for HIGH Score Phrases
-#: templates/info.html:618
+#: templates/info.html:611
 msgid "HIGH Score Phrases (60 < score)"
 msgstr "高分短語（60 < 分數）"
 
 # auto-translated
 #. Placeholder for the HIGH score phrases textarea
-#: templates/info.html:620
+#: templates/info.html:613
 msgid "Wonderfull..."
 msgstr "精彩..."
 
 #. Title text for the language settings section of preferences
-#: templates/info.html:628
+#: templates/info.html:621
 msgid "Language settings"
 msgstr "語言設定"
 
 #. Label for language selection dropdown
-#: templates/info.html:641
+#: templates/info.html:634
 msgid "Preferred language (requires restart)"
 msgstr "首選語言（需要重啟"
 
 #. Title text for the server settings section of preferences
-#: templates/info.html:650
+#: templates/info.html:643
 msgid "Server settings"
 msgstr "伺服器設定"
 
 #. Checkbox label which enable/disables audio volume normalization
-#: templates/info.html:657
+#: templates/info.html:650
 msgid "Normalize audio volume"
 msgstr "標準化音訊音量"
 
 #. Checkbox label which enable/disables high quality video downloads
-#: templates/info.html:663
+#: templates/info.html:656
 msgid "Download high quality videos"
 msgstr "下載高品質影片"
 
 #. Checkbox label which enable/disables full transcode before playback
-#: templates/info.html:669
+#: templates/info.html:662
 msgid ""
 "Transcode video completely before playing (better browser compatibility, "
 "slower starts). Buffer size will be ignored.*"
@@ -1379,7 +1391,7 @@ msgstr "在播放前完全轉碼影片（更好的瀏覽器相容性，較慢的
 
 # auto-translated
 #. Checkbox label which enable/disables CDG pixel scaling
-#: templates/info.html:675
+#: templates/info.html:668
 msgid ""
 "Enable CDG pixel scaling (crisper visuals for CDG files, may increase CPU "
 "usage)"
@@ -1387,7 +1399,7 @@ msgstr "啟用 CDG 像素縮放（CDG 檔案的視覺效果更清晰，可能會
 
 # auto-translated
 #. Checkbox label which enables automatic cleanup of YouTube song titles
-#: templates/info.html:681
+#: templates/info.html:674
 msgid ""
 "Enable automatic YouTube title cleanup (strips noise words like \"Karaoke "
 "Version HD\")"
@@ -1395,7 +1407,7 @@ msgstr "啟用自動 YouTube 標題處理（刪除“卡拉 OK 版本高清”�
 
 # auto-translated
 #. Checkbox label which enables browsing the song library by folder
-#: templates/info.html:687
+#: templates/info.html:680
 msgid ""
 "Enable folder browsing (adds a Folders view to the Songs page when the "
 "library has subfolders)"
@@ -1403,25 +1415,25 @@ msgstr "啟用資料夾瀏覽（當庫有子資料夾時，將資料夾視圖新
 
 # auto-translated
 #. Numberbox label for audio video synchronization
-#: templates/info.html:694
+#: templates/info.html:687
 msgid ""
 "Fix the audio and video synchronization in seconds (negative = advances "
 "audio | positive = delays audio)"
 msgstr "在幾秒鐘內修復音訊和視訊同步（負=提前音訊|正=延遲音訊）"
 
 #. Numberbox label for limitting the number of songs for each player
-#: templates/info.html:701
+#: templates/info.html:694
 msgid "Limit of songs an individual user can add to the queue (0 = unlimited)"
 msgstr "個別使用者可以添加到播放列表的歌曲數量限制（0 = 無限制）"
 
 # auto-translated
 #. Checkbox label which enable/disables fair queue (round-robin) mode
-#: templates/info.html:707
+#: templates/info.html:700
 msgid "Enable fair queue (round-robin mode ensures users take turns)"
 msgstr "啟用公平隊列（循環模式確保用戶輪流）"
 
 #. Numberbox label for setting the buffer size in kilobytes
-#: templates/info.html:714
+#: templates/info.html:707
 msgid ""
 "Buffer size in kilobytes. Transcode this amount of the video before sending "
 "it to the splash screen. "
@@ -1430,13 +1442,13 @@ msgstr "緩衝區大小（KB）。在將影片發送到啟動畫面之前，轉�
 # auto-translated
 #. Label for the dropdown choosing how many songs are shown per page on the
 #. Songs page.
-#: templates/info.html:727
+#: templates/info.html:720
 msgid "Default songs per page."
 msgstr "每頁預設歌曲。"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when running in a container.
-#: templates/info.html:734
+#: templates/info.html:727
 msgid ""
 "Keep the server awake: unavailable in a container. Disable sleep on the "
 "host."
@@ -1444,104 +1456,104 @@ msgstr "保持伺服器喚醒：在容器中不可用。禁用主機上的睡眠
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox when the required tool is missing.
-#: templates/info.html:736
+#: templates/info.html:729
 msgid ""
 "Keep the server awake: needs systemd-inhibit (Linux) or caffeinate (macOS)."
 msgstr "保持伺服器喚醒：需要 systemd-inhibit (Linux) 或 caffeinate (macOS)。"
 
 # auto-translated
 #. Shown instead of the keep-awake checkbox on platforms without a wake lock.
-#: templates/info.html:738
+#: templates/info.html:731
 msgid "Keep the server awake: not supported on this platform."
 msgstr "保持伺服器喚醒：此平台不支援。"
 
 # auto-translated
 #. Checkbox label which stops the server machine from sleeping
-#: templates/info.html:744
+#: templates/info.html:737
 msgid "Keep the server awake while PiKaraoke is running"
 msgstr "PiKaraoke 運行時保持伺服器處於喚醒狀態"
 
 #. Text for the link where the user can clear all user preferences
-#: templates/info.html:751
+#: templates/info.html:744
 msgid "Clear preferences"
 msgstr "清除偏好設定"
 
 #. Title of the system data section.
-#: templates/info.html:759
+#: templates/info.html:752
 msgid "System Data"
 msgstr "系統統計"
 
 #. Header of the information section about the computer running Pikaraoke.
-#: templates/info.html:764
+#: templates/info.html:757
 msgid "System Info"
 msgstr "系統資訊"
 
 #. The hardware platform
-#: templates/info.html:770
+#: templates/info.html:763
 msgid "Platform:"
 msgstr "平台："
 
 #. The os version
-#: templates/info.html:772
+#: templates/info.html:765
 msgid "OS Version:"
 msgstr "作業系統版本："
 
 #. The version of the program "yt-dlp".
-#: templates/info.html:774
+#: templates/info.html:767
 msgid "yt-dlp version:"
 msgstr "yt-dlp 版本："
 
 #. The version of the program "ffmpeg".
-#: templates/info.html:776
+#: templates/info.html:769
 msgid "FFmpeg version:"
 msgstr "FFmpeg 版本："
 
 #. The version of Pikaraoke running right now.
-#: templates/info.html:778
+#: templates/info.html:771
 msgid "Pikaraoke version:"
 msgstr "卡拉OK派版本："
 
 #. Header of the information section about the System stats.
-#: templates/info.html:784
+#: templates/info.html:777
 msgid "System stats"
 msgstr "系統統計"
 
 # auto-translated
 #. The CPU usage of the computer running Pikaraoke.
-#: templates/info.html:790
+#: templates/info.html:783
 msgid "CPU:"
 msgstr "中央處理器："
 
 # auto-translated
-#: templates/info.html:790 templates/info.html:792 templates/info.html:794
+#: templates/info.html:783 templates/info.html:785 templates/info.html:787
 msgid "Loading..."
 msgstr "載入中..."
 
 # auto-translated
 #. The disk usage of the computer running Pikaraoke. Used by downloaded songs.
-#: templates/info.html:792
+#: templates/info.html:785
 msgid "Disk Usage:"
 msgstr "磁碟使用情況："
 
 # auto-translated
 #. The memory (RAM) usage of the computer running Pikaraoke.
-#: templates/info.html:794
+#: templates/info.html:787
 msgid "Memory:"
 msgstr "記憶："
 
 #. Title of the updates section.
-#: templates/info.html:801
+#: templates/info.html:794
 msgid "Updates"
 msgstr "更新"
 
 # auto-translated
 #. Label for the YT-DLP update on the updates section
-#: templates/info.html:806
+#: templates/info.html:799
 msgid "YT-DLP update"
 msgstr "YT-DLP 更新"
 
 #. Text explaining why you might want to update yt-dlp.
-#: templates/info.html:811
+#: templates/info.html:804
 #, python-format
 msgid ""
 "\n"
@@ -1554,13 +1566,13 @@ msgstr ""
 
 #. Text for the link which will try and update yt-dlp on the machine running
 #. Pikaraoke.
-#: templates/info.html:817
+#: templates/info.html:810
 msgid "Update yt-dlp"
 msgstr "更新 yt-dlp"
 
 #. Help text which explains why updating yt-dlp can fail. The log is a file on
 #. the machine running Pikaraoke.
-#: templates/info.html:821
+#: templates/info.html:814
 msgid ""
 "* This update link above may fail if you don't have proper file permissions.\n"
 "\t\t\t\t\t\t\tCheck the pikaraoke log for errors."
@@ -1569,19 +1581,19 @@ msgstr ""
 "    檢查卡拉OK派日誌以查看錯誤。"
 
 #. Title of the updates section.
-#: templates/info.html:834
+#: templates/info.html:827
 msgid "Other"
 msgstr "其他"
 
 #. Title for section containing a few other options on the Info page.
 #. Text for button
-#: templates/info.html:839 templates/info.html:851
+#: templates/info.html:832 templates/info.html:844
 msgid "Expand Raspberry Pi filesystem"
 msgstr "擴展樹莓派檔案系統"
 
 #. Explainitory text which explains why you might want to expand the
 #. filesystem.
-#: templates/info.html:844
+#: templates/info.html:837
 msgid ""
 "If you just installed the pre-built pikaraoke pi image and your SD card is larger than 4GB,\n"
 "\t\t\t\t\t\t\tyou may want to expand the filesystem to utilize the remaining space. You only need to do this once.\n"
@@ -1592,25 +1604,47 @@ msgstr ""
 "    這將重新啟動系統。"
 
 # auto-translated
-#. Message for the log out user from admin mode button.
-#: templates/info.html:866
-msgid "Click here to logout from admin mode."
-msgstr "按一下此處從管理模式登出。"
+#. Explains the admin password field when a password is already set.
+#: templates/info.html:859
+msgid ""
+"Change the administrator password. Every other device will need to log in "
+"again."
+msgstr "更改管理員密碼。所有其他裝置都需要重新登入。"
 
 # auto-translated
-#. Link which will log out the user from admin mode.
-#: templates/info.html:868
+#. Explains the admin password field when no password has been set.
+#: templates/info.html:862
+msgid ""
+"Everyone on the network is an admin. Set a password to keep the player "
+"controls, song editing and shutdown to yourself."
+msgstr "網路上的每個人都是管理員。設定密碼，讓您自行控製播放器、編輯歌曲和關機。"
+
+# auto-translated
+#. Button which saves a new administrator password.
+#: templates/info.html:871
+msgid "Save password"
+msgstr "儲存密碼"
+
+# auto-translated
+#. Button which removes the administrator password, making everyone an admin.
+#: templates/info.html:880
+msgid "Clear password"
+msgstr "清除密碼"
+
+# auto-translated
+#. Button which logs the user out of admin mode.
+#: templates/info.html:884
 msgid "Log out"
 msgstr "退出"
 
 #. Title of the section on shutting down / turning off the machine running
 #. Pikaraoke.
-#: templates/info.html:875
+#: templates/info.html:893
 msgid "Shutdown"
 msgstr "關機"
 
 #. Explainitory text which explains why to use the shutdown link.
-#: templates/info.html:882
+#: templates/info.html:900
 msgid ""
 "Don't just pull the plug! Always shut down your server properly to avoid "
 "data corruption."
@@ -1618,17 +1652,17 @@ msgstr "不要直接拔掉電源！始終正確關閉您的伺服器，以避免
 
 #. Text for button which turns off Pikaraoke for everyone using it at your
 #. house.
-#: templates/info.html:889
+#: templates/info.html:907
 msgid "Quit Pikaraoke"
 msgstr "退出卡拉OK派"
 
 #. Text for button which reboots the machine running Pikaraoke.
-#: templates/info.html:893
+#: templates/info.html:911
 msgid "Reboot System"
 msgstr "重新啟動系統"
 
 #. Text for button which turn soff the machine running Pikaraoke.
-#: templates/info.html:896
+#: templates/info.html:914
 msgid "Shutdown System"
 msgstr "關閉系統"
 
@@ -1685,60 +1719,102 @@ msgid "Start a session to queue for singers"
 msgstr "開始一個會話來排隊等待歌手"
 
 # auto-translated
-#: templates/queue.html:214
-msgid "Pending downloads"
-msgstr "待下載"
+#. Download phase shown while yt-dlp resolves the video, before any bytes
+#. arrive.
+#. Download phase shown while a failed download waits to start again. The
+#. attempt tag says it is a retry.
+#: templates/queue.html:178 templates/queue.html:180
+msgid "Preparing"
+msgstr "準備中"
 
 # auto-translated
-#: templates/queue.html:218
+#. Download phase shown while the video stream is transferring.
+#: templates/queue.html:182
+#, python-format
+msgid "Downloading video"
+msgstr "下載影片"
+
+# auto-translated
+#. Download phase shown while the separate audio stream is transferring.
+#: templates/queue.html:184
+#, python-format
+msgid "Downloading audio"
+msgstr "下載音訊"
+
+# auto-translated
+#. Download phase shown while ffmpeg combines the downloaded video and audio.
+#: templates/queue.html:186
+msgid "Merging"
+msgstr "合併"
+
+# auto-translated
+#. Download phase shown once the download has finished.
+#: templates/queue.html:188
+msgid "Complete"
+msgstr "已完成"
+
+# auto-translated
+#. Tag on the active download showing which attempt is running, e.g. "Retrying
+#. 2/5".
+#: templates/queue.html:191 templates/queue.html:275
 msgid "Retrying"
 msgstr "重試"
 
 # auto-translated
-#: templates/queue.html:219
+#: templates/queue.html:218
+msgid "ETA"
+msgstr "ETA"
+
+# auto-translated
+#: templates/queue.html:271
+msgid "Pending downloads"
+msgstr "待下載"
+
+# auto-translated
+#: templates/queue.html:276
 msgid "Queued"
 msgstr "排隊"
 
 # auto-translated
-#: templates/queue.html:231
+#: templates/queue.html:288
 msgid "Download Errors"
 msgstr "下載錯誤"
 
 # auto-translated
-#: templates/queue.html:240
+#: templates/queue.html:297
 msgid "Failed"
 msgstr "失敗的"
 
 # auto-translated
-#: templates/queue.html:241
+#: templates/queue.html:298
 msgid "Retry"
 msgstr "重試"
 
 # auto-translated
-#: templates/queue.html:242
+#: templates/queue.html:299
 msgid "Dismiss"
 msgstr "解僱"
 
 # auto-translated
-#: templates/queue.html:311
+#: templates/queue.html:371
 msgid "Drag to reorder"
 msgstr "拖曳以重新排序"
 
-#: templates/queue.html:351
+#: templates/queue.html:411
 msgid "The queue is empty"
 msgstr "播放列表是空的"
 
 # auto-translated
-#: templates/queue.html:449
+#: templates/queue.html:509
 msgid "Play"
 msgstr "玩"
 
-#: templates/queue.html:451 templates/queue.html:580
+#: templates/queue.html:511 templates/queue.html:629
 msgid "Pause"
 msgstr "暫停"
 
 # auto-translated
-#: templates/queue.html:522
+#: templates/queue.html:571
 msgid ""
 "Add <input id=\"randomNumberInput\" class=\"input mx-2 p-2\" "
 "pattern=\"\\d*\" maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" "
@@ -1748,60 +1824,60 @@ msgstr ""
 "maxlength=\"2\" value=\"3\" min=\"1\" max=\"99\" style=\"width: 42px\" /> "
 "隨機歌曲"
 
-#: templates/queue.html:526
+#: templates/queue.html:575
 msgid "Clear all"
 msgstr "清除全部"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Play Next"
 msgstr "播放下一個"
 
 # auto-translated
-#: templates/queue.html:540
+#: templates/queue.html:589
 msgid "Move to Top"
 msgstr "移至頂部"
 
 # auto-translated
-#: templates/queue.html:544
+#: templates/queue.html:593
 msgid "Move Up"
 msgstr "向上移動"
 
 # auto-translated
-#: templates/queue.html:548
+#: templates/queue.html:597
 msgid "Move Down"
 msgstr "下移"
 
 # auto-translated
-#: templates/queue.html:552
+#: templates/queue.html:601
 msgid "Move to Bottom"
 msgstr "移至底部"
 
 # auto-translated
 #. Menu item which changes the name of a session that already has one.
 #. Button which changes the name of the session that is currently running.
-#: templates/queue.html:556 templates/sessions.html:43
-#: templates/sessions.html:651
+#: templates/queue.html:605 templates/sessions.html:43
+#: templates/sessions.html:650
 msgid "Rename"
 msgstr "重新命名"
 
 # auto-translated
-#: templates/queue.html:560
+#: templates/queue.html:609
 msgid "Remove from Queue"
 msgstr "從佇列中刪除"
 
 # auto-translated
-#: templates/queue.html:576
+#: templates/queue.html:625
 msgid "Restart"
 msgstr "重新啟動"
 
 # auto-translated
-#: templates/queue.html:584
+#: templates/queue.html:633
 msgid "Skip"
 msgstr "跳過"
 
 # auto-translated
-#: templates/queue.html:592
+#: templates/queue.html:641
 msgid "Download queue"
 msgstr "下載隊列"
 
@@ -1820,25 +1896,25 @@ msgstr "秩"
 # auto-translated
 #. Ranking table column header for how many times something was played.
 #. Session list column header for how many songs were played.
-#: templates/rankings.html:48 templates/sessions.html:689
+#: templates/rankings.html:48 templates/sessions.html:688
 msgid "Plays"
 msgstr "戲劇"
 
 # auto-translated
 #. Heading for the list of songs that have been sung the most times.
-#: templates/rankings.html:119
+#: templates/rankings.html:118
 msgid "Top songs"
 msgstr "熱門歌曲"
 
 # auto-translated
 #. Heading for the list of people who have sung the most songs.
-#: templates/rankings.html:167
+#: templates/rankings.html:166
 msgid "Top performers"
 msgstr "表現最佳者"
 
 # auto-translated
 #. Shown on the rankings page when nobody has sung anything yet.
-#: templates/rankings.html:194
+#: templates/rankings.html:193
 msgid "Nobody has sung yet."
 msgstr "還沒有人唱歌。"
 
@@ -1851,7 +1927,7 @@ msgstr "新增..."
 
 # auto-translated
 #. Badge on a YouTube search result marking a song that is already downloaded.
-#: templates/search.html:376 templates/search.html:626
+#: templates/search.html:376 templates/search.html:623
 msgid "In library"
 msgstr "在圖書館"
 
@@ -1859,49 +1935,49 @@ msgstr "在圖書館"
 #. Subtitle under the Add New heading, explaining that this page gets songs
 #. the
 #. machine does not have.
-#: templates/search.html:520
+#: templates/search.html:517
 msgid "Add new songs from YouTube"
 msgstr "新增 YouTube 的新歌曲"
 
 # auto-translated
 #. Placeholder in the box used to search YouTube for a song to download.
-#: templates/search.html:534
+#: templates/search.html:531
 msgid "Search YouTube by title, artist..."
 msgstr "按標題、藝術家搜尋 YouTube..."
 
 #. Submit button on the search form for searching YouTube.
-#: templates/search.html:540
+#: templates/search.html:537
 msgid "Search"
 msgstr "搜尋"
 
 #. Checkbox label which enables matching songs which are not karaoke versions
 #. (i.e. the songs still                                 have a singer and are
 #. not just instrumentals.)
-#: templates/search.html:550
+#: templates/search.html:547
 msgid "Include non-karaoke matches"
 msgstr "包含非卡拉OK版本"
 
 #. Link which reveals the direct-URL download form.
-#: templates/search.html:556
+#: templates/search.html:553
 msgid "Advanced"
 msgstr "進階"
 
 # auto-translated
 #. Label for an input which takes a YouTube url directly instead of searching
 #. titles.
-#: templates/search.html:564
+#: templates/search.html:561
 msgid "Paste a YouTube url:"
 msgstr "貼上 YouTube 網址："
 
 # auto-translated
 #. Button which downloads a song into the library without queuing it.
-#: templates/search.html:584 templates/search.html:662
+#: templates/search.html:581 templates/search.html:659
 msgid "Save for later"
 msgstr "儲存以供稍後使用"
 
 #. Html text which displays what was searched for, in quotes while the page is
 #. loading.
-#: templates/search.html:603
+#: templates/search.html:600
 #, python-format
 msgid ""
 "Searching YouTube for\n"
@@ -1912,7 +1988,7 @@ msgstr ""
 
 # auto-translated
 #. Html text which displays what was searched for, in quotes.
-#: templates/search.html:610
+#: templates/search.html:607
 #, python-format
 msgid ""
 "Search results for\n"
@@ -1922,7 +1998,7 @@ msgstr ""
 "\t\t\t<small><i>'%(search_string)s'</i></small>"
 
 # auto-translated
-#: templates/search.html:676
+#: templates/search.html:673
 msgid ""
 "Preview unavailable for this video. Use the YouTube link on the result to "
 "watch it."
@@ -2009,86 +2085,86 @@ msgstr "展示這些劇目"
 
 # auto-translated
 #. Heading for the section showing the session currently being recorded.
-#: templates/sessions.html:625
+#: templates/sessions.html:624
 msgid "Current Session"
 msgstr "目前會話"
 
 # auto-translated
 #. Placeholder inside the box naming a session as it is started.
-#: templates/sessions.html:642
+#: templates/sessions.html:641
 msgid "Name this session..."
 msgstr "將此會話命名..."
 
 # auto-translated
 #. Button which starts a new play history session.
-#: templates/sessions.html:648
+#: templates/sessions.html:647
 msgid "Start session"
 msgstr "開始會話"
 
 # auto-translated
 #. Button which closes the session that is currently running.
 #. Menu item which closes the session that is currently running.
-#: templates/sessions.html:654 templates/sessions.html:714
+#: templates/sessions.html:653 templates/sessions.html:713
 msgid "End session"
 msgstr "結束會話"
 
 # auto-translated
 #. Heading for the list of past karaoke sessions.
-#: templates/sessions.html:660
+#: templates/sessions.html:659
 msgid "Session History"
 msgstr "會話歷史記錄"
 
 # auto-translated
 #. Checkbox which hides the sessions PiKaraoke started on its own, which the
 #. host never named.
-#: templates/sessions.html:669
+#: templates/sessions.html:668
 msgid "Hide auto-started"
 msgstr "隱藏自動啟動"
 
 # auto-translated
 #. Session list column header for the session name.
 #. Label before the dropdown choosing which karaoke session a page reports on.
-#: templates/partials/session_filter.html:14 templates/sessions.html:685
+#: templates/partials/session_filter.html:14 templates/sessions.html:684
 msgid "Session"
 msgstr "會議"
 
 # auto-translated
 #. Session list column header for when the session started.
-#: templates/sessions.html:687
+#: templates/sessions.html:686
 msgid "Started"
 msgstr "開始"
 
 # auto-translated
 #. Menu item which makes an old session the one new songs are recorded
 #. against.
-#: templates/sessions.html:709
+#: templates/sessions.html:708
 msgid "Make active"
 msgstr "啟用設定"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a CSV file for
 #. spreadsheets.
-#: templates/sessions.html:719
+#: templates/sessions.html:718
 msgid "Export CSV"
 msgstr "匯出 CSV"
 
 # auto-translated
 #. Menu item which downloads the session's play log as a plain-text,
 #. human-readable set list.
-#: templates/sessions.html:724
+#: templates/sessions.html:723
 msgid "Export list (text)"
 msgstr "匯出清單（文字）"
 
 # auto-translated
 #. Menu item which deletes every play in the session but keeps the session
 #. itself.
-#: templates/sessions.html:735
+#: templates/sessions.html:734
 msgid "Clear plays"
 msgstr "清晰的戲劇"
 
 # auto-translated
 #. Menu item which deletes the session and every play recorded in it.
-#: templates/sessions.html:740
+#: templates/sessions.html:739
 msgid "Delete session"
 msgstr "刪除會話"
 


### PR DESCRIPTION
**Why:** A German, Japanese or Thai guest sees the admin password settings, the download phases and the rename refusal in English. Those strings have gone untranslated since 1.22.0.

- Regenerated all fifteen catalogs against master: 5 obsolete strings pruned, 15 added, 368 entries each with nothing untranslated or fuzzy.
- Corrected `ETA` in nine locales, where Google Translate expanded the acronym to its transit sense and Thai came back as the Expressway Authority of Thailand.
- Corrected `Complete` in fourteen locales, which read as the adjective meaning full or perfect, and Spanish `Preparing`, which came back as a non-word.
- The run now lists the one-word strings it wrote, across locales. Every sense error above was a one-word msgid, and the placeholder check cannot catch them because it validates structure and these were structurally perfect.
