### PR TITLE
fix: resolve previews under the android client

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -251,16 +251,23 @@ PREVIEW_FORMAT = (
     "/worst[protocol=https][vcodec!=none][acodec!=none]"
 )
 
-# YouTube answers 403 to a freshly resolved itag 18 URL often enough that it has to be
-# proven here: downloads survive it by retrying, a <video> element gets one attempt.
-# Two consecutive refusals then a working URL is a routinely observed sequence.
+# The SABR rollout is session-dependent, so even a good client is occasionally refused,
+# and a <video> element gets one attempt at a bad URL.
 _PREVIEW_ATTEMPTS = 3
 _VERIFY_TIMEOUT_SECONDS = 5
 
 
 def _resolve_stream_url(video_url: str) -> str | None:
     """Ask yt-dlp for a progressive stream URL. No guarantee it will serve bytes."""
-    cmd = yt_dlp_cmd + ["-g", "-f", PREVIEW_FORMAT] + _js_runtime_args()
+    # YouTube refuses the stream URLs yt-dlp's default client resolves, but serves android's.
+    cmd = yt_dlp_cmd + [
+        "-g",
+        "-f",
+        PREVIEW_FORMAT,
+        "--extractor-args",
+        "youtube:player_client=android",
+    ]
+    cmd += _js_runtime_args()
     cmd += [video_url]
     logging.debug(f"yt-dlp get stream URL command: {' '.join(cmd)}")
     try:

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -275,6 +275,15 @@ class TestGetStreamUrl:
             assert "[vcodec!=none][acodec!=none]" in fmt
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
+    def test_requests_android_player_client(self, mock_js):
+        """Test the client is pinned; the default resolves itag 18 then is refused on it."""
+        with self._run_with_output(b"https://rr1.googlevideo.com/videoplayback?x=1\n") as mock_run:
+            with self._serving(True):
+                get_stream_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            cmd = mock_run.call_args[0][0]
+            assert cmd[cmd.index("--extractor-args") + 1] == "youtube:player_client=android"
+
+    @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_returns_progressive_url(self, mock_js):
         """Test that a verified progressive URL is returned."""
         url = "https://rr1.googlevideo.com/videoplayback?itag=18"


### PR DESCRIPTION
**Why:** A guest tapping a search thumbnail today gets a spinner and then an error, every time. This restores the preview, so they can check a track is the right version before queuing it.

- `_resolve_stream_url` now passes `--extractor-args youtube:player_client=android`. yt-dlp's default client, `android_vr`, still resolves itag 18 but YouTube refuses every URL it hands back — measured 2026-08-28 across ten live search results, 0 served bytes under the default and 10 under `android`. The format selector was never the problem, which is why the format tweaks in `download-403-and-capacity-2026-08-17.md` did not reach this.
- Corrected the comment above `_PREVIEW_ATTEMPTS`. It claimed a freshly resolved itag 18 URL is refused "often enough that it has to be proven here", which described `android_vr`'s roughly even odds. Under `android` nothing was refused in 22 probes, so the retry now earns its place as insurance against a session-dependent SABR rollout rather than against a coin flip. The count stays at 3.
- Added a test asserting the client is pinned, alongside the existing format-selector test.

## Test plan

- [x] Search for something, tap a thumbnail: the video plays in the modal rather than showing the error.
- [x] Tap a second thumbnail while the first is still loading: the modal shows the one you tapped last.
- [x] Close the modal mid-playback: audio stops.
- [x] Downloads still work — the change is confined to the preview path.
