### PR TITLE
chore: stop mdformat rewriting line endings

### DIFF
--- a/code_quality/.pre-commit-config.yaml
+++ b/code_quality/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     name: Format Markdown Files
     additional_dependencies:
     - mdformat-black
-    args: [--number]
+    args: [--number, --end-of-line=keep]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0


### PR DESCRIPTION
**Why:** the maintainer runs the pre-commit suite and gets a clean tree back, instead of an unrelated `pikaraoke/_TRANSLATION.md` left sitting in `git status` afterwards, waiting to be swept into the next `git add -A`.

- Pass `--end-of-line=keep` to the mdformat hook. It defaults to `lf`, so every run stripped the CR from all 142 lines of `_TRANSLATION.md`, while `core.autocrlf` checks that file out as CRLF.
- The hook reported "Passed" the whole time, because pre-commit's own modification check runs through `git diff`, which applies the same CRLF-to-LF filter and so sees nothing. The file went dirty with an empty diff, which is why it never looked like a hook's doing.
- Only `_TRANSLATION.md` was affected. `CHANGELOG.md`, `bug_report.md` and `feature_request.md` are already covered by the global `exclude`, and the remaining two markdown files are formatted the way mdformat wants them.

