### PR TITLE
chore: make the docstring coverage job scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,7 @@ jobs:
     - name: Docstring Coverage
       run: |
         mkdir -p docs/badges/ docstr
-        mv code_quality/.docstr.yaml . # --config option didn't work
-        docstr-coverage 2>&1 | tee docstr/docstring_coverage.txt
-        ls docs/badges
+        docstr-coverage --config code_quality/.docstr.yaml pikaraoke/ 2>&1 | tee docstr/docstring_coverage.txt
 
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Why:** the maintainer gets a real coverage figure out of CI - 84.9% across 52 files - where the step has measured nothing since it was added in August 2024.

- Pass `pikaraoke/` to `docstr-coverage`. Its `paths` is `nargs=-1` with no default, so running it bare aborted with "No Python files found". `fail_under: 0` kept the step green, so it never surfaced.
- Drop the `mv code_quality/.docstr.yaml .` workaround. `--config` works in the pinned 2.3.2; the original failure was the missing path, not the flag.
- `fail_under` stays 0 - this reports a number, it does not start enforcing one.
