### PR TITLE
chore: bump the pinned hook versions

### DIFF
--- a/code_quality/.pre-commit-config.yaml
+++ b/code_quality/.pre-commit-config.yaml
@@ -10,25 +10,25 @@ repos:
   # Python tools
   # ----------------------------------------------------------------------------------------------
 - repo: https://github.com/hadialqattan/pycln
-  rev: v2.5.0
+  rev: v2.6.0
   hooks:
   - id: pycln
     name: Remove Unused Python Imports
     args: [--exclude, conftest.py]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 9.0.1
   hooks:
   - id: isort
     name: Sort Python Imports
     args: [--profile=black]
 
 - repo: https://github.com/psf/black
-  rev: 23.11.0
+  rev: 26.5.1
   hooks:
   - id: black
     name: Format Python Code
-    args: [--line-length, '100']
+    args: [--line-length, '100', --target-version, py310]
 
   # Run from the project environment, not an isolated one: pylint infers types
   # through imports, and without the project's dependencies installed it reports
@@ -43,7 +43,7 @@ repos:
     require_serial: true
 
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.17
+  rev: 1.0.0
   hooks:
   - id: mdformat
     name: Format Markdown Files
@@ -52,7 +52,7 @@ repos:
     args: [--number, --end-of-line=keep]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
     # Vendored assets and generated catalogs are not ours to reformat.

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -24,20 +24,20 @@ _PATH_SEPARATORS = re.compile(r"[/\\]")
 
 EMOJI_PATTERN = re.compile(
     "["
-    "\U0001F1E0-\U0001F1FF"
-    "\U0001F300-\U0001F5FF"
-    "\U0001F600-\U0001F64F"
-    "\U0001F680-\U0001F6FF"
-    "\U0001F700-\U0001F77F"
-    "\U0001F780-\U0001F7FF"
-    "\U0001F800-\U0001F8FF"
-    "\U0001F900-\U0001F9FF"
-    "\U0001FA00-\U0001FA6F"
-    "\U0001FA70-\U0001FAFF"
-    "\U00002702-\U000027B0"
-    "\U000024C2-\U000024FF"  # enclosed alphanumerics
-    "\U00002600-\U000026FF"  # miscellaneous symbols
-    "\U0001F200-\U0001F251"  # enclosed ideographic supplement
+    "\U0001f1e0-\U0001f1ff"
+    "\U0001f300-\U0001f5ff"
+    "\U0001f600-\U0001f64f"
+    "\U0001f680-\U0001f6ff"
+    "\U0001f700-\U0001f77f"
+    "\U0001f780-\U0001f7ff"
+    "\U0001f800-\U0001f8ff"
+    "\U0001f900-\U0001f9ff"
+    "\U0001fa00-\U0001fa6f"
+    "\U0001fa70-\U0001faff"
+    "\U00002702-\U000027b0"
+    "\U000024c2-\U000024ff"  # enclosed alphanumerics
+    "\U00002600-\U000026ff"  # miscellaneous symbols
+    "\U0001f200-\U0001f251"  # enclosed ideographic supplement
     "]+"
 )
 

--- a/pikaraoke/lib/play_history_manager.py
+++ b/pikaraoke/lib/play_history_manager.py
@@ -281,12 +281,10 @@ class PlayHistoryManager:
     def get_current_session(self) -> dict | None:
         """Return the open session, or None if none is active."""
         if not self._session_cached:
-            rows = self.db.query(
-                f"""
+            rows = self.db.query(f"""
                 SELECT id, uuid, name, {_local("started_at", "started_at")}, ended_at
                 FROM sessions WHERE ended_at IS NULL ORDER BY id DESC LIMIT 1
-                """
-            )
+                """)
             self._cached_session = dict(rows[0]) if rows else None
             self._session_cached = True
         return self._cached_session

--- a/pikaraoke/routes/images.py
+++ b/pikaraoke/routes/images.py
@@ -1,4 +1,5 @@
 """Image serving routes for QR code and logo."""
+
 import os
 
 import flask_babel

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -381,14 +381,12 @@ class TestUpgradeYoutubedl:
         error = subprocess.CalledProcessError(1, "yt-dlp", pip_message)
         error.output = pip_message
 
-        with patch(
-            "pikaraoke.lib.youtube_dl.get_youtubedl_version", return_value="2024.02.01"
-        ), patch("shutil.which", return_value=None), patch(
-            "subprocess.check_output"
-        ) as mock_check, patch(
-            "pikaraoke.lib.youtube_dl.sys.prefix", "/venv"
-        ), patch(
-            "pikaraoke.lib.youtube_dl.sys.base_prefix", "/different"
+        with (
+            patch("pikaraoke.lib.youtube_dl.get_youtubedl_version", return_value="2024.02.01"),
+            patch("shutil.which", return_value=None),
+            patch("subprocess.check_output") as mock_check,
+            patch("pikaraoke.lib.youtube_dl.sys.prefix", "/venv"),
+            patch("pikaraoke.lib.youtube_dl.sys.base_prefix", "/different"),
         ):
             # First call raises error suggesting pip, second call succeeds
             mock_check.side_effect = [error, b"Successfully installed yt-dlp"]
@@ -408,14 +406,12 @@ class TestUpgradeYoutubedl:
         error = subprocess.CalledProcessError(1, "yt-dlp", pip_message)
         error.output = pip_message
 
-        with patch(
-            "pikaraoke.lib.youtube_dl.get_youtubedl_version", return_value="2024.02.01"
-        ), patch("shutil.which", return_value=None), patch(
-            "subprocess.check_output"
-        ) as mock_check, patch(
-            "pikaraoke.lib.youtube_dl.sys.prefix", "/usr"
-        ), patch(
-            "pikaraoke.lib.youtube_dl.sys.base_prefix", "/usr"
+        with (
+            patch("pikaraoke.lib.youtube_dl.get_youtubedl_version", return_value="2024.02.01"),
+            patch("shutil.which", return_value=None),
+            patch("subprocess.check_output") as mock_check,
+            patch("pikaraoke.lib.youtube_dl.sys.prefix", "/usr"),
+            patch("pikaraoke.lib.youtube_dl.sys.base_prefix", "/usr"),
         ):
             # First call raises error suggesting pip, second call succeeds
             mock_check.side_effect = [error, b"Successfully installed yt-dlp"]


### PR DESCRIPTION
**Why:** the maintainer's formatters pick up three years of upstream fixes, and black stops warning that it cannot verify its own output.

- `pre-commit autoupdate`: pycln v2.6.0, isort 9.0.1, black 26.5.1, mdformat 1.0.0, pre-commit-hooks v6.0.0.
- isort, mdformat and pre-commit-hooks change no files, across four, one and two major versions. mdformat 1.0 still honours `--end-of-line=keep`, so #913 holds.
- black reformats four files in its 24 stable style: a blank line after a module docstring, lowercase unicode escapes, a multiline string hugging its parens, and parenthesized context managers replacing a backslash pileup in `test_youtube_dl.py`.
- Pin `--target-version py310` to the `requires-python` floor. Without it black 26 warns its AST safety check cannot verify output aimed at a newer Python than the runner's.

## Test plan

- [x] `uv run pre-commit run ... --all-files` passes with no black warning, and a second run changes nothing
- [x] `uv run pytest tests/ -q` passes
- [x] `pikaraoke/_TRANSLATION.md` stays CRLF, so #913 has not regressed
