### PR TITLE
fix: log in under a URL base path

### DIFF
--- a/pikaraoke/routes/admin.py
+++ b/pikaraoke/routes/admin.py
@@ -29,9 +29,6 @@ class AdminPasswordForm(Schema):
 
 class AuthForm(Schema):
     admin_password = fields.String(load_default="", metadata={"description": "Admin password"})
-    next = fields.String(
-        load_default="/", metadata={"description": "URL to redirect to after login"}
-    )
 
 
 def delayed_halt(cmd: int, k: Karaoke):
@@ -138,12 +135,6 @@ def expand_fs():
 @admin_bp.arguments(AuthForm, location="form")
 def auth(form):
     """Authenticate as admin."""
-    next_url = form["next"]
-
-    # Validate next_url to prevent open redirect vulnerabilities
-    if not next_url.startswith("/"):
-        next_url = "/"
-
     admin_auth = get_admin_auth()
     if admin_auth.verify(form["admin_password"]):
         session["admin"] = admin_auth.session_token
@@ -153,7 +144,8 @@ def auth(form):
     else:
         # MSG: Message shown after failing to login as admin
         flash(_("Incorrect admin password!"), "is-danger")
-    return redirect(next_url)
+    # The login form only renders on the info page, so that is where login ends.
+    return redirect(url_for("info.info"))
 
 
 @admin_bp.route("/admin_password", methods=["POST"])

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -336,7 +336,7 @@
 					{# MSG: Title fo the form to enter the administrator password. #}
 					<p>{% trans %}Enter the administrator password{% endtrans %}</p>
 					<form action="{{ url_for('admin.auth') }}" method="post">
-						<input type="hidden" name="next" value="{{ request.path }}" />
+						<input type="hidden" name="next" value="{{ request.script_root }}{{ request.path }}" />
 						<div class="field has-addons mb-2">
 							<div class="control" style="width: 100%; max-width: 350px">
 								<input type="password" name="admin_password" class="input" autocomplete="current-password" />

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -336,7 +336,6 @@
 					{# MSG: Title fo the form to enter the administrator password. #}
 					<p>{% trans %}Enter the administrator password{% endtrans %}</p>
 					<form action="{{ url_for('admin.auth') }}" method="post">
-						<input type="hidden" name="next" value="{{ request.script_root }}{{ request.path }}" />
 						<div class="field has-addons mb-2">
 							<div class="control" style="width: 100%; max-width: 350px">
 								<input type="password" name="admin_password" class="input" autocomplete="current-password" />

--- a/tests/unit/test_admin_routes.py
+++ b/tests/unit/test_admin_routes.py
@@ -47,7 +47,7 @@ def client(app):
 
 
 def _login(client, password=PASSWORD):
-    return client.post("/auth", data={"admin_password": password, "next": "/info"})
+    return client.post("/auth", data={"admin_password": password})
 
 
 class TestAdminCookieAttributes:


### PR DESCRIPTION
**Why:** an admin running PiKaraoke behind a path prefix (`--base-path /karaoke`, or a reverse proxy that strips one) can log in. Today the form takes the password, sets the cookie, then bounces them somewhere the cookie is never sent, so a correct password is indistinguishable from a wrong one.

## What broke it

#819 introduced `BasePathMiddleware`, which strips the prefix into `SCRIPT_NAME` before any template renders. From that commit on, `request.path` returned `/info` where a browser needs `/karaoke/info`. The login form had been passing `request.path` straight into a hidden `next` field since March, correct until the middleware existed, and #819 swept the templates and JS for exactly this without reaching it — it edited `info.html` 130 lines above the form, changing the socket.io path and nothing else.

## Changes

- **`next` is deleted rather than prefixed**: the login form renders only on the info page, so the field had one producer and one possible value. `auth()` now ends on `url_for("info.info")`, which composes `SCRIPT_NAME` itself and cannot drift out of step with the middleware.
- **The open redirect goes with it**: `auth()` redirected to `next` whether or not the password verified, and the `startswith("/")` guard admits `//evil.com` as protocol-relative. With no caller-supplied target there is nothing to forge.

## Notes

Rendering `info.html` in a test costs about forty-five mocked template variables for one assertion, so this is verified by hand below.

A tab left open across the upgrade still posts `next` and gets a 422 until it is reloaded.

## Test plan

- [x] `--base-path /karaoke`: log in from `/karaoke/info`, land back there as admin
- [x] Wrong password, same page: still refused, still on `/karaoke/info`
- [x] No base path: log in from `/info`, unchanged
