### PR TITLE
Ops: Warn on startup if binding to public IP address

### DIFF
--- a/pikaraoke/karaoke.py
+++ b/pikaraoke/karaoke.py
@@ -33,6 +33,7 @@ from pikaraoke.lib.network import get_ip
 from pikaraoke.lib.play_history_manager import PlayHistoryManager
 from pikaraoke.lib.playback_controller import PlaybackController
 from pikaraoke.lib.preference_manager import PreferenceManager
+from pikaraoke.lib.security_checks import warn_if_internet_exposed
 from pikaraoke.lib.queue_manager import QueueManager
 from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.lib.sound_manager import SoundManager
@@ -312,6 +313,9 @@ class Karaoke:
             additional_ytdl_args=self.additional_ytdl_args,
         )
         self.download_manager.start()
+
+        # Check for internet exposure and warn if detected
+        warn_if_internet_exposed(self.port, self.url)
 
         # Song library startup: warm cache from DB or blocking cold scan
         paths = self.db.get_all_song_paths()

--- a/pikaraoke/lib/security_checks.py
+++ b/pikaraoke/lib/security_checks.py
@@ -1,0 +1,65 @@
+"""Startup security checks for PiKaraoke."""
+
+import ipaddress
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _is_public_ip(ip: str) -> bool:
+    """Determine if an IP address is public (internet routable).
+
+    Args:
+        ip: IP address string.
+
+    Returns:
+        True if the IP is public, False if it is private/reserved.
+    """
+    try:
+        addr = ipaddress.ip_address(ip)
+        return not addr.is_private and not addr.is_loopback and not addr.is_reserved
+    except ValueError:
+        return False
+
+
+def check_internet_exposure(port: int, bind_address: Optional[str] = None) -> bool:
+    """Check if PiKaraoke appears to be internet exposed.
+
+    Args:
+        port: The port PiKaraoke is listening on.
+        bind_address: The address PiKaraoke is bound to (None = all interfaces).
+
+    Returns:
+        True if likely internet exposed, False otherwise.
+    """
+    if bind_address is None or bind_address == "0.0.0.0" or bind_address == "::":
+        return True
+
+    return _is_public_ip(bind_address)
+
+
+def warn_if_internet_exposed(port: int, url: Optional[str] = None) -> None:
+    """Log a warning if PiKaraoke appears internet exposed.
+
+    Args:
+        port: The port PiKaraoke is listening on.
+        url: The full URL being served (e.g., "http://192.168.1.5:5555").
+    """
+    if not url:
+        return
+
+    if url.startswith("http://") or url.startswith("https://"):
+        try:
+            host_part = url.split("://")[1].split(":")[0]
+            if _is_public_ip(host_part):
+                logger.warning(
+                    "SECURITY WARNING: PiKaraoke appears to be internet exposed. "
+                    "A public IP address detected. Ensure proper network controls are in place. "
+                    "Recommend: use a VPN, run behind a reverse proxy with authentication, or restrict network access."
+                )
+                return
+        except (IndexError, ValueError):
+            pass
+
+    logger.debug("PiKaraoke startup: no public IP detected, appears to be LAN-only")


### PR DESCRIPTION
Adds security check at startup that detects if PiKaraoke is bound to a public IPv4 address and logs a SECURITY WARNING with remediation steps.

Threat model: PiKaraoke is designed for trusted LANs only. Accidental binding to a public IP (e.g., via port forwarding misconfiguration or cloud VM public IP) exposes an unauthenticated service to the internet. This detection enables operators to catch misconfiguration early.

Private ranges recognized:
- 10.0.0.0/8
- 172.16.0.0/12
- 192.168.0.0/16
- 127.0.0.0/8 (loopback)

Anything else is flagged. Does not block startup; logs a warning and recommends VPN, reverse proxy, or firewall rules.

Impact: Startup log will include one additional security check. Zero functional impact on normal (LAN-only) deployments.

## Testing
- [x] No functional regression in existing workflows
- [x] Admin authentication still required for protected operations
- [x] Backward compatible with existing deployments

Created and Prepared By: DJ Council-Nieves (@djkidnyce)