### PR TITLE
fix: gate the mic socket handlers on admin

### DIFF
--- a/pikaraoke/routes/socket_events.py
+++ b/pikaraoke/routes/socket_events.py
@@ -1,14 +1,33 @@
 """Socket.IO event handlers for PiKaraoke."""
 
 import logging
+from collections.abc import Callable
+from functools import wraps
 
 from flask import request
 
-from pikaraoke.lib.current_app import get_karaoke_instance
+from pikaraoke.lib.current_app import get_karaoke_instance, is_admin
 
 # Track connected splash screen clients and the elected master
 splash_connections = set()
 master_splash_id = None
+
+
+def _guard(handler: Callable) -> Callable:
+    """Drop an event from a client with no admin session.
+
+    Refusing costs no reply: the only control that sends a host-only event is
+    itself host-only in the template.
+    """
+
+    @wraps(handler)
+    def guarded(*args, **kwargs):
+        if not is_admin():
+            logging.warning(f"Refused {handler.__name__}: no admin session")
+            return None
+        return handler(*args, **kwargs)
+
+    return guarded
 
 
 def setup_socket_events(socketio):
@@ -18,7 +37,22 @@ def setup_socket_events(socketio):
         socketio: The SocketIO instance.
     """
 
-    @socketio.on("end_song")
+    # The route gate is a before_request and never sees this surface, so each
+    # handler names its own audience instead. Registering through neither of
+    # these is the one way to open an event by accident, and the tests fail on
+    # a handler that appears in neither roster.
+    open_to_room = socketio.on
+
+    def host_only(event: str) -> Callable:
+        """Register a handler a guest's emit must not reach."""
+
+        def register(handler: Callable) -> Callable:
+            socketio.on(event)(_guard(handler))
+            return handler
+
+        return register
+
+    @open_to_room("end_song")
     def end_song(reason: str) -> None:
         """Handle end_song WebSocket event from client.
 
@@ -28,19 +62,19 @@ def setup_socket_events(socketio):
         k = get_karaoke_instance()
         k.playback_controller.end_song(reason)
 
-    @socketio.on("start_song")
+    @open_to_room("start_song")
     def start_song() -> None:
         """Handle start_song WebSocket event when playback begins."""
         k = get_karaoke_instance()
         k.playback_controller.start_song()
 
-    @socketio.on("clear_notification")
+    @open_to_room("clear_notification")
     def clear_notification() -> None:
         """Handle clear_notification WebSocket event to dismiss notifications."""
         k = get_karaoke_instance()
         k.reset_now_playing_notification()
 
-    @socketio.on("register_splash")
+    @open_to_room("register_splash")
     def register_splash() -> None:
         """Handle splash screen registration and assign master/slave roles."""
         global master_splash_id
@@ -56,7 +90,7 @@ def setup_socket_events(socketio):
             socketio.emit("splash_role", "slave", room=sid)
             logging.info(f"Slave splash screens assigned: {sid}")
 
-    @socketio.on("playback_position")
+    @open_to_room("playback_position")
     def handle_playback_position(position: float) -> None:
         """Handle playback_position WebSocket event from the master splash screen.
 
@@ -71,7 +105,7 @@ def setup_socket_events(socketio):
             # Broadcast position to all other splash screens (slaves)
             socketio.emit("playback_position", position, include_self=False)
 
-    @socketio.on("disconnect")
+    @open_to_room("disconnect")
     def handle_disconnect() -> None:
         """Handle Socket.IO client disconnection and manage splash role handover."""
         global master_splash_id
@@ -89,7 +123,7 @@ def setup_socket_events(socketio):
                     socketio.emit("splash_role", "master", room=new_master)
                     logging.info(f"New master splash elected: {new_master}")
 
-    @socketio.on("request_mic_devices")
+    @host_only("request_mic_devices")
     def handle_request_mic_devices() -> None:
         """Client requests the current mic device list from the server."""
         k = get_karaoke_instance()
@@ -99,7 +133,7 @@ def setup_socket_events(socketio):
             room=request.sid,
         )
 
-    @socketio.on("request_mic_settings")
+    @host_only("request_mic_settings")
     def handle_request_mic_settings() -> None:
         """Client requests current mic global settings (latency, echo cancel)."""
         k = get_karaoke_instance()
@@ -109,7 +143,7 @@ def setup_socket_events(socketio):
             room=request.sid,
         )
 
-    @socketio.on("mic_latency_change")
+    @host_only("mic_latency_change")
     def handle_mic_latency_change(data: dict) -> None:
         """Handle mic latency change from control UI."""
         k = get_karaoke_instance()
@@ -117,7 +151,7 @@ def setup_socket_events(socketio):
         state = k.sound_manager.set_latency_ms(latency_ms)
         socketio.emit("mic_settings_state", state)
 
-    @socketio.on("mic_echo_cancel_change")
+    @host_only("mic_echo_cancel_change")
     def handle_mic_echo_cancel_change(data: dict) -> None:
         """Handle echo cancellation toggle from control UI."""
         k = get_karaoke_instance()
@@ -125,14 +159,14 @@ def setup_socket_events(socketio):
         state = k.sound_manager.set_echo_cancel(enabled)
         socketio.emit("mic_settings_state", state)
 
-    @socketio.on("mic_refresh")
+    @host_only("mic_refresh")
     def handle_mic_refresh() -> None:
         """Re-enumerate mic and output devices server-side and broadcast updated lists."""
         k = get_karaoke_instance()
         enriched = k.sound_manager.refresh()
         socketio.emit("mic_devices_state", enriched)
 
-    @socketio.on("mic_update")
+    @host_only("mic_update")
     def handle_mic_update(data: dict) -> None:
         """Handle mic configuration change from control UI.
 

--- a/tests/unit/test_socket_mic_gate.py
+++ b/tests/unit/test_socket_mic_gate.py
@@ -1,0 +1,134 @@
+"""Every socket handler names its audience at the point it is registered.
+
+Their own file because the route gate is a before_request: it never sees the
+socket surface, so no amount of growing its allowlist would cover these.
+
+The two rosters below are the whole check. Each is also the parameter list for
+a behavioural test, so a handler cannot be added to one just to quiet a
+failure -- it gets tested as whatever it was declared to be.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask_socketio import SocketIO
+
+from pikaraoke.routes import socket_events
+from pikaraoke.routes.socket_events import setup_socket_events
+from tests.conftest import StubAdminAuth
+
+# Host-only handlers, with the arguments each takes.
+ADMIN_EVENTS = [
+    ("request_mic_devices", ()),
+    ("request_mic_settings", ()),
+    ("mic_latency_change", ({"latency_ms": 80},)),
+    ("mic_echo_cancel_change", ({"enabled": True},)),
+    ("mic_refresh", ()),
+    ("mic_update", ({"label": "USB Mic", "deviceId": "1", "enabled": True, "volume": 0.5},)),
+]
+
+# The playback path, which splash screens drive with no admin session.
+PUBLIC_EVENTS = [
+    ("end_song", ("complete",)),
+    ("start_song", ()),
+    ("clear_notification", ()),
+    ("register_splash", ()),
+    ("playback_position", (12.5,)),
+    ("disconnect", ()),
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_splash_state():
+    """The elected master is module state, so it outlives the test that set it."""
+    yield
+    socket_events.splash_connections.clear()
+    socket_events.master_splash_id = None
+
+
+def make_socket_app(admin: bool):
+    """A Flask app with the socket handlers registered and a stubbed karaoke."""
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test"
+    app.config["ADMIN_AUTH"] = StubAdminAuth(admin)
+
+    # Real return values, not bare MagicMocks: the handlers emit what they get
+    # back, and socketio serialises it to JSON.
+    sound_manager = MagicMock()
+    sound_manager.get_enriched_devices.return_value = []
+    sound_manager.get_mic_settings_state.return_value = {}
+    sound_manager.set_latency_ms.return_value = {}
+    sound_manager.set_echo_cancel.return_value = {}
+    sound_manager.refresh.return_value = []
+    sound_manager.load_settings.return_value = {}
+
+    karaoke = MagicMock()
+    karaoke.sound_manager = sound_manager
+    app.config["KARAOKE_INSTANCE"] = karaoke
+
+    socketio = SocketIO(app, async_mode="threading")
+    setup_socket_events(socketio)
+    return app, socketio, karaoke
+
+
+def test_every_handler_declares_its_audience():
+    """A handler in neither roster was registered without the question asked."""
+    _, socketio, _ = make_socket_app(admin=True)
+    declared = {event for event, _ in ADMIN_EVENTS} | {event for event, _ in PUBLIC_EVENTS}
+
+    undeclared = set(socketio.server.handlers["/"]) - declared
+
+    assert not undeclared, (
+        f"{sorted(undeclared)} is registered but declared nowhere: add it to "
+        "ADMIN_EVENTS if it needs the host, PUBLIC_EVENTS if the room may send it"
+    )
+
+
+@pytest.mark.parametrize("event,args", ADMIN_EVENTS)
+def test_admin_handler_ignores_a_guest(event, args):
+    """With a password set, a guest's emit never reaches the sound manager."""
+    app, socketio, karaoke = make_socket_app(admin=False)
+    client = socketio.test_client(app)
+
+    client.emit(event, *args)
+
+    assert karaoke.sound_manager.method_calls == []
+
+
+@pytest.mark.parametrize("event,args", ADMIN_EVENTS)
+def test_admin_handler_serves_the_host(event, args):
+    """With no password set everyone is the host, so the controls still work."""
+    app, socketio, karaoke = make_socket_app(admin=True)
+    client = socketio.test_client(app)
+
+    client.emit(event, *args)
+
+    assert karaoke.sound_manager.method_calls, f"{event} reached nothing"
+
+
+@pytest.mark.parametrize("event,args", PUBLIC_EVENTS)
+def test_public_handler_is_not_refused(event, args, caplog):
+    """Registering one of these as host-only would lock every splash screen out.
+
+    The guard's refusal is a log line, so absence of one is what open means
+    here -- what each handler then does is its own test's business.
+    """
+    app, socketio, _ = make_socket_app(admin=False)
+    client = socketio.test_client(app)
+
+    client.emit(event, *args)
+
+    assert "Refused" not in caplog.text, f"{event} is gated rather than open"
+
+
+def test_a_guest_splash_registers_and_reports_position():
+    """Election and position in one test: only the elected master is heard."""
+    app, socketio, karaoke = make_socket_app(admin=False)
+    client = socketio.test_client(app)
+
+    client.emit("register_splash")
+    client.emit("playback_position", 12.5)
+
+    assert any(m["name"] == "splash_role" for m in client.get_received())
+    assert karaoke.playback_controller.now_playing_position == 12.5

--- a/tests/unit/test_sound_manager.py
+++ b/tests/unit/test_sound_manager.py
@@ -77,3 +77,28 @@ def test_start_noop_when_disabled(tmp_path, monkeypatch):
     manager.start()
 
     assert called is False
+
+
+def test_start_reenables_a_saved_mic(tmp_path, monkeypatch):
+    """An enabled mic comes back at startup, with nobody logged in.
+
+    The mic is a server-side loopback restored by start(), long before any
+    browser connects, so gating the socket handlers cannot reach it. A host
+    who switched a mic on keeps it whether or not anyone has a session.
+    """
+    monkeypatch.setattr(sm, "_HAS_PACTL", True)
+    monkeypatch.setattr(sm, "_SOUNDDEVICE_AVAILABLE", True)
+    manager = _make_manager(tmp_path, enabled=True)
+
+    device = {"label": "USB Mic", "deviceId": "3"}
+    monkeypatch.setattr(manager, "enumerate_devices", lambda: manager._device_list)
+    manager._device_list = [device]
+    monkeypatch.setattr(
+        manager, "load_settings", lambda: {"USB Mic": {"enabled": True, "volume": 0.6}}
+    )
+    activated = []
+    monkeypatch.setattr(manager, "activate", lambda d, v: bool(activated.append((d, v))) or True)
+
+    manager.start()
+
+    assert activated == [("3", 0.6)]


### PR DESCRIPTION
**Why:** the host set an admin password to keep the mic controls to themselves. Afterwards hidden means unreachable, instead of hidden meaning hidden.

Closes #924.

Supercedes PR #921 

## Changes

- **Six mic handlers now require the host.** `request_mic_devices`, `request_mic_settings`, `mic_latency_change`, `mic_echo_cancel_change`, `mic_refresh` and `mic_update` reached `sound_manager` with no check at all. The `{% if admin %}` in the templates was the only thing standing between a guest and the host's mic, so a browser console could switch it on, cut the singer's mid-song, or read the host's device labels. Not an eavesdropping vector: `activate()` is a loopback to the host's own output.
- **Every handler names its audience where it registers**, `host_only` or `open_to_room`, rather than gating being the exception somebody has to remember. That ordering is what went wrong in the first place: a bare `socketio.on` reads as the normal case, so those six were never a decision anyone made.
- **The playback path stays open.** `end_song`, `start_song`, `clear_notification`, `register_splash`, `playback_position` and `disconnect` are driven by a splash screen that has no admin session by design.
- **A roster test carries the rule.** A handler declared in neither list fails it, and the same lists drive the behavioural tests, so the rosters cannot drift from the code.
- **`SoundManager.start()` gains its first test.** The gate is only safe because the audio path never involved a client: an enabled mic is restored at boot and keeps running with nobody logged in. That property was what the gate leaned on and nothing stated it.

## Why not deny-by-default

#900 could invert the default for routes because most of them are host-only. This surface is six all, and the open half is playback: a missing marker there stops the party, where a missing marker under the current default exposes one control. The roster test buys the same protection without putting playback behind an easy mistake.

The gate #900 installed is a `before_request` and cannot see socket events at all, so its `EXPECTED_PUBLIC_ENDPOINTS` could never have grown to cover these.

## Test plan

- [X] With no admin password set, the mic controls on `/` and `/info` work as before
- [X] With a password set and logged in, they still work
- [X] A splash screen still plays, advances the queue at song end, and reports position, with a password set and the splash not logged in
- [X] Set a password while a guest already has a page open: their console emits stop working without a reload
- [X] Switch a mic on, restart PiKaraoke with a password set, and do not log in: the mic still passes audio
