### PR TITLE
feat: name the JS runtime on the Info page

### DIFF
--- a/pikaraoke/routes/info.py
+++ b/pikaraoke/routes/info.py
@@ -15,7 +15,12 @@ from pikaraoke.lib.current_app import (
     get_site_name,
     is_admin,
 )
-from pikaraoke.lib.get_platform import get_platform, is_linux, is_running_in_docker
+from pikaraoke.lib.get_platform import (
+    get_installed_js_runtime,
+    get_platform,
+    is_linux,
+    is_running_in_docker,
+)
 
 _ = flask_babel.gettext
 
@@ -51,6 +56,7 @@ def info():
         ffmpeg_version=k.ffmpeg_version,
         is_transpose_enabled=k.is_transpose_enabled,
         youtubedl_version=youtubedl_version,
+        js_runtime=get_installed_js_runtime(),
         pikaraoke_version=VERSION,
         cpu=None,
         memory=None,

--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -768,6 +768,8 @@
 					<li><u>{% trans %}OS Version:{% endtrans %}</u> {{ os_version }}</li>
 					{# MSG: The version of the program "yt-dlp". #}
 					<li><u>{% trans %}yt-dlp version:{% endtrans %}</u> {{ youtubedl_version }}</li>
+					{# MSG: The JavaScript runtime yt-dlp uses. Value is a program name, or the missing-runtime note. #}
+					<li><u>{% trans %}JavaScript runtime:{% endtrans %}</u> {% if js_runtime %}{{ js_runtime }}{% else %}{% trans %}none installed, some downloads will fail. Install Deno, Node.js, Bun or QuickJS{% endtrans %}{% endif %}</li>
 					{# MSG: The version of the program "ffmpeg". #}
 					<li><u>{% trans %}FFmpeg version:{% endtrans %}</u> {{ ffmpeg_version }} {% if not is_transpose_enabled %} (missing lib-rubberband, pitch shift is not supported) {% endif %}</li>
 					{# MSG: The version of Pikaraoke running right now. #}


### PR DESCRIPTION
**Why:** A host whose downloads fail can see on the Info page whether yt-dlp has the JavaScript runtime it needs, instead of having to find a startup log line that a headless install buried in `journalctl` and a Windows install showed in a console that has since closed.

- `info.py` passes `get_installed_js_runtime()` to the template as `js_runtime`. The value was already being computed on every download by `_js_runtime_args()`, so nothing new is detected - it just stops being invisible.
- `info.html` gains one row between the yt-dlp and FFmpeg rows: the runtime name when one is found, and "none installed, some downloads will fail. Install Deno, Node.js, Bun or QuickJS" when none is. The runtime yt-dlp will use was the only member of that toolchain the page did not name.
- The missing-runtime case follows the FFmpeg row's existing shape for a missing capability - a plain parenthetical, no link, since no template in the repo carries an external anchor.
- The startup log warning is untouched.

## Test plan

- [X] On a machine with a runtime installed, Info's System Info section names it (`deno`, `node`, `bun` or `quickjs`), matching what `shutil.which` finds first in that order.
- [X] With every runtime off `PATH`, the same row reads "none installed, some downloads will fail" and names the four.
- [X] The yt-dlp, FFmpeg and Pikaraoke version rows are unchanged, and the FFmpeg row keeps its lib-rubberband note.
- [X] Starting with no runtime still logs the existing warning.

Closes #932 