### PR TITLE
feat: copy the system info in one click

### DIFF
--- a/pikaraoke/templates/info.html
+++ b/pikaraoke/templates/info.html
@@ -21,6 +21,29 @@
 		}
 
 		$(function () {
+			// Copied as markdown bullets, since this is pasted into a bug report where
+			// plain lines collapse into one paragraph. Read back off the rendered list
+			// so the copy cannot drift from what the page shows.
+			$("#copy-system-info").click(function() {
+				var $btn = $(this);
+				// execCommand, not navigator.clipboard: PiKaraoke serves plain HTTP on a
+				// LAN, so every device but the host fails the secure-context test.
+				var scratch = $("<textarea readonly>")
+					.val($("#system-info-list li").map(function() {
+						return "- " + $(this).text().replace(/\s+/g, " ").trim();
+					}).get().join("\n"))
+					.css({position: "fixed", opacity: 0})
+					.appendTo("body");
+				scratch[0].select();
+				var copied = document.execCommand("copy");
+				scratch.remove();
+				if (!copied) return;
+				var original = $btn.text();
+				// {# MSG: Shown on the copy button for a moment after the system info is copied. #}
+				$btn.text({{ _('Copied') | tojson }});
+				setTimeout(function() { $btn.text(original); }, 2000);
+			});
+
 			$(".user-preference-input").change(function() {
 				let val = $(this).val();
 				let pref = $(this).attr("data-pref");
@@ -755,13 +778,15 @@
 		<h2>{% trans %}System Data{% endtrans %}</h2>
 
 		<div class="card">
-			<header class="card-header py-3 px-5">
+			<header class="card-header py-3 px-5 is-align-items-center">
 					{# MSG: Header of the information section about the computer running Pikaraoke. #}
 					<h3 class="m-0">{% trans %}System Info{% endtrans %}</h3>
+					{# MSG: Button that copies the system info below it, for pasting into a bug report. #}
+					<button id="copy-system-info" class="button is-small is-primary is-inverted ml-auto">{% trans %}Copy{% endtrans %}</button>
 			</header>
 			<div class="card-content">
 				<div class="content">
-					<ul>
+					<ul id="system-info-list">
 					{# MSG: The hardware platform  #}
 					<li><u>{% trans %}Platform:{% endtrans %}</u> {{ platform }}</li>
 					{# MSG: The os version  #}


### PR DESCRIPTION
**Why:** A host filing a bug report taps Copy and pastes their platform, OS, yt-dlp, JavaScript runtime, FFmpeg and PiKaraoke versions straight into the issue, instead of transcribing six values by hand from a page they are reading on the machine they are reporting about.

- A `Copy` button in the System Info card header, using Bulma's `is-small is-primary is-inverted` and `ml-auto` - the same button style the Sync Now control already uses, and no new CSS.
- The text is read back off the rendered `<li>` list rather than rebuilt in JavaScript, so what lands on the clipboard cannot drift from what the page shows.
- Copied as markdown bullets, matching the bug report template's own Platform section. Plain lines collapse into a single paragraph anywhere markdown is parsed as a file rather than as a comment.
- Uses `document.execCommand("copy")` against a scratch textarea. `navigator.clipboard` is undefined outside a secure context, and PiKaraoke serves plain HTTP on a LAN - so the modern API would have worked only on the machine running PiKaraoke and silently done nothing on every phone.
- The button reports success only when the copy actually happened: it says "Copied" for two seconds, and stays as it is otherwise.

## Test plan

- [X] On the machine running PiKaraoke, Copy puts all six rows on the clipboard as `- Label: value` bullets, and the button reads "Copied" for about two seconds.
- [X] From a phone on the LAN, over `http://<ip>:5555`, the same copy works - this is the case `navigator.clipboard` would have failed.
- [X] Pasting into a GitHub issue renders six list items.
- [X] The FFmpeg row's lib-rubberband note and the JavaScript runtime warning are carried through when present.
- [X] Navigating away to another page and back via the nav links leaves the button working.
