### PR TITLE
fix: the batch renamer ignored the filename and the order setting

### DIFF
--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -474,58 +474,6 @@ def _score_penalties(
     return penalty
 
 
-# ---------------------------------------------------------------------------
-# Format detection
-# ---------------------------------------------------------------------------
-
-
-def _normalize_for_detection(text: str) -> str:
-    """Normalize text for artist/title format detection."""
-    return remove_accents(clean_search_query(text.strip().lower()))
-
-
-def _is_similar(a: str, b: str) -> bool:
-    """Check if two strings are similar (exact or substring match)."""
-    return bool(a) and bool(b) and (a == b or a in b or b in a)
-
-
-def _detect_artist_first(original_query: str, artist: str, title: str) -> bool:
-    """Detect if the original query uses 'Artist - Title' format."""
-    part1_raw, part2_raw = _split_query_parts(original_query)
-    if not part2_raw:
-        return False
-
-    part1 = _normalize_for_detection(part1_raw)
-    part2 = _normalize_for_detection(part2_raw)
-    artist_norm = _normalize_for_detection(artist)
-    title_norm = _normalize_for_detection(title)
-
-    part1_is_artist = _is_similar(part1, artist_norm)
-    part1_is_title = _is_similar(part1, title_norm)
-    part2_is_artist = _is_similar(part2, artist_norm)
-    part2_is_title = _is_similar(part2, title_norm)
-
-    # Both parts match their expected positions
-    if part1_is_artist and part2_is_title:
-        return True
-    if part1_is_title and part2_is_artist:
-        return False
-
-    # Single-part matches on part1
-    if part1_is_artist and not part1_is_title:
-        return True
-    if part1_is_title and not part1_is_artist:
-        return False
-
-    # Cross-reference with part2
-    if part2_is_title and not part2_is_artist:
-        return True
-    if part2_is_artist and not part2_is_title:
-        return False
-
-    return False
-
-
 def normalize_for_comparison(text: str) -> str:
     """Normalize text for artist/track comparison by removing punctuation."""
     normalized = text.lower().replace("&", " and ")
@@ -587,9 +535,12 @@ def _preserve_original_artist(original_name: str, lastfm_artist: str) -> str | N
 
 
 def get_best_result(
-    results: list[dict] | None, original_query: str, original_name: str | None = None
+    results: list[dict] | None,
+    original_query: str,
+    original_name: str | None = None,
+    artist_first: bool = True,
 ) -> str | None:
-    """Select the highest-scoring result and format to match the input convention."""
+    """Select the highest-scoring result and join it in the admin's chosen order."""
     if not results:
         return None
 
@@ -608,8 +559,7 @@ def get_best_result(
         if preserved:
             artist = preserved
 
-    format_query = original_name or original_query
-    if _detect_artist_first(format_query, best["artist"], clean_track_name):
+    if artist_first:
         return f"{artist} - {clean_track_name}"
 
     return f"{clean_track_name} - {artist}"
@@ -699,10 +649,11 @@ def _lastfm_track_search(cleaned_query: str, limit: int | None = None) -> list[d
     return _RATE_LIMITED
 
 
-# Cache for lookup_lastfm: maps song filename -> corrected name.
+# Cache for lookup_lastfm: maps (song filename, artist_first) -> corrected name.
+# The order is part of the key because the cached value is already joined.
 # Uses a plain dict instead of lru_cache so that rate-limited None results
 # are not cached (they should be retried on next request).
-_song_name_cache: dict[str, str | None] = {}
+_song_name_cache: dict[tuple[str, bool], str | None] = {}
 
 
 def clear_song_name_cache() -> None:
@@ -710,15 +661,16 @@ def clear_song_name_cache() -> None:
     _song_name_cache.clear()
 
 
-def lookup_lastfm(song: str) -> str | None:
+def lookup_lastfm(song: str, artist_first: bool = True) -> str | None:
     """Look up the canonical song name via the Last.fm API.
 
     Definitive results (including genuine "no results") are cached for the
     lifetime of the process. Rate-limited failures are NOT cached so the
     lookup is retried on the next request.
     """
-    if song in _song_name_cache:
-        return _song_name_cache[song]
+    key = (song, artist_first)
+    if key in _song_name_cache:
+        return _song_name_cache[key]
 
     cleaned_query = clean_search_query(song)
     results = _lastfm_track_search(cleaned_query)
@@ -726,8 +678,12 @@ def lookup_lastfm(song: str) -> str | None:
     if not isinstance(results, list):
         return None
 
-    result = get_best_result(results, cleaned_query, original_name=song) if results else None
-    _song_name_cache[song] = result
+    result = (
+        get_best_result(results, cleaned_query, original_name=song, artist_first=artist_first)
+        if results
+        else None
+    )
+    _song_name_cache[key] = result
     return result
 
 
@@ -885,7 +841,9 @@ def search_lastfm_tracks(query: str, limit: int | None = None) -> list[dict]:
     return [{"name": r.get("name", ""), "artist": r.get("artist", "")} for r in results]
 
 
-def get_song_correct_name(song: str, raw_filename: str | None = None) -> str | None:
+def get_song_correct_name(
+    song: str, raw_filename: str | None = None, artist_first: bool = True
+) -> str | None:
     """Get the best corrected name for a song, using provenance-based routing.
 
     For YouTube-sourced files (detected via raw_filename):
@@ -893,12 +851,16 @@ def get_song_correct_name(song: str, raw_filename: str | None = None) -> str | N
       - Otherwise fall through to lookup_lastfm (to find the artist)
     For non-YouTube files:
       - Always use lookup_lastfm
+
+    artist_first orders only the names Last.fm resolves. A name regex_tidy
+    already separated is returned as it stands, because nothing in it says
+    which half is the artist.
     """
     if raw_filename and has_youtube_id(raw_filename):
         tidied = regex_tidy(song)
         if has_artist_title_separator(tidied):
             return tidied
         # No separator — need Last.fm to find the artist
-        return lookup_lastfm(song)
+        return lookup_lastfm(song, artist_first=artist_first)
 
-    return lookup_lastfm(song)
+    return lookup_lastfm(song, artist_first=artist_first)

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -678,11 +678,7 @@ def lookup_lastfm(song: str, artist_first: bool = True) -> str | None:
     if not isinstance(results, list):
         return None
 
-    result = (
-        get_best_result(results, cleaned_query, original_name=song, artist_first=artist_first)
-        if results
-        else None
-    )
+    result = get_best_result(results, cleaned_query, original_name=song, artist_first=artist_first)
     _song_name_cache[key] = result
     return result
 
@@ -846,21 +842,14 @@ def get_song_correct_name(
 ) -> str | None:
     """Get the best corrected name for a song, using provenance-based routing.
 
-    For YouTube-sourced files (detected via raw_filename):
-      - regex_tidy() first; if it produces "Artist - Title", use that (fast, no API)
-      - Otherwise fall through to lookup_lastfm (to find the artist)
-    For non-YouTube files:
-      - Always use lookup_lastfm
-
-    artist_first orders only the names Last.fm resolves. A name regex_tidy
-    already separated is returned as it stands, because nothing in it says
-    which half is the artist.
+    A YouTube-sourced file whose tidied name already reads "Artist - Title"
+    costs no API call, and keeps the order it has: regex_tidy is subtractive,
+    so nothing in that name says which half is the artist. Everything else
+    goes to Last.fm, and artist_first orders what comes back.
     """
     if raw_filename and has_youtube_id(raw_filename):
         tidied = regex_tidy(song)
         if has_artist_title_separator(tidied):
             return tidied
-        # No separator — need Last.fm to find the artist
-        return lookup_lastfm(song, artist_first=artist_first)
 
     return lookup_lastfm(song, artist_first=artist_first)

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -840,16 +840,19 @@ def search_lastfm_tracks(query: str, limit: int | None = None) -> list[dict]:
 def get_song_correct_name(
     song: str, raw_filename: str | None = None, artist_first: bool = True
 ) -> str | None:
-    """Get the best corrected name for a song, using provenance-based routing.
+    """Get the best corrected name for a song, joined in the requested order.
 
-    A YouTube-sourced file whose tidied name already reads "Artist - Title"
-    costs no API call, and keeps the order it has: regex_tidy is subtractive,
-    so nothing in that name says which half is the artist. Everything else
-    goes to Last.fm, and artist_first orders what comes back.
+    Every song is looked up, because only a resolved artist says which half of
+    a name is which. regex_tidy still supplies the fallback for a YouTube-sourced
+    file, so a lookup that finds nothing costs the ordering, not the suggestion.
     """
+    resolved = lookup_lastfm(song, artist_first=artist_first)
+    if resolved:
+        return resolved
+
     if raw_filename and has_youtube_id(raw_filename):
         tidied = regex_tidy(song)
         if has_artist_title_separator(tidied):
             return tidied
 
-    return lookup_lastfm(song, artist_first=artist_first)
+    return None

--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -672,7 +672,10 @@ def lookup_lastfm(song: str, artist_first: bool = True) -> str | None:
     if key in _song_name_cache:
         return _song_name_cache[key]
 
-    cleaned_query = clean_search_query(song)
+    # regex_tidy first: clean_search_query alone leaves vendor noise like
+    # "from Zoom Karaoke" in the query. suggest_metadata splits the two the
+    # same way -- tidy to search with, untidied to compare against.
+    cleaned_query = clean_search_query(regex_tidy(song))
     results = _lastfm_track_search(cleaned_query)
 
     if not isinstance(results, list):

--- a/pikaraoke/routes/batch_song_renamer.py
+++ b/pikaraoke/routes/batch_song_renamer.py
@@ -153,6 +153,7 @@ def get_all_songs(page):
 
     k = get_karaoke_instance()
     available_songs = k.song_manager.songs
+    artist_first = k.preferences.get_or_default("suggestion_name_order") == "artist_title"
 
     pagination = Pagination(
         css_framework="bulma",
@@ -166,7 +167,9 @@ def get_all_songs(page):
     songs = []
     for song in available_songs[start_index : start_index + RESULTS_PER_PAGE]:
         song_name = k.song_manager.filename_from_path(song)
-        correct_name = get_song_correct_name(song_name, raw_filename=song)
+        correct_name = get_song_correct_name(
+            song_name, raw_filename=song, artist_first=artist_first
+        )
         is_equal = _names_match(song_name, correct_name)
         songs.append({"file": song, "correct_name": correct_name, "is_equal": is_equal})
 
@@ -187,6 +190,7 @@ def get_songs_to_rename(query):
 
     k = get_karaoke_instance()
     available_songs = k.song_manager.songs
+    artist_first = k.preferences.get_or_default("suggestion_name_order") == "artist_title"
 
     songs = []
     display_offset = page * RESULTS_PER_PAGE
@@ -194,7 +198,9 @@ def get_songs_to_rename(query):
     while len(songs) < RESULTS_PER_PAGE and song_index < len(available_songs):
         song = available_songs[song_index]
         song_name = k.song_manager.filename_from_path(song)
-        correct_name = get_song_correct_name(song_name, raw_filename=song)
+        correct_name = get_song_correct_name(
+            song_name, raw_filename=song, artist_first=artist_first
+        )
         song_index += 1
 
         if _names_match(song_name, correct_name):

--- a/pikaraoke/routes/batch_song_renamer.py
+++ b/pikaraoke/routes/batch_song_renamer.py
@@ -39,7 +39,7 @@ table_lines_template = """
 {% for song in songs %}
 <tr>
     <td class="vertical-align-middle col-num px-2">{{ loop.index + skip }}</td>
-    <td class="vertical-align-middle col-old-name px-1 old-name">{{ filename_from_path(song.file) }}</td>
+    <td class="vertical-align-middle col-old-name px-1 old-name">{{ song.name }}</td>
     <td class="vertical-align-middle col-new-name pr-0"><input class="input new-name
         {% if song.correct_name and song.is_equal %}
             is-success
@@ -47,7 +47,7 @@ table_lines_template = """
             is-warning
         {% else %}
             is-danger
-        {% endif %}" type="text" value="{{ song.correct_name or 'N/A' }}" data-new-name="{{ song.correct_name or 'N/A' }}" data-old-name="{{ filename_from_path(song.file) }}" /></td>
+        {% endif %}" type="text" value="{{ song.correct_name or 'N/A' }}" data-new-name="{{ song.correct_name or 'N/A' }}" data-old-name="{{ song.name }}" /></td>
     <td class="vertical-align-middle col-btn pr-2">
     <div class="buttons are-small is-flex-wrap-nowrap">
 		  <a class="accept-change button has-text-weight-bold has-text-success is-small "
@@ -166,12 +166,14 @@ def get_all_songs(page):
 
     songs = []
     for song in available_songs[start_index : start_index + RESULTS_PER_PAGE]:
-        song_name = k.song_manager.filename_from_path(song)
+        song_name = k.song_manager.filename_from_path(song, tidy=False)
         correct_name = get_song_correct_name(
             song_name, raw_filename=song, artist_first=artist_first
         )
         is_equal = _names_match(song_name, correct_name)
-        songs.append({"file": song, "correct_name": correct_name, "is_equal": is_equal})
+        songs.append(
+            {"file": song, "name": song_name, "correct_name": correct_name, "is_equal": is_equal}
+        )
 
     table_lines_html = render_template_string(table_lines_template, songs=songs, skip=start_index)
     html = render_template_string(
@@ -197,7 +199,7 @@ def get_songs_to_rename(query):
 
     while len(songs) < RESULTS_PER_PAGE and song_index < len(available_songs):
         song = available_songs[song_index]
-        song_name = k.song_manager.filename_from_path(song)
+        song_name = k.song_manager.filename_from_path(song, tidy=False)
         correct_name = get_song_correct_name(
             song_name, raw_filename=song, artist_first=artist_first
         )
@@ -206,7 +208,9 @@ def get_songs_to_rename(query):
         if _names_match(song_name, correct_name):
             continue
 
-        songs.append({"file": song, "correct_name": correct_name, "is_equal": False})
+        songs.append(
+            {"file": song, "name": song_name, "correct_name": correct_name, "is_equal": False}
+        )
 
     table_lines_html = render_template_string(
         table_lines_template, songs=songs, skip=display_offset

--- a/tests/unit/test_batch_renamer.py
+++ b/tests/unit/test_batch_renamer.py
@@ -146,3 +146,31 @@ class TestAcceptingASuggestion:
 
         assert body["success"] is False
         assert "Invalid argument" in body["message"]
+
+
+class TestNameOrderPreference:
+    """The renamer's suggestions follow the admin's chosen join order."""
+
+    @pytest.mark.parametrize(
+        ("preference", "artist_first"),
+        [("artist_title", True), ("title_artist", False)],
+    )
+    def test_the_preference_reaches_the_suggestion(self, app, client, preference, artist_first):
+        # app.py binds this global for real; the row template calls it.
+        app.jinja_env.globals["filename_from_path"] = lambda path: Path(path).stem
+        k = MagicMock()
+        k.song_manager.songs = ["/songs/Song - Artist.mp4"]
+        k.song_manager.filename_from_path.return_value = "Song - Artist"
+        k.preferences.get_or_default.return_value = preference
+
+        with (
+            patch("pikaraoke.routes.batch_song_renamer.get_karaoke_instance", return_value=k),
+            patch(
+                "pikaraoke.routes.batch_song_renamer.get_song_correct_name",
+                return_value="Artist - Song",
+            ) as mock_correct,
+        ):
+            response = client.get("/batch-song-renamer/get-songs-to-rename")
+
+        assert response.status_code == 200
+        assert mock_correct.call_args.kwargs["artist_first"] is artist_first

--- a/tests/unit/test_batch_renamer.py
+++ b/tests/unit/test_batch_renamer.py
@@ -11,6 +11,7 @@ if not hasattr(werkzeug, "__version__"):
 
 from pikaraoke.karaoke import SongInUseError
 from pikaraoke.lib.metadata_parser import sanitize_filename
+from pikaraoke.lib.song_manager import SongManager
 from pikaraoke.routes.batch_song_renamer import _names_match, batch_song_renamer_bp
 from tests.conftest import make_route_app
 
@@ -155,9 +156,7 @@ class TestNameOrderPreference:
         ("preference", "artist_first"),
         [("artist_title", True), ("title_artist", False)],
     )
-    def test_the_preference_reaches_the_suggestion(self, app, client, preference, artist_first):
-        # app.py binds this global for real; the row template calls it.
-        app.jinja_env.globals["filename_from_path"] = lambda path: Path(path).stem
+    def test_the_preference_reaches_the_suggestion(self, client, preference, artist_first):
         k = MagicMock()
         k.song_manager.songs = ["/songs/Song - Artist.mp4"]
         k.song_manager.filename_from_path.return_value = "Song - Artist"
@@ -174,3 +173,20 @@ class TestNameOrderPreference:
 
         assert response.status_code == 200
         assert mock_correct.call_args.kwargs["artist_first"] is artist_first
+
+    def test_a_noisy_filename_is_listed_for_rename(self, client):
+        """The comparison sees the filename, not the tidied display name."""
+        path = "/songs/ABBA - Waterloo - Karaoke Version from Zoom Karaoke---dQw4w9WgXcQ.mp4"
+        k = MagicMock()
+        k.song_manager.songs = [path]
+        k.song_manager.filename_from_path.side_effect = SongManager.filename_from_path
+        k.preferences.get_or_default.return_value = "artist_title"
+
+        with (
+            patch("pikaraoke.routes.batch_song_renamer.get_karaoke_instance", return_value=k),
+            patch("pikaraoke.lib.metadata_parser._lastfm_track_search", return_value=[]),
+        ):
+            html = client.get("/batch-song-renamer/get-songs-to-rename").get_json()["html"]
+
+        assert "ABBA - Waterloo - Karaoke Version from Zoom Karaoke" in html
+        assert 'value="ABBA - Waterloo"' in html

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pikaraoke.lib.metadata_parser import (
-    _detect_artist_first,
     clean_search_query,
     clear_song_name_cache,
     get_best_result,
@@ -327,37 +326,6 @@ class TestScoreResult:
         assert isinstance(score, int)
 
 
-class TestDetectArtistFirst:
-    """Tests for the _detect_artist_first format detection function."""
-
-    def test_detects_artist_first(self):
-        assert _detect_artist_first("Coldplay - Viva La Vida", "Coldplay", "Viva La Vida") is True
-
-    def test_detects_title_first(self):
-        assert _detect_artist_first("Viva La Vida - Coldplay", "Coldplay", "Viva La Vida") is False
-
-    def test_no_separator_returns_false(self):
-        assert _detect_artist_first("Bohemian Rhapsody", "Queen", "Bohemian Rhapsody") is False
-
-    def test_handles_accented_characters(self):
-        assert _detect_artist_first("Beyonce - Halo", "Beyonc\u00e9", "Halo") is True
-
-    def test_partial_artist_match(self):
-        assert _detect_artist_first("Coldplay Band - Song", "Coldplay", "Song") is True
-
-    def test_cross_references_part2_when_part1_ambiguous(self):
-        assert _detect_artist_first("AC DC - Back In Black", "AC/DC", "Back in Black") is True
-
-    def test_cross_references_part2_for_title_first(self):
-        assert _detect_artist_first("Back In Black - AC DC", "AC/DC", "Back in Black") is False
-
-    def test_no_space_separator(self):
-        assert _detect_artist_first("Artist-Song Title", "Artist", "Song Title") is True
-
-    def test_fullwidth_pipe_separator(self):
-        assert _detect_artist_first("Artist \uff5c Song", "Artist", "Song") is True
-
-
 class TestGetBestResult:
     """Tests for the get_best_result function."""
 
@@ -367,14 +335,16 @@ class TestGetBestResult:
     def test_returns_none_for_none_results(self):
         assert get_best_result(None, "Artist - Song") is None
 
-    def test_preserves_artist_first_format(self):
+    def test_joins_artist_first(self):
+        """The query is title-first; the requested order wins anyway."""
         results = [{"name": "Song Title", "artist": "Artist Name"}]
-        result = get_best_result(results, "Artist Name - Song Title")
+        result = get_best_result(results, "Song Title - Artist Name", artist_first=True)
         assert result == "Artist Name - Song Title"
 
-    def test_preserves_title_first_format(self):
+    def test_joins_title_first(self):
+        """And the same in reverse, so neither order is merely the default."""
         results = [{"name": "Song Title", "artist": "Artist Name"}]
-        result = get_best_result(results, "Song Title - Artist Name")
+        result = get_best_result(results, "Artist Name - Song Title", artist_first=False)
         assert result == "Song Title - Artist Name"
 
     def test_selects_best_match(self):
@@ -438,7 +408,7 @@ class TestLookupLastfm:
         assert "official" not in params["track"].lower()
 
     @patch("requests.get")
-    def test_preserves_format_from_original_filename(self, mock_get):
+    def test_the_filename_order_does_not_decide(self, mock_get):
         mock_get.return_value.status_code = 200
         mock_get.return_value.json.return_value = {
             "results": {
@@ -449,8 +419,24 @@ class TestLookupLastfm:
                 }
             }
         }
-        result = lookup_lastfm("Artist Name - Song Title (Official Video) karaoke")
+        result = lookup_lastfm("Song Title - Artist Name (Official Video) karaoke")
         assert result == "Artist Name - Song Title"
+
+    @patch("requests.get")
+    def test_the_order_is_part_of_the_cache_key(self, mock_get):
+        """Without it the second call would serve the first call's join."""
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "results": {
+                "trackmatches": {
+                    "track": [
+                        {"name": "Viva La Vida", "artist": "Coldplay"},
+                    ]
+                }
+            }
+        }
+        assert lookup_lastfm("Viva La Vida", artist_first=True) == "Coldplay - Viva La Vida"
+        assert lookup_lastfm("Viva La Vida", artist_first=False) == "Viva La Vida - Coldplay"
 
     @patch("requests.get")
     def test_returns_none_on_missing_trackmatches(self, mock_get):
@@ -882,21 +868,21 @@ class TestProvenanceRouting:
         result = get_song_correct_name(
             "Sweet Caroline", raw_filename="/songs/Sweet Caroline---dQw4w9WgXcQ.mp4"
         )
-        mock_lookup.assert_called_once_with("Sweet Caroline")
+        mock_lookup.assert_called_once_with("Sweet Caroline", artist_first=True)
         assert result == "Sweet Caroline - Neil Diamond"
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
     def test_non_youtube_file_always_uses_lastfm(self, mock_lookup):
         mock_lookup.return_value = "Artist - Song"
         result = get_song_correct_name("Artist - Song", raw_filename="/songs/Artist - Song.mp4")
-        mock_lookup.assert_called_once_with("Artist - Song")
+        mock_lookup.assert_called_once_with("Artist - Song", artist_first=True)
         assert result == "Artist - Song"
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
     def test_no_raw_filename_uses_lastfm(self, mock_lookup):
         mock_lookup.return_value = "Artist - Song"
         result = get_song_correct_name("Artist - Song")
-        mock_lookup.assert_called_once_with("Artist - Song")
+        mock_lookup.assert_called_once_with("Artist - Song", artist_first=True)
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
     def test_youtube_bracket_format_with_separator(self, mock_lookup):

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -851,15 +851,27 @@ class TestSearchLastfmTracks:
         assert params["limit"] == "3"
 
 
-class TestProvenanceRouting:
-    """Tests for get_song_correct_name provenance-based routing."""
+class TestGetSongCorrectName:
+    """Every song is looked up; provenance decides only the fallback."""
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
-    def test_youtube_file_with_separator_skips_lastfm(self, mock_lookup):
+    def test_a_youtube_file_with_a_separator_is_still_looked_up(self, mock_lookup):
+        """The filename's own order is not evidence of which half is the artist."""
+        mock_lookup.return_value = "Artist - Song Title"
         result = get_song_correct_name(
-            "Artist - Song Title", raw_filename="/songs/Artist - Song Title---dQw4w9WgXcQ.mp4"
+            "Song Title - Artist", raw_filename="/songs/Song Title - Artist---dQw4w9WgXcQ.mp4"
         )
-        mock_lookup.assert_not_called()
+        mock_lookup.assert_called_once_with("Song Title - Artist", artist_first=True)
+        assert result == "Artist - Song Title"
+
+    @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
+    def test_a_failed_lookup_falls_back_to_the_tidied_name(self, mock_lookup):
+        """A lookup that finds nothing costs the ordering, not the suggestion."""
+        mock_lookup.return_value = None
+        result = get_song_correct_name(
+            "Artist - Song Title (Karaoke Version)",
+            raw_filename="/songs/Artist - Song Title---dQw4w9WgXcQ.mp4",
+        )
         assert result == "Artist - Song Title"
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
@@ -870,6 +882,13 @@ class TestProvenanceRouting:
         )
         mock_lookup.assert_called_once_with("Sweet Caroline", artist_first=True)
         assert result == "Sweet Caroline - Neil Diamond"
+
+    @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
+    def test_a_non_youtube_file_has_no_tidy_fallback(self, mock_lookup):
+        """Only YouTube filenames carry the noise regex_tidy exists to strip."""
+        mock_lookup.return_value = None
+        result = get_song_correct_name("Artist - Song", raw_filename="/songs/Artist - Song.mp4")
+        assert result is None
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
     def test_non_youtube_file_always_uses_lastfm(self, mock_lookup):
@@ -885,9 +904,9 @@ class TestProvenanceRouting:
         mock_lookup.assert_called_once_with("Artist - Song", artist_first=True)
 
     @patch("pikaraoke.lib.metadata_parser.lookup_lastfm")
-    def test_youtube_bracket_format_with_separator(self, mock_lookup):
+    def test_youtube_bracket_format_falls_back_too(self, mock_lookup):
+        mock_lookup.return_value = None
         result = get_song_correct_name(
             "Artist - Song", raw_filename="/songs/Artist - Song [dQw4w9WgXcQ].mp4"
         )
-        mock_lookup.assert_not_called()
         assert result == "Artist - Song"


### PR DESCRIPTION
**Why:** An admin's rename suggestions now follow the order they picked on the Info page, on every song. The setting shipped a while back and the renamer never read it — and files whose only fault was noise never appeared in the list at all.

A stopgap on old code: the changes stay inside the Last.fm path the renamer already used.

## Changes

- The renamer reads the preference and passes it down, so the setting decides the order rather than the filename.
- Deleted the 46-line heuristic that guessed the order, and its nine tests.
- Every song is looked up now, with `regex_tidy` as the fallback rather than the shortcut. A YouTube-tagged file with a separator used to return early, which exempted most of a library.
- Filenames are read with `tidy=False`, as the edit page already does. Tidying both sides of the comparison made `ABBA - Waterloo - Karaoke Version from Zoom Karaoke` read as already correct.
- `lookup_lastfm` tidies before searching, and its cache is keyed on the order.

**Cost:** a YouTube-tagged row now costs a Last.fm lookup where it cost none.

## Test plan

- [x] A file named `Artist - Title - Karaoke Version from <vendor>` appears in the list, suggesting `Artist - Title`.
- [x] Switching the order setting flips the suggestions on reload.
- [x] Accepting a rename keeps the `---videoId` suffix.
