### PR TITLE
fix: fold article placement into name matching

### DIFF
--- a/pikaraoke/lib/metadata_providers.py
+++ b/pikaraoke/lib/metadata_providers.py
@@ -55,6 +55,10 @@ _WHITESPACE_RE = re.compile(r"\s+")
 # Stylized character substitutions used by artists (P!nk -> Pink, Ke$ha -> Kesha)
 _STYLIZED_CHARS = str.maketrans({"!": "i", "$": "s"})
 
+# Leading or trailing, because a library writes the same name three ways:
+# "The Commodores", "Commodores, The", and the vendor's bare "Commodores".
+_ARTICLE_RE = re.compile(r"^(?:the|a|an)\s+|\s+(?:the|a|an)$")
+
 
 def _fix_ssl_recursion() -> None:
     """Fix ssl.SSLContext.minimum_version RecursionError.
@@ -233,7 +237,8 @@ def _normalize_for_matching(text: str) -> str:
     """Normalize text for fuzzy matching: punctuation, case, and conjunctions.
 
     Extends normalize_for_comparison (which handles punctuation and case) with:
-    - Comma stripping: 'Commodores, The' matches 'The Commodores'
+    - Comma stripping: 'Sex Machine, Pt. 1' matches 'Sex Machine Pt 1'
+    - Article folding: 'Commodores, The' matches 'The Commodores' and 'Commodores'
     - Dotted-letter collapse: 'D.I.V.O.R.C.E.' -> 'divorce', 'S.O.S.' -> 'sos'
     - Conjunction normalization: 'Simon And Garfunkel' matches 'Simon & Garfunkel'
     """
@@ -244,7 +249,8 @@ def _normalize_for_matching(text: str) -> str:
     # like "D.I.V.O.R.C.E." which normalize_for_comparison turns into "d i v o r c e")
     normalized = _SINGLE_LETTER_SEQ_RE.sub(_collapse_single_letters, normalized)
     normalized = _WHITESPACE_RE.sub(" ", normalized).strip()
-    return normalized
+    # "or normalized" so a name that is nothing but an article survives.
+    return _ARTICLE_RE.sub("", normalized).strip() or normalized
 
 
 def _words_near_match(w1: str, w2: str) -> bool:

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -697,14 +697,9 @@ class TestScoreAnchoring:
     def test_a_misplaced_article_is_one_correction(self):
         """The vendor-export "Commodores, The" names the same artist iTunes
         does, so the rename that fixes it is a rewrite, not a failed match."""
-        assert (
-            _anchored("Commodores, The - Three Times a Lady", "Commodores", "Three Times a Lady")
-            == 98
-        )
-        assert (
-            _anchored("The Commodores - Three Times a Lady", "Commodores", "Three Times a Lady")
-            == 98
-        )
+        commodores = ("The Commodores", "Three Times a Lady")
+        assert _anchored("Commodores, The - Three Times a Lady", *commodores) == 98
+        assert _anchored("Commodores - Three Times a Lady", *commodores) == 98
         assert _anchored("Beatles - Hey Jude", "The Beatles", "Hey Jude") == 98
         assert _anchored("Simon & Garfunkel - Boxer, The", "Simon & Garfunkel", "The Boxer") == 98
 
@@ -712,7 +707,9 @@ class TestScoreAnchoring:
         """The guard reads the title, which the fold does not reach past."""
         assert (
             _anchored(
-                "Commodores, The - Three Times a Lady (Live)", "Commodores", "Three Times a Lady"
+                "Commodores, The - Three Times a Lady (Live)",
+                "The Commodores",
+                "Three Times a Lady",
             )
             <= 94
         )

--- a/tests/unit/test_metadata_providers.py
+++ b/tests/unit/test_metadata_providers.py
@@ -457,7 +457,17 @@ class TestNormalizeForMatching:
     """Tests for _normalize_for_matching edge cases."""
 
     def test_strips_commas(self):
-        assert _normalize_for_matching("Commodores, The") == "commodores the"
+        assert _normalize_for_matching("Sex Machine, Pt. 1") == "sex machine pt 1"
+
+    def test_folds_an_article_wherever_the_library_puts_it(self):
+        """All three forms have to reach the one string, or the two the vendor
+        did not write are left unable to confirm against it."""
+        assert _normalize_for_matching("Commodores, The") == "commodores"
+        assert _normalize_for_matching("The Commodores") == "commodores"
+        assert _normalize_for_matching("Commodores") == "commodores"
+
+    def test_a_name_that_is_only_an_article_survives(self):
+        assert _normalize_for_matching("The The") == "the"
 
     def test_collapses_dotted_acronyms(self):
         assert _normalize_for_matching("D.I.V.O.R.C.E.") == "divorce"
@@ -683,6 +693,29 @@ class TestScoreAnchoring:
         """The tidy decides confidence; the raw stem decides whether there is
         anything to apply. Confirmed fields alone must not reach 100."""
         assert _anchored("Beyoncé - Halo (Official Video)", "Beyoncé", "Halo") == 98
+
+    def test_a_misplaced_article_is_one_correction(self):
+        """The vendor-export "Commodores, The" names the same artist iTunes
+        does, so the rename that fixes it is a rewrite, not a failed match."""
+        assert (
+            _anchored("Commodores, The - Three Times a Lady", "Commodores", "Three Times a Lady")
+            == 98
+        )
+        assert (
+            _anchored("The Commodores - Three Times a Lady", "Commodores", "Three Times a Lady")
+            == 98
+        )
+        assert _anchored("Beatles - Hey Jude", "The Beatles", "Hey Jude") == 98
+        assert _anchored("Simon & Garfunkel - Boxer, The", "Simon & Garfunkel", "The Boxer") == 98
+
+    def test_folding_an_article_does_not_excuse_a_variant(self):
+        """The guard reads the title, which the fold does not reach past."""
+        assert (
+            _anchored(
+                "Commodores, The - Three Times a Lady (Live)", "Commodores", "Three Times a Lady"
+            )
+            <= 94
+        )
 
     def test_the_variant_guard_ignores_karaoke(self):
         """'(Karaoke Version)' is this app's commonest noise token. Treating it


### PR DESCRIPTION
**Why:** An admin batch-renaming a library exported as "Commodores, The" sees those files score 89 and sit below worse suggestions. After this they score 98 and sort where they belong.

- The 89 was the raw tally leaking through, not a weak match: fields are confirmed by exact equality after normalization, `"commodores the" != "commodores"` failed it, and the 95-100 band became unreachable. Every article discrepancy sat in that hole - leading, trailing, comma-form, present or absent, artist or title.
- Fold a leading or trailing article in `_normalize_for_matching`, beside the accents, ampersands and stylized characters it already resolves, all of which land at 98. 98 and not 100 is right: the rename does rewrite characters.
- The docstring credited comma stripping with a match it never made. Corrected.

Left alone, both distinct from normalization: a leading `01 - ` prefix scores 55, because the query splits on the first `" - "`; a vendor code like `[SF123]` caps at 94 as an unrecognized qualifier.

## Test plan

- [X] `Commodores, The - Three Times A Lady.mp4` suggests `The Commodores - Three Times a Lady` at 98
- [X] `Simon & Garfunkel - Boxer, The.mp4` suggests `The Boxer` at 98
- [X] The same file with `(Live)` still sits at 94, not renamed away
