### PR TITLE
fix: leave an iTunes searchable name after tidying

### DIFF
--- a/pikaraoke/lib/metadata_parser.py
+++ b/pikaraoke/lib/metadata_parser.py
@@ -159,9 +159,12 @@ _LEADING_NOISE = re.compile(
     rf"^(?:{_KARAOKE_KEYWORDS_ALT}|official\s+(?:music\s+)?video)\s*[-|:】》」』]\s*",
     re.IGNORECASE,
 )
-# Leading [square brackets] containing a karaoke keyword — strip entirely.
+# A leading bracket containing a karaoke keyword — strip entirely. Round as well
+# as square: "(USA Karaoke) Title - Artist" is a real YouTube name, and left
+# here its keyword is where the trailing sweep starts deleting, taking the song
+# with it.
 _LEADING_BRACKET_NOISE_RE = re.compile(
-    rf"^\s*\[[^\]]*?(?:{_KARAOKE_KEYWORDS_ALT})[^\]]*?\]\s*",
+    rf"^\s*[\(\[][^)\]]*?(?:{_KARAOKE_KEYWORDS_ALT})[^)\]]*?[\)\]]\s*",
     re.IGNORECASE,
 )
 
@@ -752,13 +755,20 @@ def _step_extract_attribution_or_strip_noise(name: str) -> str:
         prev = None
         while prev != name:
             prev = name
-            name = noise_pat.sub("", name)
+            stripped = noise_pat.sub("", name)
+            # A keyword can open the name -- "Karaoke Cover of Title - Artist" --
+            # where everything after it is everything. A name we cannot read is
+            # worth more than no name at all: the search still gets a query, and
+            # the score still gets something to measure against.
+            name = stripped if stripped.strip() else name
     return name
 
 
 def _step_normalize_separators_and_whitespace(name: str) -> str:
-    # Strip dangling open paren/bracket left by noise removal (e.g. "Title (")
-    name = re.sub(r"\s*[\(\[]\s*$", "", name)
+    # Strip an unclosed bracket left by noise removal, with whatever text trails
+    # it: the sweep deletes from a keyword inside a bracket, so "(Piano Karaoke)"
+    # leaves "(Piano" behind as well as the bare "Title (" case.
+    name = re.sub(r"\s*[\(\[][^)\]]*$", "", name)
     # Normalize separators: en-dash, em-dash, big solidus, fullwidth solidus -> " - "
     name = re.sub(r"\s*[\u2013\u2014\u29f8\uff0f]\s*", " - ", name)
     # Collapse whitespace

--- a/tests/unit/test_metadata_parser.py
+++ b/tests/unit/test_metadata_parser.py
@@ -644,6 +644,28 @@ class TestRegexTidy:
         )
         assert result == "Paul Kelly - Firewood and Candles"
 
+    def test_a_leading_round_bracket_of_noise_is_stripped_not_swept(self):
+        """The sweep deletes from a karaoke keyword to the end, so a vendor who
+        opens with the tag rather than closing with it lost the whole song."""
+        assert (
+            regex_tidy("(USA Karaoke) The Sound Of Silence - Simon & Garfunkel")
+            == "The Sound Of Silence - Simon & Garfunkel"
+        )
+
+    def test_a_name_opening_on_a_keyword_survives(self):
+        """Nothing precedes it, so the sweep would take everything. An unreadable
+        name still gives the search a query and the score something to measure."""
+        name = "Karaoke Cover of Sound of Silence - Todd Hoffman Cover"
+        assert regex_tidy(name) == name
+
+    def test_an_unclosed_bracket_takes_its_tail_with_it(self):
+        """The sweep starts inside the bracket, so what it leaves is an opening
+        bracket and the words before the keyword: "(Piano", not "(" alone."""
+        assert (
+            regex_tidy("Simon&Garfunkel - Sound Of Silence (Piano Karaoke) Higher Key")
+            == "Simon&Garfunkel - Sound Of Silence"
+        )
+
     def test_preserves_feat_parenthetical(self):
         assert regex_tidy("Artist - Song (feat. Other)") == "Artist - Song (feat. Other)"
 


### PR DESCRIPTION
**Why:** An admin renaming a freshly downloaded YouTube file gets a suggestion for it. Today about one file in thirty gets nothing, because the name it was searched under was a fragment or an empty string.

- The trailing-noise sweep deletes from a karaoke keyword to the end of the string, but nothing anchors it to the end. A keyword opening the name, or sitting inside a bracket, took the song with it - and the tidied name is also the iTunes query.
- A leading bracket now strips whole, round as well as square: `[Karaoke] Title` was already handled, `(USA Karaoke) Title` was not.
- The sweep refuses to empty a name, and an unclosed bracket takes its tail rather than leaving `ABBA - Dancing Queen (Piano` behind.
- Over 250 real YouTube search results, names that tidy cleanly go from 92% to 95%.

## Test plan

- [X] A video titled `(USA Karaoke) The Sound Of Silence - Simon & Garfunkel` gets a suggestion rather than nothing
- [X] `ABBA - Dancing Queen (Piano Karaoke)` suggests with no `(Piano` fragment in the search
- [X] `Karaoke Lower Key -1 Journey Don't Stop Believin'` still searches on the whole name
- [X] `Paul Kelly - Firewood and Candles (Karaoke Version) with Lyrics HD Vocal-Star Karaoke` still tidies to `Paul Kelly - Firewood and Candles`
