### PR TITLE
fix: make Clear reset a letter jump or page

### DIFF
--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -469,7 +469,7 @@
 			{% trans %}Sort Alphabetically{% endtrans %}
 		</a>
 		<a class="button sort-link {% if sort_order == 'Date' %}is-info is-selected{% endif %}" data-sort="date"
-			href="{{ url_for('files.browse', sort='date', q=q or None, letter=letter or None, view=view or None, folder=folder or None) }}">
+			href="{{ url_for('files.browse', q=q or None, letter=letter or None, view=view or None, folder=folder or None, sort='date') }}">
 			{# MSG: Button which changes how the songs are sorted so they become sorted by date. #}
 			{% trans %}Sort by Date{% endtrans %}
 		</a>

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -188,11 +188,15 @@
 				inflight.abort();
 				inflight = null;
 			}
-			// Both sides through URLSearchParams: url_for leaves the "/" of a nested
-			// folder unescaped where URLSearchParams writes %2F.
+			// Compared as sorted, decoded pairs: the date sort link puts `sort` first,
+			// and url_for leaves the "/" of a nested folder unescaped where a raw
+			// query string carries %2F.
+			const key = (params) => [...params].sort().join("&");
 			const target = new URL(clearLink.href);
-			const here = new URLSearchParams(window.location.search).toString();
-			if (target.pathname === window.location.pathname && target.searchParams.toString() === here) {
+			if (
+				target.pathname === window.location.pathname &&
+				key(target.searchParams) === key(new URLSearchParams(window.location.search))
+			) {
 				e.preventDefault();
 				input.focus();
 			}

--- a/pikaraoke/templates/files.html
+++ b/pikaraoke/templates/files.html
@@ -177,11 +177,25 @@
 		});
 		input.addEventListener("compositionend", runFilter);
 
+		// `letter` and `page` narrow the list too but live only in the URL, so
+		// emptying the box resolves to the query already rendered and applyFilter
+		// returns early. The href hands those cases to the SPA layer instead.
+		const clearLink = document.getElementById("clear-filter");
+
 		$("#clear-filter").on("click", function (e) {
-			e.preventDefault();
 			input.value = "";
-			applyFilter();
-			input.focus();
+			if (inflight) {
+				inflight.abort();
+				inflight = null;
+			}
+			// Both sides through URLSearchParams: url_for leaves the "/" of a nested
+			// folder unescaped where URLSearchParams writes %2F.
+			const target = new URL(clearLink.href);
+			const here = new URLSearchParams(window.location.search).toString();
+			if (target.pathname === window.location.pathname && target.searchParams.toString() === here) {
+				e.preventDefault();
+				input.focus();
+			}
 		});
 
 		// A cookie, not the preference Settings edits, which everyone shares. Not
@@ -372,7 +386,9 @@
 	</div>
 	<div class="control">
 		{# MSG: Button which empties the filter box and shows every song again. #}
-		<a id="clear-filter" class="button">{% trans %}Clear{% endtrans %}</a>
+		<a id="clear-filter" class="button"
+			href="{{ url_for('files.browse', view=view or None, folder=folder or None, sort=sort_param) }}"
+			>{% trans %}Clear{% endtrans %}</a>
 	</div>
 </div>
 


### PR DESCRIPTION
**Why:** A guest who taps "B" on the alpha bar, or pages into the library, can now get back to the full list with the button that says Clear. Today it does nothing and they have to find the unlabelled bullet-list icon at the head of the alpha bar.

- Clear emptied the box and re-ran the filter, but `letter` and `page` live only in the URL, so the query resolved to the one already rendered and the request was skipped entirely.
- It now carries an href for the unfiltered scope and lets the SPA layer follow it, which also repaints the heading suffix and alpha bar that sit outside the swapped results fragment.
- Scope and sort still survive a clear: clearing a filter is not a request to leave the folder you are browsing.
- The date sort link built its href with `sort` first while every other link appends it last, so clicking Sort by Date and then Clear visibly reordered the query string. `sort` now goes last everywhere.

## Test plan

- [X] Tap a letter on the alpha bar, then Clear - the full list returns and the `: "A"` heading suffix goes.
- [X] Page to 2 or beyond, then Clear - back to page one.
- [X] Type a filter, then Clear - unchanged from before.
- [X] Clear on an already-unfiltered page - nothing happens, focus lands in the box.
- [X] In a folder, hit Sort by Date, then Clear - nothing happens, no jump to the top of the page.
- [X] With folder browsing on, enter a folder, tap a letter, then Clear - the folder listing returns and you stay in the folder.
