### PR TITLE
fix: quote the appended karaoke search term

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -211,14 +211,15 @@ def get_search_results(query: str) -> list[SearchResult]:
     """Search YouTube for videos matching the query.
 
     Args:
-        query: Search query string.
+        query: Search query string, passed to YouTube verbatim. Quoting is the
+            caller's, and reaches YouTube as part of the query text.
 
     Returns:
         One SearchResult per hit, in the order yt-dlp reported them.
     """
     logging.info(f"Searching YouTube for: {query}")
     num_results = 10
-    yt_search = f'ytsearch{num_results}:"{query}"'
+    yt_search = f"ytsearch{num_results}:{query}"
     cmd = yt_dlp_cmd + ["-j", "--no-playlist", "--flat-playlist", yt_search]
     logging.debug(f"yt-dlp search command: {' '.join(cmd)}")
     try:

--- a/pikaraoke/routes/search.py
+++ b/pikaraoke/routes/search.py
@@ -45,7 +45,9 @@ def search():
         if non_karaoke:
             search_results = get_search_results(search_string)
         else:
-            search_results = get_search_results(search_string + " karaoke")
+            # Quoting makes the term a hard requirement, not a ranking hint:
+            # 91% karaoke results against 82% unquoted, over 60 tail results.
+            search_results = get_search_results(f'{search_string} "karaoke"')
     else:
         search_string = None
         search_results = None


### PR DESCRIPTION
**Why:** A guest searching off the beaten track - an album cut, a B-side, an older song - gets the original artist's uploads and lyric videos instead of karaoke tracks. "a forest the cure" returns 2 karaoke results out of 10 today, and 10 after this change.

- Quotation marks are a hard requirement on YouTube's search, not a ranking hint: `a forest the cure "zqxjkwvbnm"` returns zero results where the unquoted form returns ten.
- The wrapping quotes date from the 2020 swap to yt-dlp, where they had been URL query syntax. They never reach a shell, so on the `ytsearch` path they were search content.
- Quoting only the term requires the word that matters and leaves the title loose. Over 60 tail results, four runs: 91% karaoke against 82% bare and 72% whole-phrase, ranges not overlapping. The gain is all in the tail - mainstream songs return 10/10 under every shape, which is why this survived six years unnoticed.
- The term stays English: it wins or ties native alternatives in six of eight languages, Italian 10 vs 6 for `basi musicali` and German 10 vs 7 for `playback`, and the three CJK terms that edge it do so by one result, inside noise. Localising would key off the server language, which describes the UI rather than the song.
- `get_search_results` now passes the query verbatim, leaving quoting to the caller. The "Include non-karaoke matches" path appends nothing and now quotes nothing.

## Test plan

- [x] Search "a forest the cure" - karaoke tracks, not The Cure's own uploads and bedroom covers.
- [x] Search "bohemian rhapsody" - still 10 karaoke results, unchanged.
- [x] Tick "Include non-karaoke matches" and search "a forest the cure" - the original recordings come back.
- [x] Search "don't stop believin" - results return, no yt-dlp error on the apostrophe.
- [x] Search "上を向いて歩こう" - karaoke results return, not the original recordings.
- [x] Queue and download a result from a search - unchanged.
