### PR TITLE
fix: require an audio track in the download fallbacks

### DIFF
--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -174,10 +174,17 @@ def build_ytdl_download_command(
     height = 1080 if high_quality else 720
     # The capped fallback matters because -S sorts on resolution: without it, a video with
     # no avc1 DASH pair lands on a 1080p HLS variant no matter what the cap says.
+    # bestaudio[ext!=webm] stays first so the audio can be stream-copied, but YouTube
+    # publishes opus-in-webm as the only audio for some videos: that pair then matches
+    # nothing, so pair with any audio before falling back to a single format. Every
+    # fallback requires acodec!=none -- a video-only format otherwise satisfies
+    # best[...], downloads silently, exits 0, and only fails later at -map 0:a, which
+    # is a successful download that will not play.
     file_quality = (
         f"bestvideo[vcodec^=avc1][height<={height}]+bestaudio[ext!=webm]"
-        f"/best[ext!=webm][height<={height}]"
-        "/best[ext!=webm]"
+        f"/bestvideo[vcodec^=avc1][height<={height}]+bestaudio"
+        f"/best[ext!=webm][height<={height}][acodec!=none]"
+        "/best[ext!=webm][acodec!=none]"
     )
     args = [
         "-f",

--- a/pikaraoke/lib/youtube_dl.py
+++ b/pikaraoke/lib/youtube_dl.py
@@ -174,12 +174,9 @@ def build_ytdl_download_command(
     height = 1080 if high_quality else 720
     # The capped fallback matters because -S sorts on resolution: without it, a video with
     # no avc1 DASH pair lands on a 1080p HLS variant no matter what the cap says.
-    # bestaudio[ext!=webm] stays first so the audio can be stream-copied, but YouTube
-    # publishes opus-in-webm as the only audio for some videos: that pair then matches
-    # nothing, so pair with any audio before falling back to a single format. Every
-    # fallback requires acodec!=none -- a video-only format otherwise satisfies
-    # best[...], downloads silently, exits 0, and only fails later at -map 0:a, which
-    # is a successful download that will not play.
+    # Every fallback needs acodec!=none: a video-only format otherwise satisfies
+    # best[...], downloads, exits 0, then fails at -map 0:a -- a "successful"
+    # download that cannot play. The bare +bestaudio pair covers opus-in-webm-only.
     file_quality = (
         f"bestvideo[vcodec^=avc1][height<={height}]+bestaudio[ext!=webm]"
         f"/bestvideo[vcodec^=avc1][height<={height}]+bestaudio"

--- a/tests/unit/test_youtube_dl.py
+++ b/tests/unit/test_youtube_dl.py
@@ -138,7 +138,8 @@ class TestBuildYtdlDownloadCommand:
         """A video with no avc1 DASH pair still has to respect the height cap.
 
         -S sorts on resolution, so an uncapped fallback would pick a 1080p HLS variant.
-        The uncapped tier stays last so selection can never fail outright.
+        The uncapped tier stays last so selection can never fail outright, and every
+        pre-merged tier requires an audio track so it cannot land on a video-only format.
         """
         cmd = build_ytdl_download_command(
             video_url="https://www.youtube.com/watch?v=test123",
@@ -146,8 +147,9 @@ class TestBuildYtdlDownloadCommand:
             high_quality=high_quality,
         )
         tiers = cmd[cmd.index("-f") + 1].split("/")
-        assert tiers[1] == f"best[ext!=webm][height<={height}]"
-        assert tiers[2] == "best[ext!=webm]"
+        assert tiers[1] == f"bestvideo[vcodec^=avc1][height<={height}]+bestaudio"
+        assert tiers[2] == f"best[ext!=webm][height<={height}][acodec!=none]"
+        assert tiers[3] == "best[ext!=webm][acodec!=none]"
 
     @patch("pikaraoke.lib.youtube_dl.get_installed_js_runtime", return_value=None)
     def test_progress_templates(self, mock_js):


### PR DESCRIPTION
**Why:** A video whose only audio is opus-in-webm downloads video-only, exits 0, enters the library, then fails at playback with `Skipping track`. Follow-up to #899, which fixed `-f mp4` but left the `best[...]` fallbacks still admitting a video-only format.

## Changes

- Add an any-audio pair (`+bestaudio`) before falling back to a single format, for videos whose only audio is webm.
- Require `acodec!=none` in both fallbacks, so a video-only format can no longer satisfy them.
- Keep `bestaudio[ext!=webm]` first, so audio is still stream-copied where possible.

A video offering only webm-muxed audio now fails visibly instead of downloading silently. The `.mkv` the new pair produces needs no container forcing — it is already in `song_list.VALID_EXTENSIONS`, and `lib/ffmpeg.py` already transcodes it.

## Test plan

- [x] Download `2014hFU6I9s`, whose only audio is opus-in-webm — yt-dlp merges an avc1 video with the webm audio, `ffprobe` shows `video,audio`, and it plays. Before: format 136, video-only, `ffprobe` showed `video`.
- [x] Download a video with m4a available — unchanged, still stream-copies.
- [x] Queue and play both — no transcode error, no `Skipping track`.
- [x] Running on a Pi 4 all day via `--ytdl-args`, no side effects seen.

Existing silent files can't be repaired; this finds them:

```bash
find /path/to/songs -type f \( -iname '*.mp4' -o -iname '*.mkv' -o -iname '*.webm' \) -print0 |
while IFS= read -r -d '' f; do
  [ -z "$(ffprobe -v error -select_streams a -show_entries stream=index -of csv=p=0 "$f")" ] && echo "$f"
done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)