### PR TITLE
fix: keep loopback an accepted socket.io origin when --url is set

### DIFF
--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -13,7 +13,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import flask_babel
 from flask import Flask, request, session
@@ -58,20 +58,18 @@ from gevent.pywsgi import WSGIServer
 
 args = parse_pikaraoke_args()
 socketio_path = f"{args.base_path}/socket.io" if args.base_path else "/socket.io"
-# --url replaces engineio's same-origin default rather than adding to it, so setting it
-# makes that URL the ONLY accepted origin. A headless host running its own kiosk browser
-# reaches the splash on loopback, and that connection is then refused: the splash stays
-# on the logo with no play events and nothing is logged but "is not an accepted origin".
-# Keep None when --url is unset, so the same-origin default is preserved for everyone
-# who is not overriding the URL.
+# Setting cors_allowed_origins REPLACES engineio's same-origin default, so --url alone
+# locks out the kiosk browser on loopback ("is not an accepted origin"). Origin headers
+# never carry a path, hence the normalise.
+cors_allowed_origins = None
 if args.url:
+    split_url = urlsplit(args.url)
     cors_allowed_origins = [
-        args.url,
+        f"{split_url.scheme}://{split_url.netloc}",
         f"http://localhost:{args.port}",
         f"http://127.0.0.1:{args.port}",
+        f"http://[::1]:{args.port}",
     ]
-else:
-    cors_allowed_origins = None
 socketio = SocketIO(
     async_mode="gevent", cors_allowed_origins=cors_allowed_origins, path=socketio_path
 )

--- a/pikaraoke/app.py
+++ b/pikaraoke/app.py
@@ -58,7 +58,23 @@ from gevent.pywsgi import WSGIServer
 
 args = parse_pikaraoke_args()
 socketio_path = f"{args.base_path}/socket.io" if args.base_path else "/socket.io"
-socketio = SocketIO(async_mode="gevent", cors_allowed_origins=args.url, path=socketio_path)
+# --url replaces engineio's same-origin default rather than adding to it, so setting it
+# makes that URL the ONLY accepted origin. A headless host running its own kiosk browser
+# reaches the splash on loopback, and that connection is then refused: the splash stays
+# on the logo with no play events and nothing is logged but "is not an accepted origin".
+# Keep None when --url is unset, so the same-origin default is preserved for everyone
+# who is not overriding the URL.
+if args.url:
+    cors_allowed_origins = [
+        args.url,
+        f"http://localhost:{args.port}",
+        f"http://127.0.0.1:{args.port}",
+    ]
+else:
+    cors_allowed_origins = None
+socketio = SocketIO(
+    async_mode="gevent", cors_allowed_origins=cors_allowed_origins, path=socketio_path
+)
 babel = Babel()
 
 


### PR DESCRIPTION
**Why:** Setting `--url` makes that URL the only accepted socket.io origin, so a headless host running its own kiosk browser on loopback has its socket refused — the splash sits on the logo indefinitely and the only clue is `<origin> is not an accepted origin`. #519 fixed the reverse-proxy direction by making `--url` the allowed origin; both origins need to be accepted, not one or the other.

## Changes

- Add the loopback origins (`localhost`, `127.0.0.1`, `[::1]`) alongside `--url`.
- Normalise `--url` through `urlsplit` to `scheme://host[:port]`. `karaoke.py` supports a base path in `--url`, and an `Origin` header never carries one, so `--url https://host/karaoke` could never match anything a browser sends — broken today, independently of this PR.
- Keep `cors_allowed_origins = None` when `--url` is unset, preserving engineio's same-origin default. Always passing a list would narrow that default from "same origin" to "only these" and break LAN access for anyone who never sets `--url`.

Does not cover the LAN address or `--prefer-hostname` while `--url` names a public host — that needs the `--allowed-origins` flag asked for in #519. Happy to do that separately.

## Test plan

- [x] `--headless -u https://<host>` with kiosk Chromium on `http://localhost:5555/splash` — splash connects and plays. Previously stuck on the logo all day.
- [x] Same box reached over the public URL — still works.
- [x] No `--url` — LAN access unchanged.
- [ ] `--url https://host/karaoke` with a base path — not exercised on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)