### PR TITLE
fix: hold the last CDG frame so video is not shorter than audio

### DIFF
--- a/pikaraoke/lib/ffmpeg.py
+++ b/pikaraoke/lib/ffmpeg.py
@@ -15,18 +15,18 @@ if TYPE_CHECKING:
     from pikaraoke.lib.file_resolver import FileResolver
 
 
-def get_media_duration(file_path: str) -> int | None:
+def get_media_duration(file_path: str) -> float | None:
     """Get the duration of a media file in seconds.
 
     Args:
         file_path: Path to the media file.
 
     Returns:
-        Duration in seconds (rounded), or None if unable to determine.
+        Duration in seconds, or None if unable to determine.
     """
     try:
         duration = ffmpeg.probe(file_path)["format"]["duration"]
-        return round(float(duration))
+        return float(duration)
     except:
         return None
 
@@ -113,17 +113,18 @@ def build_ffmpeg_cmd(
         logging.info("Playing CDG/MP3 file: " + fr.file_path)
         cdg_input = ffmpeg.input(fr.cdg_file_path, copyts=None)
         video = cdg_input.video.filter("fps", fps=25)
-        # CDG graphics routinely end seconds before the music does: the lyrics finish
-        # and the instrumental outro plays on with nothing left to draw. That leaves
-        # video shorter than audio -- 7 to 17s on the discs I have measured -- and a
-        # browser that stops at the shorter track then never fires "ended", so the
-        # queue never advances. Hold the last graphic frame instead; -shortest below
-        # trims the output at the end of the audio, so the whole song still plays.
+        # CDG graphics end 7-17s before the music, and Chromium 150+ stops at the
+        # shorter track rather than playing through, so "ended" never fires (#942).
+        # 600s is a ceiling on any outro; -t trims back to the audio length.
         video = video.filter("tpad", stop_mode="clone", stop_duration=600)
         if cdg_pixel_scaling:
             video = video.filter("scale", -1, 720, flags="neighbor")
     else:
         video = input.video
+
+    cdg_opts = {"pix_fmt": "yuv420p"}
+    if is_cdg and fr.duration_exact:
+        cdg_opts["t"] = fr.duration_exact + avsync
 
     # Build output based on format
     if force_mp4_encoding:
@@ -141,7 +142,7 @@ def build_ffmpeg_cmd(
             f="mp4",
             video_bitrate=vbitrate,
             movflags=movflags,
-            **({"pix_fmt": "yuv420p", "shortest": None} if is_cdg else {}),
+            **(cdg_opts if is_cdg else {}),
         )
     else:
         # HLS format with fMP4 segments
@@ -166,8 +167,7 @@ def build_ffmpeg_cmd(
             hls_fmp4_init_filename=fr.init_filename,
             hls_segment_filename=fr.segment_pattern,
             video_bitrate=vbitrate,
-            # CDG needs pix_fmt for proper color space
-            **({"pix_fmt": "yuv420p", "shortest": None} if is_cdg else {}),
+            **(cdg_opts if is_cdg else {}),
             **{
                 "fps_mode": "cfr",
                 "avoid_negative_ts": "make_zero",

--- a/pikaraoke/lib/ffmpeg.py
+++ b/pikaraoke/lib/ffmpeg.py
@@ -113,6 +113,13 @@ def build_ffmpeg_cmd(
         logging.info("Playing CDG/MP3 file: " + fr.file_path)
         cdg_input = ffmpeg.input(fr.cdg_file_path, copyts=None)
         video = cdg_input.video.filter("fps", fps=25)
+        # CDG graphics routinely end seconds before the music does: the lyrics finish
+        # and the instrumental outro plays on with nothing left to draw. That leaves
+        # video shorter than audio -- 7 to 17s on the discs I have measured -- and a
+        # browser that stops at the shorter track then never fires "ended", so the
+        # queue never advances. Hold the last graphic frame instead; -shortest below
+        # trims the output at the end of the audio, so the whole song still plays.
+        video = video.filter("tpad", stop_mode="clone", stop_duration=600)
         if cdg_pixel_scaling:
             video = video.filter("scale", -1, 720, flags="neighbor")
     else:
@@ -134,7 +141,7 @@ def build_ffmpeg_cmd(
             f="mp4",
             video_bitrate=vbitrate,
             movflags=movflags,
-            **({"pix_fmt": "yuv420p"} if is_cdg else {}),
+            **({"pix_fmt": "yuv420p", "shortest": None} if is_cdg else {}),
         )
     else:
         # HLS format with fMP4 segments
@@ -160,7 +167,7 @@ def build_ffmpeg_cmd(
             hls_segment_filename=fr.segment_pattern,
             video_bitrate=vbitrate,
             # CDG needs pix_fmt for proper color space
-            **({"pix_fmt": "yuv420p"} if is_cdg else {}),
+            **({"pix_fmt": "yuv420p", "shortest": None} if is_cdg else {}),
             **{
                 "fps_mode": "cfr",
                 "avoid_negative_ts": "make_zero",

--- a/pikaraoke/lib/file_resolver.py
+++ b/pikaraoke/lib/file_resolver.py
@@ -106,7 +106,8 @@ class FileResolver:
         segment_pattern: Pattern for HLS segment filenames.
         init_filename: Filename for HLS initialization segment.
         streaming_format: Video streaming format ('hls' or 'mp4').
-        duration: Duration of the media file in seconds.
+        duration: Duration of the media file in seconds, rounded.
+        duration_exact: Unrounded duration, used for the CDG output trim.
     """
 
     file_path: str | None = None
@@ -256,4 +257,8 @@ class FileResolver:
             self.handle_aegissub_subtile(file_path)
         if not self.file_path:
             raise ValueError("File path is required to process file")
-        self.duration = get_media_duration(self.file_path)
+        duration = get_media_duration(self.file_path)
+        # duration is what the UI shows; duration_exact drives the CDG -t trim, where
+        # rounding to the nearest second would clip the end of the song.
+        self.duration = round(duration) if duration is not None else None
+        self.duration_exact = duration

--- a/tests/unit/test_ffmpeg.py
+++ b/tests/unit/test_ffmpeg.py
@@ -121,12 +121,12 @@ class TestIsFfmpegInstalled:
 class TestGetMediaDuration:
     """Tests for the get_media_duration function."""
 
-    def test_returns_duration_rounded(self):
-        """Test that duration is returned as rounded integer."""
+    def test_returns_exact_duration(self):
+        """Duration is returned unrounded: the CDG -t trim needs sub-second precision."""
         with patch("pikaraoke.lib.ffmpeg.ffmpeg.probe") as mock_probe:
             mock_probe.return_value = {"format": {"duration": "183.456"}}
             result = get_media_duration("/path/to/video.mp4")
-            assert result == 183
+            assert result == 183.456
 
     def test_returns_none_on_probe_error(self):
         """Test that None is returned when probe fails."""


### PR DESCRIPTION
**Why:** CDG graphics end 7–17s before the music, so the transcode leaves video shorter than audio and songs lose their endings — a 245s song plays 238s. Part of #942.

## Changes

- `tpad` clones the last CDG graphic frame, and `-t` trims the output to the audio length. Measured gap: 7.10s → 0.258s.
- `-t` uses the source duration plus `avsync`, unrounded. `adelay`/`atrim` change the audio length after the probe, so the raw source duration would cut ~2s off every song when `--avsync` is set, and `get_media_duration`'s rounding would clip ~0.09s off the 245.088s example.
- `get_media_duration` now returns a float; `FileResolver` keeps the rounded value for the UI and an exact one for the trim.
- Both are gated on `is_cdg` and travel together — `tpad` leaves the video unbounded, so without the trim the output would run 600s past the music. `-t` is omitted entirely if the probe fails.

**This does not on its own stop the queue wedging.** The residual gap is frame quantisation at 25fps, still enough for Chromium 150+ to stop short, so a stall timeout is needed as well (#928).

## Test plan

- [x] Full-length CDG playback on a Pi 4, final lyric screen held through the outro — with the earlier `-shortest` form of this change.
- [x] Built command verified for CDG, non-CDG, `avsync` ±2, and a failed probe: `-t` present only for CDG, and never without a duration.
- [x] End-to-end ffmpeg run on 6.1.1: `-t 22.035918` → video 22.040 / audio 22.023.
- [ ] `-t` form on hardware — not yet run.
- [ ] `--streaming-format mp4`, which now shares the same options — not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)